### PR TITLE
Fixes spo file get unit tests, clarification on id in the description

### DIFF
--- a/docs/manual/docs/cmd/spo/file/file-get.md
+++ b/docs/manual/docs/cmd/spo/file/file-get.md
@@ -15,7 +15,7 @@ Option|Description
 `--help`|output usage information
 `-w, --webUrl <webUrl>`|The URL of the site where the file is located
 `-u, --url [url]`|The server-relative URL of the file to retrieve. Specify either `url` or `id` but not both
-`-i, --id [id]`|The ID of the file to retrieve. Specify either `url` or `id` but not both
+`-i, --id [id]`|The UniqueId (GUID) of the file to retrieve. Specify either `url` or `id` but not both
 `--asString`|Set to retrieve the contents of the specified file as string
 `--asListItem`|Set to retrieve the underlying list item
 `--asFile`|Set to save the file to the path specified in the path option
@@ -33,25 +33,25 @@ To get a file, you have to first connect to a SharePoint Online site using the [
 
 ## Examples
 
-Get file properties for file with id _b2307a39-e878-458b-bc90-03bc578531d6_ located in site _https://contoso.sharepoint.com/sites/project-x_
+Get file properties for file with id (UniqueId) _b2307a39-e878-458b-bc90-03bc578531d6_ located in site _https://contoso.sharepoint.com/sites/project-x_
 
 ```sh
 spo file get --webUrl https://contoso.sharepoint.com/sites/project-x --id 'b2307a39-e878-458b-bc90-03bc578531d6'
 ```
 
-Get contents of the file with id _b2307a39-e878-458b-bc90-03bc578531d6_ located in site _https://contoso.sharepoint.com/sites/project-x_
+Get contents of the file with id (UniqueId) _b2307a39-e878-458b-bc90-03bc578531d6_ located in site _https://contoso.sharepoint.com/sites/project-x_
 
 ```sh
 spo file get --webUrl https://contoso.sharepoint.com/sites/project-x --id 'b2307a39-e878-458b-bc90-03bc578531d6' --asString
 ```
 
-Get list item properties for file with id _b2307a39-e878-458b-bc90-03bc578531d6_ located in site _https://contoso.sharepoint.com/sites/project-x_
+Get list item properties for file with id (UniqueId) _b2307a39-e878-458b-bc90-03bc578531d6_ located in site _https://contoso.sharepoint.com/sites/project-x_
 
 ```sh
 spo file get --webUrl https://contoso.sharepoint.com/sites/project-x --id 'b2307a39-e878-458b-bc90-03bc578531d6' --asListItem
 ```
 
-Save file with id _b2307a39-e878-458b-bc90-03bc578531d6_ located in site _https://contoso.sharepoint.com/sites/project-x_ to local file _/Users/user/documents/SavedAsTest1.docx_
+Save file with id (UniqueId) _b2307a39-e878-458b-bc90-03bc578531d6_ located in site _https://contoso.sharepoint.com/sites/project-x_ to local file _/Users/user/documents/SavedAsTest1.docx_
 
 ```sh
 spo file get --webUrl https://contoso.sharepoint.com/sites/project-x --id 'b2307a39-e878-458b-bc90-03bc578531d6' --asFile --path /Users/user/documents/SavedAsTest1.docx

--- a/src/o365/spo/commands/file/file-get.spec.ts
+++ b/src/o365/spo/commands/file/file-get.spec.ts
@@ -361,7 +361,7 @@ describe(commands.FILE_GET, () => {
   it('uses correct API url when id option is passed', (done) => {
     stubAuth();
 
-    sinon.stub(request, 'get').callsFake((opts) => {
+    const getStub: any = sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url.indexOf('/_api/web/GetFileById(') > -1) {
         return Promise.resolve('Correct Url')
       }
@@ -385,7 +385,8 @@ describe(commands.FILE_GET, () => {
     }, () => {
 
       try {
-        assert(1 === 1);
+        assert.equal(getStub.lastCall.args[0].url, 'https://contoso.sharepoint.com/sites/project-x/_api/web/GetFileById(\'0CD891EF-AFCE-4E55-B836-FCE03286CCCF\')');
+        assert.equal(getStub.lastCall.args[0].headers.authorization, 'Bearer ABC');
         done();
       }
       catch (e) {
@@ -403,7 +404,7 @@ describe(commands.FILE_GET, () => {
   it('uses correct API url when url option is passed', (done) => {
     stubAuth();
 
-    sinon.stub(request, 'get').callsFake((opts) => {
+    const getStub: any = sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url.indexOf('/_api/web/GetFileByServerRelativeUrl(') > -1) {
         return Promise.resolve('Correct Url')
       }
@@ -425,7 +426,8 @@ describe(commands.FILE_GET, () => {
     }, () => {
 
       try {
-        assert(1 === 1);
+        assert.equal(getStub.lastCall.args[0].url, 'https://contoso.sharepoint.com/sites/project-x/_api/web/GetFileByServerRelativeUrl(\'%2Fsites%2Fproject-x%2FDocuments%2FTest1.docx\')');
+        assert.equal(getStub.lastCall.args[0].headers.authorization, 'Bearer ABC');
         done();
       }
       catch (e) {
@@ -440,15 +442,11 @@ describe(commands.FILE_GET, () => {
     });
   });
 
-  it('uses correct API url when url and id are both not passed', (done) => {
+  it('should handle promise rejection', (done) => {
     stubAuth();
-
+    const expectedError: any = JSON.stringify({"odata.error":{"code":"-2130575338, Microsoft.SharePoint.SPException","message":{"lang":"en-US","value":"Error: File Not Found."}}});
     sinon.stub(request, 'get').callsFake((opts) => {
-      if (opts.url === '') {
-        return Promise.resolve('Correct Url')
-      }
-
-      return Promise.reject('Invalid request');
+      return Promise.reject(expectedError);
     });
 
     auth.site = new Site();
@@ -461,10 +459,10 @@ describe(commands.FILE_GET, () => {
         debug: false,
         webUrl: 'https://contoso.sharepoint.com/sites/project-x',
       }
-    }, () => {
+    }, (err: any) => {
 
       try {
-        assert(1 === 1);
+        assert.equal(JSON.stringify(err.message), JSON.stringify(expectedError));
         done();
       }
       catch (e) {

--- a/src/o365/spo/commands/file/file-get.ts
+++ b/src/o365/spo/commands/file/file-get.ts
@@ -149,7 +149,7 @@ class SpoFileGetCommand extends SpoCommand {
       },
       {
         option: '-i, --id [id]',
-        description: 'The ID of the file to retrieve. Specify either url or id but not both'
+        description: 'The UniqueId (GUID) of the file to retrieve. Specify either url or id but not both'
       },
       {
         option: '--asString',
@@ -236,20 +236,20 @@ class SpoFileGetCommand extends SpoCommand {
         
   Examples:
   
-    Get file properties for file with id ${chalk.grey('b2307a39-e878-458b-bc90-03bc578531d6')}
+    Get file properties for file with id (UniqueId) ${chalk.grey('b2307a39-e878-458b-bc90-03bc578531d6')}
     located in site ${chalk.grey('https://contoso.sharepoint.com/sites/project-x')}
       ${chalk.grey(config.delimiter)} ${commands.FILE_GET} --webUrl https://contoso.sharepoint.com/sites/project-x --id 'b2307a39-e878-458b-bc90-03bc578531d6'
 
-    Get contents of the file with id ${chalk.grey('b2307a39-e878-458b-bc90-03bc578531d6')}
+    Get contents of the file with id (UniqueId) ${chalk.grey('b2307a39-e878-458b-bc90-03bc578531d6')}
     located in site ${chalk.grey('https://contoso.sharepoint.com/sites/project-x')}
       ${chalk.grey(config.delimiter)} ${commands.FILE_GET} --webUrl https://contoso.sharepoint.com/sites/project-x --id 'b2307a39-e878-458b-bc90-03bc578531d6' --asString
 
-    Get list item properties for file with id
+    Get list item properties for file with id (UniqueId)
     ${chalk.grey('b2307a39-e878-458b-bc90-03bc578531d6')} located in site
     ${chalk.grey('https://contoso.sharepoint.com/sites/project-x')}
       ${chalk.grey(config.delimiter)} ${commands.FILE_GET} --webUrl https://contoso.sharepoint.com/sites/project-x --id 'b2307a39-e878-458b-bc90-03bc578531d6' --asListItem   
 
-    Save file with id ${chalk.grey('b2307a39-e878-458b-bc90-03bc578531d6')} located
+    Save file with id (UniqueId) ${chalk.grey('b2307a39-e878-458b-bc90-03bc578531d6')} located
     in site ${chalk.grey('https://contoso.sharepoint.com/sites/project-x')} to local file
     ${chalk.grey('/Users/user/documents/SavedAsTest1.docx')}
       ${chalk.grey(config.delimiter)} ${commands.FILE_GET} --webUrl https://contoso.sharepoint.com/sites/project-x --id 'b2307a39-e878-458b-bc90-03bc578531d6' --asFile --path /Users/user/documents/SavedAsTest1.docx


### PR DESCRIPTION
- Spo file get - 3 unit tests completed, seems someone forgot to complete them.
- I also changed the description and examples adding the `UniqueId` word. This might prevent ambiguity around the id since a SPList has ID (int) and UniqueId (GUID).