### PR TITLE
Added support for upgrading SPFx@1.0.1 to 1.0.2 projects solving #536

### DIFF
--- a/src/o365/spfx/commands/project/project-upgrade.spec.ts
+++ b/src/o365/spfx/commands/project/project-upgrade.spec.ts
@@ -507,6 +507,23 @@ describe(commands.PROJECT_UPGRADE, () => {
     const project: Project = getProject('./');
     assert.equal(typeof ((project.vsCode) as VsCode).settingsJson, 'undefined');
   });
+  it('e2e: shows correct number of findings for upgrading no framework web part 1.0.1 project to 1.0.2', () => {
+    sinon.stub(command as any, 'getProjectRoot').callsFake(_ => path.join(process.cwd(), 'src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-nolib'));
+    cmdInstance.action = command.action();
+    cmdInstance.action({ options: { toVersion: '1.0.2' } }, (err?: any) => {
+      const findings: Finding[] = log[0];
+      assert.equal(findings.length, 2);
+    });
+  });
+ 
+  it('e2e: shows correct number of findings for upgrading react web part 1.0.1 project to 1.0.2', () => {
+    sinon.stub(command as any, 'getProjectRoot').callsFake(_ => path.join(process.cwd(), 'src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-react'));
+    cmdInstance.action = command.action();
+    cmdInstance.action({ options: { toVersion: '1.0.2', debug: true } }, (err?: any) => {
+      const findings: Finding[] = log[3];
+      assert.equal(findings.length, 2);
+    });
+  });
 
   it('e2e: shows correct number of findings for upgrading no framework web part 1.2.0 project to 1.3.0', () => {
     sinon.stub(command as any, 'getProjectRoot').callsFake(_ => path.join(process.cwd(), 'src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-120-webpart-nolib'));

--- a/src/o365/spfx/commands/project/project-upgrade.ts
+++ b/src/o365/spfx/commands/project/project-upgrade.ts
@@ -27,6 +27,8 @@ class SpfxProjectUpgradeCommand extends Command {
   private projectRootPath: string | null = null;
   private allFindings: Finding[] = [];
   private supportedVersions: string[] = [
+    '1.0.1',
+    '1.0.2',
     '1.2.0',
     '1.3.0',
     '1.3.1',

--- a/src/o365/spfx/commands/project/project-upgrade/model/TsLintJson.ts
+++ b/src/o365/spfx/commands/project/project-upgrade/model/TsLintJson.ts
@@ -1,3 +1,9 @@
 export interface TsLintJson {
   $schema: string;
+  lintConfig?: {
+    rules: {
+    "prefer-const"?: boolean;
+    "class-name"?: boolean;
+    }
+  };
 }

--- a/src/o365/spfx/commands/project/project-upgrade/rules/FN010201_CFG_TSL_preferConst.spec.ts
+++ b/src/o365/spfx/commands/project/project-upgrade/rules/FN010201_CFG_TSL_preferConst.spec.ts
@@ -1,0 +1,38 @@
+import * as assert from 'assert';
+import { Finding } from '../Finding';
+import { Project } from '../model';
+import { FN010201_CFG_TSL_preferConst } from './FN010201_CFG_TSL_preferConst';
+
+describe('FN010201_CFG_TSL_preferConst', () => {
+  let findings: Finding[];
+  let rule: FN010201_CFG_TSL_preferConst;
+
+  beforeEach(() => {
+    findings = [];
+    rule = new FN010201_CFG_TSL_preferConst();
+  });
+
+  it('doesn\'t return notification if preferConst is absent', () => {
+    const project: Project = {
+      path: '/usr/tmp',
+      tsLintJson: {
+        $schema: "https://schema.org/dummy.json",
+        lintConfig: {
+          rules: {
+            "class-name": false,
+          }
+        }
+      }
+    };
+    rule.visit(project, findings);
+    assert.equal(findings.length, 0);
+  });
+
+  it('doesn\'t return notification if tslint is not available', () => {
+    const project: Project = {
+      path: '/usr/tmp'
+    };
+    rule.visit(project, findings);
+    assert.equal(findings.length, 0);
+  });
+});

--- a/src/o365/spfx/commands/project/project-upgrade/rules/FN010201_CFG_TSL_preferConst.ts
+++ b/src/o365/spfx/commands/project/project-upgrade/rules/FN010201_CFG_TSL_preferConst.ts
@@ -1,0 +1,48 @@
+import { Finding } from "../Finding";
+import { Project } from "../model";
+import { Rule } from "./Rule";
+
+export class FN010201_CFG_TSL_preferConst extends Rule {
+  constructor() {
+    super();
+  }
+
+  get id(): string {
+    return 'FN010201';
+  }
+
+  get title(): string {
+    return 'tslint.json prefer-const';
+  }
+
+  get description(): string {
+    return `Remove prefer-const from tslint.json`;
+  };
+
+  get resolution(): string {
+    return `"prefer-const: true"`;
+  };
+
+  get resolutionType(): string {
+    return 'json';
+  };
+
+  get severity(): string {
+    return 'Required';
+  };
+
+  get file(): string {
+    return './config/tslint.json';
+  };
+
+  visit(project: Project, findings: Finding[]): void {
+    if (!project.tsConfigJson) {
+      return;
+    }
+
+    if (project.tsLintJson && project.tsLintJson.lintConfig && project.tsLintJson.lintConfig.rules &&
+      project.tsLintJson.lintConfig.rules["prefer-const"] === true) {
+      this.addFinding(findings);
+    }
+  }
+}

--- a/src/o365/spfx/commands/project/project-upgrade/rules/FN010202_DEP_types_knockout.spec.ts
+++ b/src/o365/spfx/commands/project/project-upgrade/rules/FN010202_DEP_types_knockout.spec.ts
@@ -1,0 +1,27 @@
+import * as assert from 'assert';
+import { Finding } from '../Finding';
+import { Project } from '../model';
+import { FN010202_DEP_types_knockout } from './FN010202_DEP_types_knockout';
+
+describe('FN010202_DEP_types_knockout', () => {
+  let findings: Finding[];
+  let rule: FN010202_DEP_types_knockout;
+
+  beforeEach(() => {
+    findings = [];
+    rule = new FN010202_DEP_types_knockout('3.4.39');
+  });
+
+  it('returns notification if types definitions are missing', () => {
+    const project: Project = {
+      path: '/usr/tmp',
+      packageJson: {
+        dependencies: {
+          '@types/react': '15.6.5'
+        }
+      }
+    };
+    rule.visit(project, findings);
+    assert.equal(findings.length, 1);
+  });
+});

--- a/src/o365/spfx/commands/project/project-upgrade/rules/FN010202_DEP_types_knockout.ts
+++ b/src/o365/spfx/commands/project/project-upgrade/rules/FN010202_DEP_types_knockout.ts
@@ -1,0 +1,12 @@
+import { DependencyRule } from "./DependencyRule";
+
+export class FN010202_DEP_types_knockout extends DependencyRule {
+  constructor(packageVersion: string) {
+    /* istanbul ignore next */
+    super('@types/knockout', packageVersion);
+  }
+
+  get id(): string {
+    return 'FN010202';
+  }
+}

--- a/src/o365/spfx/commands/project/project-upgrade/rules/FN010203_DEP_knockout.spec.ts
+++ b/src/o365/spfx/commands/project/project-upgrade/rules/FN010203_DEP_knockout.spec.ts
@@ -1,0 +1,27 @@
+import * as assert from 'assert';
+import { Finding } from '../Finding';
+import { Project } from '../model';
+import { FN010203_DEP_knockout } from './FN010203_DEP_knockout';
+
+describe('FN010203_DEP_knockout', () => {
+  let findings: Finding[];
+  let rule: FN010203_DEP_knockout;
+
+  beforeEach(() => {
+    findings = [];
+    rule = new FN010203_DEP_knockout('3.4.0');
+  });
+
+  it('returns notification if types definitions are missing', () => {
+    const project: Project = {
+      path: '/usr/tmp',
+      packageJson: {
+        dependencies: {
+          '@types/react': '15.6.5'
+        }
+      }
+    };
+    rule.visit(project, findings);
+    assert.equal(findings.length, 1);
+  });
+});

--- a/src/o365/spfx/commands/project/project-upgrade/rules/FN010203_DEP_knockout.ts
+++ b/src/o365/spfx/commands/project/project-upgrade/rules/FN010203_DEP_knockout.ts
@@ -1,0 +1,12 @@
+import { DependencyRule } from "./DependencyRule";
+
+export class FN010203_DEP_knockout extends DependencyRule {
+  constructor(packageVersion: string) {
+    /* istanbul ignore next */
+    super('@types/knockout', packageVersion);
+  }
+
+  get id(): string {
+    return 'FN010203';
+  }
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-ko/.editorconfig
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-ko/.editorconfig
@@ -1,0 +1,25 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+
+[*]
+
+# change these settings to your own preference
+indent_style = space
+indent_size = 2
+
+# we recommend you to keep these unchanged
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[{package,bower}.json]
+indent_style = space
+indent_size = 2

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-ko/.gitattributes
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-ko/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-ko/.gitignore
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-ko/.gitignore
@@ -1,0 +1,32 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+
+# Dependency directories
+node_modules
+
+# Build generated files
+dist
+lib
+solution
+temp
+*.sppkg
+
+# Coverage directory used by tools like istanbul
+coverage
+
+# OSX
+.DS_Store
+
+# Visual Studio files
+.ntvs_analysis.dat
+.vs
+bin
+obj
+
+# Resx Generated Code
+*.resx.ts
+
+# Styles Generated Code
+*.scss.ts

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-ko/.npmignore
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-ko/.npmignore
@@ -1,0 +1,14 @@
+# Folders
+.vscode
+coverage
+node_modules
+sharepoint
+src
+temp
+
+# Files
+*.csproj
+.git*
+.yo-rc.json
+gulpfile.js
+tsconfig.json

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-ko/.yo-rc.json
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-ko/.yo-rc.json
@@ -1,0 +1,8 @@
+{
+  "@microsoft/generator-sharepoint": {
+    "libraryName": "spfx",
+    "framework": "knockout",
+    "version": "1.0.1",
+    "libraryId": "75c8a978-d3a2-44ab-b930-11e3f56397b4"
+  }
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-ko/README.md
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-ko/README.md
@@ -1,0 +1,26 @@
+## spfx
+
+This is where you include your WebPart documentation.
+
+### Building the code
+
+```bash
+git clone the repo
+npm i
+npm i -g gulp
+gulp
+```
+
+This package produces the following:
+
+* lib/* - intermediate-stage commonjs build artifacts
+* dist/* - the bundled script, along with other resources
+* deploy/* - all resources which should be uploaded to a CDN.
+
+### Build options
+
+gulp clean - TODO
+gulp test - TODO
+gulp serve - TODO
+gulp bundle - TODO
+gulp package-solution - TODO

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-ko/config/config.json
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-ko/config/config.json
@@ -1,0 +1,13 @@
+{
+  "entries": [
+    {
+      "entry": "./lib/webparts/helloWorld/HelloWorldWebPart.js",
+      "manifest": "./src/webparts/helloWorld/HelloWorldWebPart.manifest.json",
+      "outputPath": "./dist/hello-world.bundle.js"
+    }
+  ],
+  "externals": {},
+  "localizedResources": {
+    "helloWorldStrings": "webparts/helloWorld/loc/{locale}.js"
+  }
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-ko/config/copy-assets.json
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-ko/config/copy-assets.json
@@ -1,0 +1,3 @@
+{
+  "deployCdnPath": "temp/deploy"
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-ko/config/deploy-azure-storage.json
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-ko/config/deploy-azure-storage.json
@@ -1,0 +1,6 @@
+{
+  "workingDir": "./temp/deploy/",
+  "account": "<!-- STORAGE ACCOUNT NAME -->",
+  "container": "spfx",
+  "accessKey": "<!-- ACCESS KEY -->"
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-ko/config/package-solution.json
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-ko/config/package-solution.json
@@ -1,0 +1,10 @@
+{
+  "solution": {
+    "name": "spfx-client-side-solution",
+    "id": "75c8a978-d3a2-44ab-b930-11e3f56397b4",
+    "version": "1.0.0.0"
+  },
+  "paths": {
+    "zippedPackage": "solution/spfx.sppkg"
+  }
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-ko/config/serve.json
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-ko/config/serve.json
@@ -1,0 +1,9 @@
+{
+  "port": 4321,
+  "initialPage": "https://localhost:5432/workbench",
+  "https": true,
+  "api": {
+    "port": 5432,
+    "entryPath": "node_modules/@microsoft/sp-webpart-workbench/lib/api/"
+  }
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-ko/config/tslint.json
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-ko/config/tslint.json
@@ -1,0 +1,46 @@
+{
+  // Display errors as warnings
+  "displayAsWarning": true,
+  // The TSLint task may have been configured with several custom lint rules
+  // before this config file is read (for example lint rules from the tslint-microsoft-contrib
+  // project). If true, this flag will deactivate any of these rules.
+  "removeExistingRules": true,
+  // When true, the TSLint task is configured with some default TSLint "rules.":
+  "useDefaultConfigAsBase": false,
+  // Since removeExistingRules=true and useDefaultConfigAsBase=false, there will be no lint rules
+  // which are active, other than the list of rules below.
+  "lintConfig": {
+    // Opt-in to Lint rules which help to eliminate bugs in JavaScript
+    "rules": {
+      "class-name": false,
+      "export-name": false,
+      "forin": false,
+      "label-position": false,
+      "member-access": true,
+      "no-arg": false,
+      "no-console": false,
+      "no-construct": false,
+      "no-duplicate-case": true,
+      "no-duplicate-variable": true,
+      "no-eval": false,
+      "no-function-expression": true,
+      "no-internal-module": true,
+      "no-shadowed-variable": true,
+      "no-switch-case-fall-through": true,
+      "no-unnecessary-semicolons": true,
+      "no-unused-expression": true,
+      "no-unused-imports": true,
+      "no-use-before-declare": true,
+      "no-with-statement": true,
+      "semicolon": true,
+      "trailing-comma": false,
+      "typedef": false,
+      "typedef-whitespace": false,
+      "use-named-parameter": true,
+      "valid-typeof": true,
+      "variable-name": false,
+      "whitespace": false,
+      "prefer-const": true
+    }
+  }
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-ko/config/write-manifests.json
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-ko/config/write-manifests.json
@@ -1,0 +1,3 @@
+{
+  "cdnBasePath": "<!-- PATH TO CDN -->"
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-ko/gulpfile.js
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-ko/gulpfile.js
@@ -1,0 +1,6 @@
+'use strict';
+
+const gulp = require('gulp');
+const build = require('@microsoft/sp-build-web');
+
+build.initialize(gulp);

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-ko/package.json
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-ko/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "spfx",
+  "version": "0.0.1",
+  "private": true,
+  "engines": {
+    "node": ">=0.10.0"
+  },
+  "dependencies": {
+    "@microsoft/sp-client-base": "~1.0.0",
+    "@microsoft/sp-core-library": "~1.0.0",
+    "@microsoft/sp-webpart-base": "~1.0.0",
+    "@types/webpack-env": ">=1.12.1 <1.14.0"
+  },
+  "devDependencies": {
+    "@microsoft/sp-build-web": "~1.0.1",
+    "@microsoft/sp-module-interfaces": "~1.0.0",
+    "@microsoft/sp-webpart-workbench": "~1.0.0",
+    "gulp": "~3.9.1",
+    "@types/chai": ">=3.4.34 <3.6.0",
+    "@types/mocha": ">=2.2.33 <2.6.0"
+  },
+  "scripts": {
+    "build": "gulp bundle",
+    "clean": "gulp clean",
+    "test": "gulp test"
+  }
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-ko/src/webparts/helloWorld/HelloWorld.module.scss
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-ko/src/webparts/helloWorld/HelloWorld.module.scss
@@ -1,0 +1,52 @@
+.helloWorld {
+  .container {
+    max-width: 700px;
+    margin: 0px auto;
+    box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.2), 0 25px 50px 0 rgba(0, 0, 0, 0.1);
+  }
+
+  .row {
+    padding: 20px;
+  }
+
+  .listItem {
+    max-width: 715px;
+    margin: 5px auto 5px auto;
+    box-shadow: 0 0 4px 0 rgba(0, 0, 0, 0.2), 0 25px 50px 0 rgba(0, 0, 0, 0.1);
+  }
+
+  .button {
+    // Our button
+    text-decoration: none;
+    height: 32px;
+
+    // Primary Button
+    min-width: 80px;
+    background-color: #0078d7;
+    border-color: #0078d7;
+    color: #ffffff;
+
+    // Basic Button
+    outline: transparent;
+    position: relative;
+    font-family: "Segoe UI WestEuropean","Segoe UI",-apple-system,BlinkMacSystemFont,Roboto,"Helvetica Neue",sans-serif;
+    -webkit-font-smoothing: antialiased;
+    font-size: 14px;
+    font-weight: 400;
+    border-width: 0;
+    text-align: center;
+    cursor: pointer;
+    display: inline-block;
+    padding: 0 16px;
+
+    .label {
+      font-weight: 600;
+      font-size: 14px;
+      height: 32px;
+      line-height: 32px;
+      margin: 0 4px;
+      vertical-align: top;
+      display: inline-block;
+    }
+  }
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-ko/src/webparts/helloWorld/HelloWorld.template.html
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-ko/src/webparts/helloWorld/HelloWorld.template.html
@@ -1,0 +1,14 @@
+<div data-bind="attr: {class:helloWorldClass}">
+    <div data-bind="attr: {class:containerClass}">
+      <div data-bind="attr: {class:rowClass}">
+        <div class="ms-Grid-col ms-u-lg10 ms-u-xl8 ms-u-xlPush2 ms-u-lgPush1">
+          <span class="ms-font-xl ms-fontColor-white">Welcome to SharePoint!</span>
+          <p class="ms-font-l ms-fontColor-white">Customize SharePoint experiences using Web Parts.</p>
+          <p class="ms-font-l ms-fontColor-white" data-bind="text:description"></p>
+          <a href="https://aka.ms/spfx" data-bind="attr: {class:buttonClass}">
+            <span data-bind="attr: {class:labelClass}">Learn more</span>
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-ko/src/webparts/helloWorld/HelloWorldViewModel.ts
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-ko/src/webparts/helloWorld/HelloWorldViewModel.ts
@@ -1,0 +1,26 @@
+import * as ko from 'knockout';
+import styles from './HelloWorld.module.scss';
+import { IHelloWorldWebPartProps } from './IHelloWorldWebPartProps';
+
+export interface IHelloWorldBindingContext extends IHelloWorldWebPartProps {
+  shouter: KnockoutSubscribable<{}>;
+}
+
+export default class HelloWorldViewModel {
+  public description: KnockoutObservable<string> = ko.observable('');
+
+  public labelClass: string = styles.label;
+  public helloWorldClass: string = styles.helloWorld;
+  public containerClass: string = styles.container;
+  public rowClass: string = `ms-Grid-row ms-bgColor-themeDark ms-fontColor-white ${styles.row}`;
+  public buttonClass: string = `ms-Button ${styles.button}`;
+
+  constructor(bindings: IHelloWorldBindingContext) {
+    this.description(bindings.description);
+
+    // When web part description is updated, change this view model's description.
+    bindings.shouter.subscribe((value: string) => {
+      this.description(value);
+    }, this, 'description');
+  }
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-ko/src/webparts/helloWorld/HelloWorldWebPart.manifest.json
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-ko/src/webparts/helloWorld/HelloWorldWebPart.manifest.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "../../../node_modules/@microsoft/sp-module-interfaces/lib/manifestSchemas/jsonSchemas/clientSideComponentManifestSchema.json",
+
+  "id": "c502f6a2-af42-444b-864b-34a78ff02f82",
+  "alias": "HelloWorldWebPart",
+  "componentType": "WebPart",
+  "version": "0.0.1",
+  "manifestVersion": 2,
+
+  "preconfiguredEntries": [{
+    "groupId": "c502f6a2-af42-444b-864b-34a78ff02f82",
+    "group": { "default": "Under Development" },
+    "title": { "default": "HelloWorld" },
+    "description": { "default": "HelloWorld description" },
+    "officeFabricIconFontName": "Page",
+    "properties": {
+      "description": "HelloWorld"
+    }
+  }]
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-ko/src/webparts/helloWorld/HelloWorldWebPart.ts
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-ko/src/webparts/helloWorld/HelloWorldWebPart.ts
@@ -1,0 +1,100 @@
+import * as ko from 'knockout';
+import { Version } from '@microsoft/sp-core-library';
+import {
+  BaseClientSideWebPart,
+  IPropertyPaneConfiguration,
+  PropertyPaneTextField
+} from '@microsoft/sp-webpart-base';
+
+import * as strings from 'helloWorldStrings';
+import HelloWorldViewModel, { IHelloWorldBindingContext } from './HelloWorldViewModel';
+import { IHelloWorldWebPartProps } from './IHelloWorldWebPartProps';
+
+let _instance: number = 0;
+
+export default class HelloWorldWebPart extends BaseClientSideWebPart<IHelloWorldWebPartProps> {
+  private _id: number;
+  private _componentElement: HTMLElement;
+  private _koDescription: KnockoutObservable<string> = ko.observable('');
+
+  /**
+   * Shouter is used to communicate between web part and view model.
+   */
+  private _shouter: KnockoutSubscribable<{}> = new ko.subscribable();
+
+  /**
+   * Initialize the web part.
+   */
+  protected onInit(): Promise<void> {
+    this._id = _instance++;
+
+    const tagName: string = `ComponentElement-${this._id}`;
+    this._componentElement = this._createComponentElement(tagName);
+    this._registerComponent(tagName);
+
+    // When web part description is changed, notify view model to update.
+    this._koDescription.subscribe((newValue: string) => {
+      this._shouter.notifySubscribers(newValue, 'description');
+    });
+
+    const bindings: IHelloWorldBindingContext = {
+      description: this.properties.description,
+      shouter: this._shouter
+    };
+
+    ko.applyBindings(bindings, this._componentElement);
+
+    return super.onInit();
+  }
+
+  public render(): void {
+    if (!this.renderedOnce) {
+      this.domElement.appendChild(this._componentElement);
+    }
+
+    this._koDescription(this.properties.description);
+  }
+
+  private _createComponentElement(tagName: string): HTMLElement {
+    const componentElement: HTMLElement = document.createElement('div');
+    componentElement.setAttribute('data-bind', `component: { name: "${tagName}", params: $data }`);
+    return componentElement;
+  }
+
+  private _registerComponent(tagName: string): void {
+    ko.components.register(
+      tagName,
+      {
+        viewModel: HelloWorldViewModel,
+        template: require('./HelloWorld.template.html'),
+        synchronous: false
+      }
+    );
+  }
+
+  protected get dataVersion(): Version {
+    return Version.parse('1.0');
+  }
+
+  protected getPropertyPaneConfiguration(): IPropertyPaneConfiguration {
+    return {
+      pages: [
+        {
+          header: {
+            description: strings.PropertyPaneDescription
+          },
+          groups: [
+            {
+              groupName: strings.BasicGroupName,
+              groupFields: [
+                PropertyPaneTextField('description', {
+                  label: strings.DescriptionFieldLabel
+                })
+              ]
+            }
+          ]
+        }
+      ]
+    };
+  }
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-ko/src/webparts/helloWorld/IHelloWorldWebPartProps.ts
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-ko/src/webparts/helloWorld/IHelloWorldWebPartProps.ts
@@ -1,0 +1,3 @@
+export interface IHelloWorldWebPartProps {
+  description: string;
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-ko/src/webparts/helloWorld/loc/en-us.js
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-ko/src/webparts/helloWorld/loc/en-us.js
@@ -1,0 +1,7 @@
+define([], function() {
+  return {
+    "PropertyPaneDescription": "Description",
+    "BasicGroupName": "Group Name",
+    "DescriptionFieldLabel": "Description Field"
+  }
+});

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-ko/src/webparts/helloWorld/loc/mystrings.d.ts
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-ko/src/webparts/helloWorld/loc/mystrings.d.ts
@@ -1,0 +1,10 @@
+declare interface IHelloWorldStrings {
+  PropertyPaneDescription: string;
+  BasicGroupName: string;
+  DescriptionFieldLabel: string;
+}
+
+declare module 'helloWorldStrings' {
+  const strings: IHelloWorldStrings;
+  export = strings;
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-ko/src/webparts/helloWorld/tests/HelloWorld.test.ts
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-ko/src/webparts/helloWorld/tests/HelloWorld.test.ts
@@ -1,0 +1,9 @@
+/// <reference types="mocha" />
+
+import { assert } from 'chai';
+
+describe('HelloWorldWebPart', () => {
+  it('should do something', () => {
+    assert.ok(true);
+  });
+});

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-ko/tsconfig.json
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-ko/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "forceConsistentCasingInFileNames": true,
+    "module": "commonjs",
+    "jsx": "react",
+    "declaration": true,
+    "sourceMap": true,
+    "types": [
+      "es6-promise",
+      "es6-collections",
+      "webpack-env"
+    ]
+  }
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-nolib/.editorconfig
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-nolib/.editorconfig
@@ -1,0 +1,25 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+
+[*]
+
+# change these settings to your own preference
+indent_style = space
+indent_size = 2
+
+# we recommend you to keep these unchanged
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[{package,bower}.json]
+indent_style = space
+indent_size = 2

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-nolib/.gitattributes
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-nolib/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-nolib/.gitignore
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-nolib/.gitignore
@@ -1,0 +1,32 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+
+# Dependency directories
+node_modules
+
+# Build generated files
+dist
+lib
+solution
+temp
+*.sppkg
+
+# Coverage directory used by tools like istanbul
+coverage
+
+# OSX
+.DS_Store
+
+# Visual Studio files
+.ntvs_analysis.dat
+.vs
+bin
+obj
+
+# Resx Generated Code
+*.resx.ts
+
+# Styles Generated Code
+*.scss.ts

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-nolib/.npmignore
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-nolib/.npmignore
@@ -1,0 +1,14 @@
+# Folders
+.vscode
+coverage
+node_modules
+sharepoint
+src
+temp
+
+# Files
+*.csproj
+.git*
+.yo-rc.json
+gulpfile.js
+tsconfig.json

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-nolib/.yo-rc.json
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-nolib/.yo-rc.json
@@ -1,0 +1,8 @@
+{
+  "@microsoft/generator-sharepoint": {
+    "libraryName": "spfx",
+    "framework": "none",
+    "version": "1.0.1",
+    "libraryId": "46c6efd4-2bd4-4339-bccb-4bfe2476d9c6"
+  }
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-nolib/README.md
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-nolib/README.md
@@ -1,0 +1,26 @@
+## spfx
+
+This is where you include your WebPart documentation.
+
+### Building the code
+
+```bash
+git clone the repo
+npm i
+npm i -g gulp
+gulp
+```
+
+This package produces the following:
+
+* lib/* - intermediate-stage commonjs build artifacts
+* dist/* - the bundled script, along with other resources
+* deploy/* - all resources which should be uploaded to a CDN.
+
+### Build options
+
+gulp clean - TODO
+gulp test - TODO
+gulp serve - TODO
+gulp bundle - TODO
+gulp package-solution - TODO

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-nolib/config/config.json
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-nolib/config/config.json
@@ -1,0 +1,13 @@
+{
+  "entries": [
+    {
+      "entry": "./lib/webparts/helloWorld/HelloWorldWebPart.js",
+      "manifest": "./src/webparts/helloWorld/HelloWorldWebPart.manifest.json",
+      "outputPath": "./dist/hello-world.bundle.js"
+    }
+  ],
+  "externals": {},
+  "localizedResources": {
+    "helloWorldStrings": "webparts/helloWorld/loc/{locale}.js"
+  }
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-nolib/config/copy-assets.json
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-nolib/config/copy-assets.json
@@ -1,0 +1,3 @@
+{
+  "deployCdnPath": "temp/deploy"
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-nolib/config/deploy-azure-storage.json
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-nolib/config/deploy-azure-storage.json
@@ -1,0 +1,6 @@
+{
+  "workingDir": "./temp/deploy/",
+  "account": "<!-- STORAGE ACCOUNT NAME -->",
+  "container": "spfx",
+  "accessKey": "<!-- ACCESS KEY -->"
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-nolib/config/package-solution.json
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-nolib/config/package-solution.json
@@ -1,0 +1,10 @@
+{
+  "solution": {
+    "name": "spfx-client-side-solution",
+    "id": "46c6efd4-2bd4-4339-bccb-4bfe2476d9c6",
+    "version": "1.0.0.0"
+  },
+  "paths": {
+    "zippedPackage": "solution/spfx.sppkg"
+  }
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-nolib/config/serve.json
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-nolib/config/serve.json
@@ -1,0 +1,9 @@
+{
+  "port": 4321,
+  "initialPage": "https://localhost:5432/workbench",
+  "https": true,
+  "api": {
+    "port": 5432,
+    "entryPath": "node_modules/@microsoft/sp-webpart-workbench/lib/api/"
+  }
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-nolib/config/tslint.json
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-nolib/config/tslint.json
@@ -1,0 +1,46 @@
+{
+  // Display errors as warnings
+  "displayAsWarning": true,
+  // The TSLint task may have been configured with several custom lint rules
+  // before this config file is read (for example lint rules from the tslint-microsoft-contrib
+  // project). If true, this flag will deactivate any of these rules.
+  "removeExistingRules": true,
+  // When true, the TSLint task is configured with some default TSLint "rules.":
+  "useDefaultConfigAsBase": false,
+  // Since removeExistingRules=true and useDefaultConfigAsBase=false, there will be no lint rules
+  // which are active, other than the list of rules below.
+  "lintConfig": {
+    // Opt-in to Lint rules which help to eliminate bugs in JavaScript
+    "rules": {
+      "class-name": false,
+      "export-name": false,
+      "forin": false,
+      "label-position": false,
+      "member-access": true,
+      "no-arg": false,
+      "no-console": false,
+      "no-construct": false,
+      "no-duplicate-case": true,
+      "no-duplicate-variable": true,
+      "no-eval": false,
+      "no-function-expression": true,
+      "no-internal-module": true,
+      "no-shadowed-variable": true,
+      "no-switch-case-fall-through": true,
+      "no-unnecessary-semicolons": true,
+      "no-unused-expression": true,
+      "no-unused-imports": true,
+      "no-use-before-declare": true,
+      "no-with-statement": true,
+      "semicolon": true,
+      "trailing-comma": false,
+      "typedef": false,
+      "typedef-whitespace": false,
+      "use-named-parameter": true,
+      "valid-typeof": true,
+      "variable-name": false,
+      "whitespace": false,
+      "prefer-const": true
+    }
+  }
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-nolib/config/write-manifests.json
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-nolib/config/write-manifests.json
@@ -1,0 +1,3 @@
+{
+  "cdnBasePath": "<!-- PATH TO CDN -->"
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-nolib/gulpfile.js
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-nolib/gulpfile.js
@@ -1,0 +1,6 @@
+'use strict';
+
+const gulp = require('gulp');
+const build = require('@microsoft/sp-build-web');
+
+build.initialize(gulp);

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-nolib/package.json
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-nolib/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "spfx",
+  "version": "0.0.1",
+  "private": true,
+  "engines": {
+    "node": ">=0.10.0"
+  },
+  "dependencies": {
+    "@microsoft/sp-client-base": "~1.0.0",
+    "@microsoft/sp-core-library": "~1.0.0",
+    "@microsoft/sp-webpart-base": "~1.0.0",
+    "@types/webpack-env": ">=1.12.1 <1.14.0"
+  },
+  "devDependencies": {
+    "@microsoft/sp-build-web": "~1.0.1",
+    "@microsoft/sp-module-interfaces": "~1.0.0",
+    "@microsoft/sp-webpart-workbench": "~1.0.0",
+    "gulp": "~3.9.1",
+    "@types/chai": ">=3.4.34 <3.6.0",
+    "@types/mocha": ">=2.2.33 <2.6.0"
+  },
+  "scripts": {
+    "build": "gulp bundle",
+    "clean": "gulp clean",
+    "test": "gulp test"
+  }
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-nolib/src/webparts/helloWorld/HelloWorld.module.scss
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-nolib/src/webparts/helloWorld/HelloWorld.module.scss
@@ -1,0 +1,52 @@
+.helloWorld {
+  .container {
+    max-width: 700px;
+    margin: 0px auto;
+    box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.2), 0 25px 50px 0 rgba(0, 0, 0, 0.1);
+  }
+
+  .row {
+    padding: 20px;
+  }
+
+  .listItem {
+    max-width: 715px;
+    margin: 5px auto 5px auto;
+    box-shadow: 0 0 4px 0 rgba(0, 0, 0, 0.2), 0 25px 50px 0 rgba(0, 0, 0, 0.1);
+  }
+
+  .button {
+    // Our button
+    text-decoration: none;
+    height: 32px;
+
+    // Primary Button
+    min-width: 80px;
+    background-color: #0078d7;
+    border-color: #0078d7;
+    color: #ffffff;
+
+    // Basic Button
+    outline: transparent;
+    position: relative;
+    font-family: "Segoe UI WestEuropean","Segoe UI",-apple-system,BlinkMacSystemFont,Roboto,"Helvetica Neue",sans-serif;
+    -webkit-font-smoothing: antialiased;
+    font-size: 14px;
+    font-weight: 400;
+    border-width: 0;
+    text-align: center;
+    cursor: pointer;
+    display: inline-block;
+    padding: 0 16px;
+
+    .label {
+      font-weight: 600;
+      font-size: 14px;
+      height: 32px;
+      line-height: 32px;
+      margin: 0 4px;
+      vertical-align: top;
+      display: inline-block;
+    }
+  }
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-nolib/src/webparts/helloWorld/HelloWorldWebPart.manifest.json
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-nolib/src/webparts/helloWorld/HelloWorldWebPart.manifest.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "../../../node_modules/@microsoft/sp-module-interfaces/lib/manifestSchemas/jsonSchemas/clientSideComponentManifestSchema.json",
+
+  "id": "2df55f17-9fa6-47dd-a5f7-f0ed96685b5b",
+  "alias": "HelloWorldWebPart",
+  "componentType": "WebPart",
+  "version": "0.0.1",
+  "manifestVersion": 2,
+
+  "preconfiguredEntries": [{
+    "groupId": "2df55f17-9fa6-47dd-a5f7-f0ed96685b5b",
+    "group": { "default": "Under Development" },
+    "title": { "default": "HelloWorld" },
+    "description": { "default": "HelloWorld description" },
+    "officeFabricIconFontName": "Page",
+    "properties": {
+      "description": "HelloWorld"
+    }
+  }]
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-nolib/src/webparts/helloWorld/HelloWorldWebPart.ts
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-nolib/src/webparts/helloWorld/HelloWorldWebPart.ts
@@ -1,0 +1,58 @@
+import { Version } from '@microsoft/sp-core-library';
+import {
+  BaseClientSideWebPart,
+  IPropertyPaneConfiguration,
+  PropertyPaneTextField
+} from '@microsoft/sp-webpart-base';
+import { escape } from '@microsoft/sp-lodash-subset';
+
+import styles from './HelloWorld.module.scss';
+import * as strings from 'helloWorldStrings';
+import { IHelloWorldWebPartProps } from './IHelloWorldWebPartProps';
+
+export default class HelloWorldWebPart extends BaseClientSideWebPart<IHelloWorldWebPartProps> {
+
+  public render(): void {
+    this.domElement.innerHTML = `
+      <div class="${styles.helloWorld}">
+        <div class="${styles.container}">
+          <div class="ms-Grid-row ms-bgColor-themeDark ms-fontColor-white ${styles.row}">
+            <div class="ms-Grid-col ms-u-lg10 ms-u-xl8 ms-u-xlPush2 ms-u-lgPush1">
+              <span class="ms-font-xl ms-fontColor-white">Welcome to SharePoint!</span>
+              <p class="ms-font-l ms-fontColor-white">Customize SharePoint experiences using Web Parts.</p>
+              <p class="ms-font-l ms-fontColor-white">${escape(this.properties.description)}</p>
+              <a href="https://aka.ms/spfx" class="${styles.button}">
+                <span class="${styles.label}">Learn more</span>
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>`;
+  }
+
+  protected get dataVersion(): Version {
+    return Version.parse('1.0');
+  }
+
+  protected getPropertyPaneConfiguration(): IPropertyPaneConfiguration {
+    return {
+      pages: [
+        {
+          header: {
+            description: strings.PropertyPaneDescription
+          },
+          groups: [
+            {
+              groupName: strings.BasicGroupName,
+              groupFields: [
+                PropertyPaneTextField('description', {
+                  label: strings.DescriptionFieldLabel
+                })
+              ]
+            }
+          ]
+        }
+      ]
+    };
+  }
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-nolib/src/webparts/helloWorld/IHelloWorldWebPartProps.ts
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-nolib/src/webparts/helloWorld/IHelloWorldWebPartProps.ts
@@ -1,0 +1,3 @@
+export interface IHelloWorldWebPartProps {
+  description: string;
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-nolib/src/webparts/helloWorld/loc/en-us.js
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-nolib/src/webparts/helloWorld/loc/en-us.js
@@ -1,0 +1,7 @@
+define([], function() {
+  return {
+    "PropertyPaneDescription": "Description",
+    "BasicGroupName": "Group Name",
+    "DescriptionFieldLabel": "Description Field"
+  }
+});

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-nolib/src/webparts/helloWorld/loc/mystrings.d.ts
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-nolib/src/webparts/helloWorld/loc/mystrings.d.ts
@@ -1,0 +1,10 @@
+declare interface IHelloWorldStrings {
+  PropertyPaneDescription: string;
+  BasicGroupName: string;
+  DescriptionFieldLabel: string;
+}
+
+declare module 'helloWorldStrings' {
+  const strings: IHelloWorldStrings;
+  export = strings;
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-nolib/src/webparts/helloWorld/tests/HelloWorld.test.ts
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-nolib/src/webparts/helloWorld/tests/HelloWorld.test.ts
@@ -1,0 +1,9 @@
+/// <reference types="mocha" />
+
+import { assert } from 'chai';
+
+describe('HelloWorldWebPart', () => {
+  it('should do something', () => {
+    assert.ok(true);
+  });
+});

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-nolib/tsconfig.json
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-nolib/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "forceConsistentCasingInFileNames": true,
+    "module": "commonjs",
+    "jsx": "react",
+    "declaration": true,
+    "sourceMap": true,
+    "types": [
+      "es6-promise",
+      "es6-collections",
+      "webpack-env"
+    ]
+  }
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-react/.editorconfig
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-react/.editorconfig
@@ -1,0 +1,25 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+
+[*]
+
+# change these settings to your own preference
+indent_style = space
+indent_size = 2
+
+# we recommend you to keep these unchanged
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[{package,bower}.json]
+indent_style = space
+indent_size = 2

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-react/.gitattributes
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-react/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-react/.gitignore
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-react/.gitignore
@@ -1,0 +1,32 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+
+# Dependency directories
+node_modules
+
+# Build generated files
+dist
+lib
+solution
+temp
+*.sppkg
+
+# Coverage directory used by tools like istanbul
+coverage
+
+# OSX
+.DS_Store
+
+# Visual Studio files
+.ntvs_analysis.dat
+.vs
+bin
+obj
+
+# Resx Generated Code
+*.resx.ts
+
+# Styles Generated Code
+*.scss.ts

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-react/.npmignore
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-react/.npmignore
@@ -1,0 +1,14 @@
+# Folders
+.vscode
+coverage
+node_modules
+sharepoint
+src
+temp
+
+# Files
+*.csproj
+.git*
+.yo-rc.json
+gulpfile.js
+tsconfig.json

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-react/.yo-rc.json
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-react/.yo-rc.json
@@ -1,0 +1,8 @@
+{
+  "@microsoft/generator-sharepoint": {
+    "libraryName": "spfx",
+    "framework": "react",
+    "version": "1.0.1",
+    "libraryId": "86230391-6bfa-4d4f-aac8-988626981086"
+  }
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-react/README.md
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-react/README.md
@@ -1,0 +1,26 @@
+## spfx
+
+This is where you include your WebPart documentation.
+
+### Building the code
+
+```bash
+git clone the repo
+npm i
+npm i -g gulp
+gulp
+```
+
+This package produces the following:
+
+* lib/* - intermediate-stage commonjs build artifacts
+* dist/* - the bundled script, along with other resources
+* deploy/* - all resources which should be uploaded to a CDN.
+
+### Build options
+
+gulp clean - TODO
+gulp test - TODO
+gulp serve - TODO
+gulp bundle - TODO
+gulp package-solution - TODO

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-react/config/config.json
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-react/config/config.json
@@ -1,0 +1,13 @@
+{
+  "entries": [
+    {
+      "entry": "./lib/webparts/helloWorld/HelloWorldWebPart.js",
+      "manifest": "./src/webparts/helloWorld/HelloWorldWebPart.manifest.json",
+      "outputPath": "./dist/hello-world.bundle.js"
+    }
+  ],
+  "externals": {},
+  "localizedResources": {
+    "helloWorldStrings": "webparts/helloWorld/loc/{locale}.js"
+  }
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-react/config/copy-assets.json
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-react/config/copy-assets.json
@@ -1,0 +1,3 @@
+{
+  "deployCdnPath": "temp/deploy"
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-react/config/deploy-azure-storage.json
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-react/config/deploy-azure-storage.json
@@ -1,0 +1,6 @@
+{
+  "workingDir": "./temp/deploy/",
+  "account": "<!-- STORAGE ACCOUNT NAME -->",
+  "container": "spfx",
+  "accessKey": "<!-- ACCESS KEY -->"
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-react/config/package-solution.json
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-react/config/package-solution.json
@@ -1,0 +1,10 @@
+{
+  "solution": {
+    "name": "spfx-client-side-solution",
+    "id": "86230391-6bfa-4d4f-aac8-988626981086",
+    "version": "1.0.0.0"
+  },
+  "paths": {
+    "zippedPackage": "solution/spfx.sppkg"
+  }
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-react/config/serve.json
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-react/config/serve.json
@@ -1,0 +1,9 @@
+{
+  "port": 4321,
+  "initialPage": "https://localhost:5432/workbench",
+  "https": true,
+  "api": {
+    "port": 5432,
+    "entryPath": "node_modules/@microsoft/sp-webpart-workbench/lib/api/"
+  }
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-react/config/tslint.json
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-react/config/tslint.json
@@ -1,0 +1,46 @@
+{
+  // Display errors as warnings
+  "displayAsWarning": true,
+  // The TSLint task may have been configured with several custom lint rules
+  // before this config file is read (for example lint rules from the tslint-microsoft-contrib
+  // project). If true, this flag will deactivate any of these rules.
+  "removeExistingRules": true,
+  // When true, the TSLint task is configured with some default TSLint "rules.":
+  "useDefaultConfigAsBase": false,
+  // Since removeExistingRules=true and useDefaultConfigAsBase=false, there will be no lint rules
+  // which are active, other than the list of rules below.
+  "lintConfig": {
+    // Opt-in to Lint rules which help to eliminate bugs in JavaScript
+    "rules": {
+      "class-name": false,
+      "export-name": false,
+      "forin": false,
+      "label-position": false,
+      "member-access": true,
+      "no-arg": false,
+      "no-console": false,
+      "no-construct": false,
+      "no-duplicate-case": true,
+      "no-duplicate-variable": true,
+      "no-eval": false,
+      "no-function-expression": true,
+      "no-internal-module": true,
+      "no-shadowed-variable": true,
+      "no-switch-case-fall-through": true,
+      "no-unnecessary-semicolons": true,
+      "no-unused-expression": true,
+      "no-unused-imports": true,
+      "no-use-before-declare": true,
+      "no-with-statement": true,
+      "semicolon": true,
+      "trailing-comma": false,
+      "typedef": false,
+      "typedef-whitespace": false,
+      "use-named-parameter": true,
+      "valid-typeof": true,
+      "variable-name": false,
+      "whitespace": false,
+      "prefer-const": true
+    }
+  }
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-react/config/write-manifests.json
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-react/config/write-manifests.json
@@ -1,0 +1,3 @@
+{
+  "cdnBasePath": "<!-- PATH TO CDN -->"
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-react/gulpfile.js
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-react/gulpfile.js
@@ -1,0 +1,6 @@
+'use strict';
+
+const gulp = require('gulp');
+const build = require('@microsoft/sp-build-web');
+
+build.initialize(gulp);

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-react/package.json
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-react/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "spfx",
+  "version": "0.0.1",
+  "private": true,
+  "engines": {
+    "node": ">=0.10.0"
+  },
+  "dependencies": {
+    "@microsoft/sp-client-base": "~1.0.0",
+    "@microsoft/sp-core-library": "~1.0.0",
+    "@microsoft/sp-webpart-base": "~1.0.0",
+    "@types/webpack-env": ">=1.12.1 <1.14.0"
+  },
+  "devDependencies": {
+    "@microsoft/sp-build-web": "~1.0.1",
+    "@microsoft/sp-module-interfaces": "~1.0.0",
+    "@microsoft/sp-webpart-workbench": "~1.0.0",
+    "gulp": "~3.9.1",
+    "@types/chai": ">=3.4.34 <3.6.0",
+    "@types/mocha": ">=2.2.33 <2.6.0"
+  },
+  "scripts": {
+    "build": "gulp bundle",
+    "clean": "gulp clean",
+    "test": "gulp test"
+  }
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-react/src/webparts/helloWorld/HelloWorldWebPart.manifest.json
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-react/src/webparts/helloWorld/HelloWorldWebPart.manifest.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "../../../node_modules/@microsoft/sp-module-interfaces/lib/manifestSchemas/jsonSchemas/clientSideComponentManifestSchema.json",
+
+  "id": "e98a8fc5-77f0-47f9-8a41-fdf6c3353a50",
+  "alias": "HelloWorldWebPart",
+  "componentType": "WebPart",
+  "version": "0.0.1",
+  "manifestVersion": 2,
+
+  "preconfiguredEntries": [{
+    "groupId": "e98a8fc5-77f0-47f9-8a41-fdf6c3353a50",
+    "group": { "default": "Under Development" },
+    "title": { "default": "HelloWorld" },
+    "description": { "default": "HelloWorld description" },
+    "officeFabricIconFontName": "Page",
+    "properties": {
+      "description": "HelloWorld"
+    }
+  }]
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-react/src/webparts/helloWorld/HelloWorldWebPart.ts
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-react/src/webparts/helloWorld/HelloWorldWebPart.ts
@@ -1,0 +1,53 @@
+import * as React from 'react';
+import * as ReactDom from 'react-dom';
+import { Version } from '@microsoft/sp-core-library';
+import {
+  BaseClientSideWebPart,
+  IPropertyPaneConfiguration,
+  PropertyPaneTextField
+} from '@microsoft/sp-webpart-base';
+
+import * as strings from 'helloWorldStrings';
+import HelloWorld from './components/HelloWorld';
+import { IHelloWorldProps } from './components/IHelloWorldProps';
+import { IHelloWorldWebPartProps } from './IHelloWorldWebPartProps';
+
+export default class HelloWorldWebPart extends BaseClientSideWebPart<IHelloWorldWebPartProps> {
+
+  public render(): void {
+    const element: React.ReactElement<IHelloWorldProps > = React.createElement(
+      HelloWorld,
+      {
+        description: this.properties.description
+      }
+    );
+
+    ReactDom.render(element, this.domElement);
+  }
+
+  protected get dataVersion(): Version {
+    return Version.parse('1.0');
+  }
+
+  protected getPropertyPaneConfiguration(): IPropertyPaneConfiguration {
+    return {
+      pages: [
+        {
+          header: {
+            description: strings.PropertyPaneDescription
+          },
+          groups: [
+            {
+              groupName: strings.BasicGroupName,
+              groupFields: [
+                PropertyPaneTextField('description', {
+                  label: strings.DescriptionFieldLabel
+                })
+              ]
+            }
+          ]
+        }
+      ]
+    };
+  }
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-react/src/webparts/helloWorld/IHelloWorldWebPartProps.ts
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-react/src/webparts/helloWorld/IHelloWorldWebPartProps.ts
@@ -1,0 +1,3 @@
+export interface IHelloWorldWebPartProps {
+  description: string;
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-react/src/webparts/helloWorld/components/HelloWorld.module.scss
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-react/src/webparts/helloWorld/components/HelloWorld.module.scss
@@ -1,0 +1,52 @@
+.helloWorld {
+  .container {
+    max-width: 700px;
+    margin: 0px auto;
+    box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.2), 0 25px 50px 0 rgba(0, 0, 0, 0.1);
+  }
+
+  .row {
+    padding: 20px;
+  }
+
+  .listItem {
+    max-width: 715px;
+    margin: 5px auto 5px auto;
+    box-shadow: 0 0 4px 0 rgba(0, 0, 0, 0.2), 0 25px 50px 0 rgba(0, 0, 0, 0.1);
+  }
+
+  .button {
+    // Our button
+    text-decoration: none;
+    height: 32px;
+
+    // Primary Button
+    min-width: 80px;
+    background-color: #0078d7;
+    border-color: #0078d7;
+    color: #ffffff;
+
+    // Basic Button
+    outline: transparent;
+    position: relative;
+    font-family: "Segoe UI WestEuropean","Segoe UI",-apple-system,BlinkMacSystemFont,Roboto,"Helvetica Neue",sans-serif;
+    -webkit-font-smoothing: antialiased;
+    font-size: 14px;
+    font-weight: 400;
+    border-width: 0;
+    text-align: center;
+    cursor: pointer;
+    display: inline-block;
+    padding: 0 16px;
+
+    .label {
+      font-weight: 600;
+      font-size: 14px;
+      height: 32px;
+      line-height: 32px;
+      margin: 0 4px;
+      vertical-align: top;
+      display: inline-block;
+    }
+  }
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-react/src/webparts/helloWorld/components/HelloWorld.tsx
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-react/src/webparts/helloWorld/components/HelloWorld.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react';
+import styles from './HelloWorld.module.scss';
+import { IHelloWorldProps } from './IHelloWorldProps';
+import { escape } from '@microsoft/sp-lodash-subset';
+
+export default class HelloWorld extends React.Component<IHelloWorldProps, void> {
+  public render(): React.ReactElement<IHelloWorldProps> {
+    return (
+      <div className={styles.helloWorld}>
+        <div className={styles.container}>
+          <div className={`ms-Grid-row ms-bgColor-themeDark ms-fontColor-white ${styles.row}`}>
+            <div className="ms-Grid-col ms-u-lg10 ms-u-xl8 ms-u-xlPush2 ms-u-lgPush1">
+              <span className="ms-font-xl ms-fontColor-white">Welcome to SharePoint!</span>
+              <p className="ms-font-l ms-fontColor-white">Customize SharePoint experiences using Web Parts.</p>
+              <p className="ms-font-l ms-fontColor-white">{escape(this.props.description)}</p>
+              <a href="https://aka.ms/spfx" className={styles.button}>
+                <span className={styles.label}>Learn more</span>
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-react/src/webparts/helloWorld/components/IHelloWorldProps.ts
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-react/src/webparts/helloWorld/components/IHelloWorldProps.ts
@@ -1,0 +1,3 @@
+export interface IHelloWorldProps {
+  description: string;
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-react/src/webparts/helloWorld/loc/en-us.js
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-react/src/webparts/helloWorld/loc/en-us.js
@@ -1,0 +1,7 @@
+define([], function() {
+  return {
+    "PropertyPaneDescription": "Description",
+    "BasicGroupName": "Group Name",
+    "DescriptionFieldLabel": "Description Field"
+  }
+});

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-react/src/webparts/helloWorld/loc/mystrings.d.ts
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-react/src/webparts/helloWorld/loc/mystrings.d.ts
@@ -1,0 +1,10 @@
+declare interface IHelloWorldStrings {
+  PropertyPaneDescription: string;
+  BasicGroupName: string;
+  DescriptionFieldLabel: string;
+}
+
+declare module 'helloWorldStrings' {
+  const strings: IHelloWorldStrings;
+  export = strings;
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-react/src/webparts/helloWorld/tests/HelloWorld.test.ts
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-react/src/webparts/helloWorld/tests/HelloWorld.test.ts
@@ -1,0 +1,9 @@
+/// <reference types="mocha" />
+
+import { assert } from 'chai';
+
+describe('HelloWorldWebPart', () => {
+  it('should do something', () => {
+    assert.ok(true);
+  });
+});

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-react/tsconfig.json
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-101-webpart-react/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "forceConsistentCasingInFileNames": true,
+    "module": "commonjs",
+    "jsx": "react",
+    "declaration": true,
+    "sourceMap": true,
+    "types": [
+      "es6-promise",
+      "es6-collections",
+      "webpack-env"
+    ]
+  }
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-ko/.editorconfig
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-ko/.editorconfig
@@ -1,0 +1,25 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+
+[*]
+
+# change these settings to your own preference
+indent_style = space
+indent_size = 2
+
+# we recommend you to keep these unchanged
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[{package,bower}.json]
+indent_style = space
+indent_size = 2

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-ko/.gitattributes
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-ko/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-ko/.gitignore
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-ko/.gitignore
@@ -1,0 +1,32 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+
+# Dependency directories
+node_modules
+
+# Build generated files
+dist
+lib
+solution
+temp
+*.sppkg
+
+# Coverage directory used by tools like istanbul
+coverage
+
+# OSX
+.DS_Store
+
+# Visual Studio files
+.ntvs_analysis.dat
+.vs
+bin
+obj
+
+# Resx Generated Code
+*.resx.ts
+
+# Styles Generated Code
+*.scss.ts

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-ko/.npmignore
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-ko/.npmignore
@@ -1,0 +1,14 @@
+# Folders
+.vscode
+coverage
+node_modules
+sharepoint
+src
+temp
+
+# Files
+*.csproj
+.git*
+.yo-rc.json
+gulpfile.js
+tsconfig.json

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-ko/.yo-rc.json
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-ko/.yo-rc.json
@@ -1,0 +1,8 @@
+{
+  "@microsoft/generator-sharepoint": {
+    "libraryName": "spfx",
+    "framework": "knockout",
+    "version": "1.0.2",
+    "libraryId": "01c963a9-615c-4d84-9d5e-baa4a84ff381"
+  }
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-ko/README.md
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-ko/README.md
@@ -1,0 +1,26 @@
+## spfx
+
+This is where you include your WebPart documentation.
+
+### Building the code
+
+```bash
+git clone the repo
+npm i
+npm i -g gulp
+gulp
+```
+
+This package produces the following:
+
+* lib/* - intermediate-stage commonjs build artifacts
+* dist/* - the bundled script, along with other resources
+* deploy/* - all resources which should be uploaded to a CDN.
+
+### Build options
+
+gulp clean - TODO
+gulp test - TODO
+gulp serve - TODO
+gulp bundle - TODO
+gulp package-solution - TODO

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-ko/config/config.json
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-ko/config/config.json
@@ -1,0 +1,13 @@
+{
+  "entries": [
+    {
+      "entry": "./lib/webparts/helloWorld/HelloWorldWebPart.js",
+      "manifest": "./src/webparts/helloWorld/HelloWorldWebPart.manifest.json",
+      "outputPath": "./dist/hello-world.bundle.js"
+    }
+  ],
+  "externals": {},
+  "localizedResources": {
+    "helloWorldStrings": "webparts/helloWorld/loc/{locale}.js"
+  }
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-ko/config/copy-assets.json
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-ko/config/copy-assets.json
@@ -1,0 +1,3 @@
+{
+  "deployCdnPath": "temp/deploy"
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-ko/config/deploy-azure-storage.json
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-ko/config/deploy-azure-storage.json
@@ -1,0 +1,6 @@
+{
+  "workingDir": "./temp/deploy/",
+  "account": "<!-- STORAGE ACCOUNT NAME -->",
+  "container": "spfx",
+  "accessKey": "<!-- ACCESS KEY -->"
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-ko/config/package-solution.json
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-ko/config/package-solution.json
@@ -1,0 +1,10 @@
+{
+  "solution": {
+    "name": "spfx-client-side-solution",
+    "id": "01c963a9-615c-4d84-9d5e-baa4a84ff381",
+    "version": "1.0.0.0"
+  },
+  "paths": {
+    "zippedPackage": "solution/spfx.sppkg"
+  }
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-ko/config/serve.json
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-ko/config/serve.json
@@ -1,0 +1,9 @@
+{
+  "port": 4321,
+  "initialPage": "https://localhost:5432/workbench",
+  "https": true,
+  "api": {
+    "port": 5432,
+    "entryPath": "node_modules/@microsoft/sp-webpart-workbench/lib/api/"
+  }
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-ko/config/tslint.json
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-ko/config/tslint.json
@@ -1,0 +1,45 @@
+{
+  // Display errors as warnings
+  "displayAsWarning": true,
+  // The TSLint task may have been configured with several custom lint rules
+  // before this config file is read (for example lint rules from the tslint-microsoft-contrib
+  // project). If true, this flag will deactivate any of these rules.
+  "removeExistingRules": true,
+  // When true, the TSLint task is configured with some default TSLint "rules.":
+  "useDefaultConfigAsBase": false,
+  // Since removeExistingRules=true and useDefaultConfigAsBase=false, there will be no lint rules
+  // which are active, other than the list of rules below.
+  "lintConfig": {
+    // Opt-in to Lint rules which help to eliminate bugs in JavaScript
+    "rules": {
+      "class-name": false,
+      "export-name": false,
+      "forin": false,
+      "label-position": false,
+      "member-access": true,
+      "no-arg": false,
+      "no-console": false,
+      "no-construct": false,
+      "no-duplicate-case": true,
+      "no-duplicate-variable": true,
+      "no-eval": false,
+      "no-function-expression": true,
+      "no-internal-module": true,
+      "no-shadowed-variable": true,
+      "no-switch-case-fall-through": true,
+      "no-unnecessary-semicolons": true,
+      "no-unused-expression": true,
+      "no-unused-imports": true,
+      "no-use-before-declare": true,
+      "no-with-statement": true,
+      "semicolon": true,
+      "trailing-comma": false,
+      "typedef": false,
+      "typedef-whitespace": false,
+      "use-named-parameter": true,
+      "valid-typeof": true,
+      "variable-name": false,
+      "whitespace": false
+    }
+  }
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-ko/config/write-manifests.json
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-ko/config/write-manifests.json
@@ -1,0 +1,3 @@
+{
+  "cdnBasePath": "<!-- PATH TO CDN -->"
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-ko/gulpfile.js
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-ko/gulpfile.js
@@ -1,0 +1,6 @@
+'use strict';
+
+const gulp = require('gulp');
+const build = require('@microsoft/sp-build-web');
+
+build.initialize(gulp);

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-ko/package-lock.json
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-ko/package-lock.json
@@ -1,0 +1,18 @@
+{
+  "name": "spfx",
+  "version": "0.0.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@types/knockout": {
+      "version": "3.4.39",
+      "resolved": "https://registry.npmjs.org/@types/knockout/-/knockout-3.4.39.tgz",
+      "integrity": "sha1-9CGEj5KqmW/8v5/506pX0gOKsS4="
+    },
+    "knockout": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/knockout/-/knockout-3.4.0.tgz",
+      "integrity": "sha1-WdcmGBWhHrfBo/PHB3yomKRMqts="
+    }
+  }
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-ko/package.json
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-ko/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "spfx",
+  "version": "0.0.1",
+  "private": true,
+  "engines": {
+    "node": ">=0.10.0"
+  },
+  "dependencies": {
+    "@microsoft/sp-client-base": "~1.0.0",
+    "@microsoft/sp-core-library": "~1.0.0",
+    "@microsoft/sp-webpart-base": "~1.0.0",
+    "@types/knockout": "3.4.39",
+    "@types/webpack-env": ">=1.12.1 <1.14.0",
+    "knockout": "3.4.0"
+  },
+  "devDependencies": {
+    "@microsoft/sp-build-web": "~1.0.1",
+    "@microsoft/sp-module-interfaces": "~1.0.0",
+    "@microsoft/sp-webpart-workbench": "~1.0.0",
+    "gulp": "~3.9.1",
+    "@types/chai": ">=3.4.34 <3.6.0",
+    "@types/mocha": ">=2.2.33 <2.6.0"
+  },
+  "scripts": {
+    "build": "gulp bundle",
+    "clean": "gulp clean",
+    "test": "gulp test"
+  }
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-ko/src/webparts/helloWorld/HelloWorld.module.scss
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-ko/src/webparts/helloWorld/HelloWorld.module.scss
@@ -1,0 +1,52 @@
+.helloWorld {
+  .container {
+    max-width: 700px;
+    margin: 0px auto;
+    box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.2), 0 25px 50px 0 rgba(0, 0, 0, 0.1);
+  }
+
+  .row {
+    padding: 20px;
+  }
+
+  .listItem {
+    max-width: 715px;
+    margin: 5px auto 5px auto;
+    box-shadow: 0 0 4px 0 rgba(0, 0, 0, 0.2), 0 25px 50px 0 rgba(0, 0, 0, 0.1);
+  }
+
+  .button {
+    // Our button
+    text-decoration: none;
+    height: 32px;
+
+    // Primary Button
+    min-width: 80px;
+    background-color: #0078d7;
+    border-color: #0078d7;
+    color: #ffffff;
+
+    // Basic Button
+    outline: transparent;
+    position: relative;
+    font-family: "Segoe UI WestEuropean","Segoe UI",-apple-system,BlinkMacSystemFont,Roboto,"Helvetica Neue",sans-serif;
+    -webkit-font-smoothing: antialiased;
+    font-size: 14px;
+    font-weight: 400;
+    border-width: 0;
+    text-align: center;
+    cursor: pointer;
+    display: inline-block;
+    padding: 0 16px;
+
+    .label {
+      font-weight: 600;
+      font-size: 14px;
+      height: 32px;
+      line-height: 32px;
+      margin: 0 4px;
+      vertical-align: top;
+      display: inline-block;
+    }
+  }
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-ko/src/webparts/helloWorld/HelloWorld.template.html
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-ko/src/webparts/helloWorld/HelloWorld.template.html
@@ -1,0 +1,14 @@
+<div data-bind="attr: {class:helloWorldClass}">
+    <div data-bind="attr: {class:containerClass}">
+      <div data-bind="attr: {class:rowClass}">
+        <div class="ms-Grid-col ms-u-lg10 ms-u-xl8 ms-u-xlPush2 ms-u-lgPush1">
+          <span class="ms-font-xl ms-fontColor-white">Welcome to SharePoint!</span>
+          <p class="ms-font-l ms-fontColor-white">Customize SharePoint experiences using Web Parts.</p>
+          <p class="ms-font-l ms-fontColor-white" data-bind="text:description"></p>
+          <a href="https://aka.ms/spfx" data-bind="attr: {class:buttonClass}">
+            <span data-bind="attr: {class:labelClass}">Learn more</span>
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-ko/src/webparts/helloWorld/HelloWorldViewModel.ts
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-ko/src/webparts/helloWorld/HelloWorldViewModel.ts
@@ -1,0 +1,26 @@
+import * as ko from 'knockout';
+import styles from './HelloWorld.module.scss';
+import { IHelloWorldWebPartProps } from './IHelloWorldWebPartProps';
+
+export interface IHelloWorldBindingContext extends IHelloWorldWebPartProps {
+  shouter: KnockoutSubscribable<{}>;
+}
+
+export default class HelloWorldViewModel {
+  public description: KnockoutObservable<string> = ko.observable('');
+
+  public labelClass: string = styles.label;
+  public helloWorldClass: string = styles.helloWorld;
+  public containerClass: string = styles.container;
+  public rowClass: string = `ms-Grid-row ms-bgColor-themeDark ms-fontColor-white ${styles.row}`;
+  public buttonClass: string = `ms-Button ${styles.button}`;
+
+  constructor(bindings: IHelloWorldBindingContext) {
+    this.description(bindings.description);
+
+    // When web part description is updated, change this view model's description.
+    bindings.shouter.subscribe((value: string) => {
+      this.description(value);
+    }, this, 'description');
+  }
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-ko/src/webparts/helloWorld/HelloWorldWebPart.manifest.json
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-ko/src/webparts/helloWorld/HelloWorldWebPart.manifest.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "../../../node_modules/@microsoft/sp-module-interfaces/lib/manifestSchemas/jsonSchemas/clientSideComponentManifestSchema.json",
+
+  "id": "6cb8f485-8f36-43d7-8bb4-8a18a87f9b0c",
+  "alias": "HelloWorldWebPart",
+  "componentType": "WebPart",
+  "version": "0.0.1",
+  "manifestVersion": 2,
+
+  "preconfiguredEntries": [{
+    "groupId": "6cb8f485-8f36-43d7-8bb4-8a18a87f9b0c",
+    "group": { "default": "Under Development" },
+    "title": { "default": "HelloWorld" },
+    "description": { "default": "HelloWorld description" },
+    "officeFabricIconFontName": "Page",
+    "properties": {
+      "description": "HelloWorld"
+    }
+  }]
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-ko/src/webparts/helloWorld/HelloWorldWebPart.ts
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-ko/src/webparts/helloWorld/HelloWorldWebPart.ts
@@ -1,0 +1,100 @@
+import * as ko from 'knockout';
+import { Version } from '@microsoft/sp-core-library';
+import {
+  BaseClientSideWebPart,
+  IPropertyPaneConfiguration,
+  PropertyPaneTextField
+} from '@microsoft/sp-webpart-base';
+
+import * as strings from 'helloWorldStrings';
+import HelloWorldViewModel, { IHelloWorldBindingContext } from './HelloWorldViewModel';
+import { IHelloWorldWebPartProps } from './IHelloWorldWebPartProps';
+
+let _instance: number = 0;
+
+export default class HelloWorldWebPart extends BaseClientSideWebPart<IHelloWorldWebPartProps> {
+  private _id: number;
+  private _componentElement: HTMLElement;
+  private _koDescription: KnockoutObservable<string> = ko.observable('');
+
+  /**
+   * Shouter is used to communicate between web part and view model.
+   */
+  private _shouter: KnockoutSubscribable<{}> = new ko.subscribable();
+
+  /**
+   * Initialize the web part.
+   */
+  protected onInit(): Promise<void> {
+    this._id = _instance++;
+
+    const tagName: string = `ComponentElement-${this._id}`;
+    this._componentElement = this._createComponentElement(tagName);
+    this._registerComponent(tagName);
+
+    // When web part description is changed, notify view model to update.
+    this._koDescription.subscribe((newValue: string) => {
+      this._shouter.notifySubscribers(newValue, 'description');
+    });
+
+    const bindings: IHelloWorldBindingContext = {
+      description: this.properties.description,
+      shouter: this._shouter
+    };
+
+    ko.applyBindings(bindings, this._componentElement);
+
+    return super.onInit();
+  }
+
+  public render(): void {
+    if (!this.renderedOnce) {
+      this.domElement.appendChild(this._componentElement);
+    }
+
+    this._koDescription(this.properties.description);
+  }
+
+  private _createComponentElement(tagName: string): HTMLElement {
+    const componentElement: HTMLElement = document.createElement('div');
+    componentElement.setAttribute('data-bind', `component: { name: "${tagName}", params: $data }`);
+    return componentElement;
+  }
+
+  private _registerComponent(tagName: string): void {
+    ko.components.register(
+      tagName,
+      {
+        viewModel: HelloWorldViewModel,
+        template: require('./HelloWorld.template.html'),
+        synchronous: false
+      }
+    );
+  }
+
+  protected get dataVersion(): Version {
+    return Version.parse('1.0');
+  }
+
+  protected getPropertyPaneConfiguration(): IPropertyPaneConfiguration {
+    return {
+      pages: [
+        {
+          header: {
+            description: strings.PropertyPaneDescription
+          },
+          groups: [
+            {
+              groupName: strings.BasicGroupName,
+              groupFields: [
+                PropertyPaneTextField('description', {
+                  label: strings.DescriptionFieldLabel
+                })
+              ]
+            }
+          ]
+        }
+      ]
+    };
+  }
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-ko/src/webparts/helloWorld/IHelloWorldWebPartProps.ts
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-ko/src/webparts/helloWorld/IHelloWorldWebPartProps.ts
@@ -1,0 +1,3 @@
+export interface IHelloWorldWebPartProps {
+  description: string;
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-ko/src/webparts/helloWorld/loc/en-us.js
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-ko/src/webparts/helloWorld/loc/en-us.js
@@ -1,0 +1,7 @@
+define([], function() {
+  return {
+    "PropertyPaneDescription": "Description",
+    "BasicGroupName": "Group Name",
+    "DescriptionFieldLabel": "Description Field"
+  }
+});

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-ko/src/webparts/helloWorld/loc/mystrings.d.ts
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-ko/src/webparts/helloWorld/loc/mystrings.d.ts
@@ -1,0 +1,10 @@
+declare interface IHelloWorldStrings {
+  PropertyPaneDescription: string;
+  BasicGroupName: string;
+  DescriptionFieldLabel: string;
+}
+
+declare module 'helloWorldStrings' {
+  const strings: IHelloWorldStrings;
+  export = strings;
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-ko/src/webparts/helloWorld/tests/HelloWorld.test.ts
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-ko/src/webparts/helloWorld/tests/HelloWorld.test.ts
@@ -1,0 +1,9 @@
+/// <reference types="mocha" />
+
+import { assert } from 'chai';
+
+describe('HelloWorldWebPart', () => {
+  it('should do something', () => {
+    assert.ok(true);
+  });
+});

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-ko/tsconfig.json
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-ko/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "forceConsistentCasingInFileNames": true,
+    "module": "commonjs",
+    "jsx": "react",
+    "declaration": true,
+    "sourceMap": true,
+    "types": [
+      "es6-promise",
+      "es6-collections",
+      "webpack-env"
+    ]
+  }
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-nolib/.editorconfig
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-nolib/.editorconfig
@@ -1,0 +1,25 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+
+[*]
+
+# change these settings to your own preference
+indent_style = space
+indent_size = 2
+
+# we recommend you to keep these unchanged
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[{package,bower}.json]
+indent_style = space
+indent_size = 2

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-nolib/.gitattributes
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-nolib/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-nolib/.gitignore
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-nolib/.gitignore
@@ -1,0 +1,32 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+
+# Dependency directories
+node_modules
+
+# Build generated files
+dist
+lib
+solution
+temp
+*.sppkg
+
+# Coverage directory used by tools like istanbul
+coverage
+
+# OSX
+.DS_Store
+
+# Visual Studio files
+.ntvs_analysis.dat
+.vs
+bin
+obj
+
+# Resx Generated Code
+*.resx.ts
+
+# Styles Generated Code
+*.scss.ts

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-nolib/.npmignore
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-nolib/.npmignore
@@ -1,0 +1,14 @@
+# Folders
+.vscode
+coverage
+node_modules
+sharepoint
+src
+temp
+
+# Files
+*.csproj
+.git*
+.yo-rc.json
+gulpfile.js
+tsconfig.json

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-nolib/.yo-rc.json
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-nolib/.yo-rc.json
@@ -1,0 +1,8 @@
+{
+  "@microsoft/generator-sharepoint": {
+    "libraryName": "spfx",
+    "framework": "none",
+    "version": "1.0.2",
+    "libraryId": "f20941ac-f35b-46ad-96c7-10661267da7d"
+  }
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-nolib/README.md
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-nolib/README.md
@@ -1,0 +1,26 @@
+## spfx
+
+This is where you include your WebPart documentation.
+
+### Building the code
+
+```bash
+git clone the repo
+npm i
+npm i -g gulp
+gulp
+```
+
+This package produces the following:
+
+* lib/* - intermediate-stage commonjs build artifacts
+* dist/* - the bundled script, along with other resources
+* deploy/* - all resources which should be uploaded to a CDN.
+
+### Build options
+
+gulp clean - TODO
+gulp test - TODO
+gulp serve - TODO
+gulp bundle - TODO
+gulp package-solution - TODO

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-nolib/config/config.json
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-nolib/config/config.json
@@ -1,0 +1,13 @@
+{
+  "entries": [
+    {
+      "entry": "./lib/webparts/helloWorld/HelloWorldWebPart.js",
+      "manifest": "./src/webparts/helloWorld/HelloWorldWebPart.manifest.json",
+      "outputPath": "./dist/hello-world.bundle.js"
+    }
+  ],
+  "externals": {},
+  "localizedResources": {
+    "helloWorldStrings": "webparts/helloWorld/loc/{locale}.js"
+  }
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-nolib/config/copy-assets.json
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-nolib/config/copy-assets.json
@@ -1,0 +1,3 @@
+{
+  "deployCdnPath": "temp/deploy"
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-nolib/config/deploy-azure-storage.json
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-nolib/config/deploy-azure-storage.json
@@ -1,0 +1,6 @@
+{
+  "workingDir": "./temp/deploy/",
+  "account": "<!-- STORAGE ACCOUNT NAME -->",
+  "container": "spfx",
+  "accessKey": "<!-- ACCESS KEY -->"
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-nolib/config/package-solution.json
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-nolib/config/package-solution.json
@@ -1,0 +1,10 @@
+{
+  "solution": {
+    "name": "spfx-client-side-solution",
+    "id": "f20941ac-f35b-46ad-96c7-10661267da7d",
+    "version": "1.0.0.0"
+  },
+  "paths": {
+    "zippedPackage": "solution/spfx.sppkg"
+  }
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-nolib/config/serve.json
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-nolib/config/serve.json
@@ -1,0 +1,9 @@
+{
+  "port": 4321,
+  "initialPage": "https://localhost:5432/workbench",
+  "https": true,
+  "api": {
+    "port": 5432,
+    "entryPath": "node_modules/@microsoft/sp-webpart-workbench/lib/api/"
+  }
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-nolib/config/tslint.json
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-nolib/config/tslint.json
@@ -1,0 +1,45 @@
+{
+  // Display errors as warnings
+  "displayAsWarning": true,
+  // The TSLint task may have been configured with several custom lint rules
+  // before this config file is read (for example lint rules from the tslint-microsoft-contrib
+  // project). If true, this flag will deactivate any of these rules.
+  "removeExistingRules": true,
+  // When true, the TSLint task is configured with some default TSLint "rules.":
+  "useDefaultConfigAsBase": false,
+  // Since removeExistingRules=true and useDefaultConfigAsBase=false, there will be no lint rules
+  // which are active, other than the list of rules below.
+  "lintConfig": {
+    // Opt-in to Lint rules which help to eliminate bugs in JavaScript
+    "rules": {
+      "class-name": false,
+      "export-name": false,
+      "forin": false,
+      "label-position": false,
+      "member-access": true,
+      "no-arg": false,
+      "no-console": false,
+      "no-construct": false,
+      "no-duplicate-case": true,
+      "no-duplicate-variable": true,
+      "no-eval": false,
+      "no-function-expression": true,
+      "no-internal-module": true,
+      "no-shadowed-variable": true,
+      "no-switch-case-fall-through": true,
+      "no-unnecessary-semicolons": true,
+      "no-unused-expression": true,
+      "no-unused-imports": true,
+      "no-use-before-declare": true,
+      "no-with-statement": true,
+      "semicolon": true,
+      "trailing-comma": false,
+      "typedef": false,
+      "typedef-whitespace": false,
+      "use-named-parameter": true,
+      "valid-typeof": true,
+      "variable-name": false,
+      "whitespace": false
+    }
+  }
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-nolib/config/write-manifests.json
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-nolib/config/write-manifests.json
@@ -1,0 +1,3 @@
+{
+  "cdnBasePath": "<!-- PATH TO CDN -->"
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-nolib/gulpfile.js
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-nolib/gulpfile.js
@@ -1,0 +1,6 @@
+'use strict';
+
+const gulp = require('gulp');
+const build = require('@microsoft/sp-build-web');
+
+build.initialize(gulp);

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-nolib/package.json
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-nolib/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "spfx",
+  "version": "0.0.1",
+  "private": true,
+  "engines": {
+    "node": ">=0.10.0"
+  },
+  "dependencies": {
+    "@microsoft/sp-client-base": "~1.0.0",
+    "@microsoft/sp-core-library": "~1.0.0",
+    "@microsoft/sp-webpart-base": "~1.0.0",
+    "@types/webpack-env": ">=1.12.1 <1.14.0"
+  },
+  "devDependencies": {
+    "@microsoft/sp-build-web": "~1.0.1",
+    "@microsoft/sp-module-interfaces": "~1.0.0",
+    "@microsoft/sp-webpart-workbench": "~1.0.0",
+    "gulp": "~3.9.1",
+    "@types/chai": ">=3.4.34 <3.6.0",
+    "@types/mocha": ">=2.2.33 <2.6.0"
+  },
+  "scripts": {
+    "build": "gulp bundle",
+    "clean": "gulp clean",
+    "test": "gulp test"
+  }
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-nolib/src/webparts/helloWorld/HelloWorld.module.scss
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-nolib/src/webparts/helloWorld/HelloWorld.module.scss
@@ -1,0 +1,52 @@
+.helloWorld {
+  .container {
+    max-width: 700px;
+    margin: 0px auto;
+    box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.2), 0 25px 50px 0 rgba(0, 0, 0, 0.1);
+  }
+
+  .row {
+    padding: 20px;
+  }
+
+  .listItem {
+    max-width: 715px;
+    margin: 5px auto 5px auto;
+    box-shadow: 0 0 4px 0 rgba(0, 0, 0, 0.2), 0 25px 50px 0 rgba(0, 0, 0, 0.1);
+  }
+
+  .button {
+    // Our button
+    text-decoration: none;
+    height: 32px;
+
+    // Primary Button
+    min-width: 80px;
+    background-color: #0078d7;
+    border-color: #0078d7;
+    color: #ffffff;
+
+    // Basic Button
+    outline: transparent;
+    position: relative;
+    font-family: "Segoe UI WestEuropean","Segoe UI",-apple-system,BlinkMacSystemFont,Roboto,"Helvetica Neue",sans-serif;
+    -webkit-font-smoothing: antialiased;
+    font-size: 14px;
+    font-weight: 400;
+    border-width: 0;
+    text-align: center;
+    cursor: pointer;
+    display: inline-block;
+    padding: 0 16px;
+
+    .label {
+      font-weight: 600;
+      font-size: 14px;
+      height: 32px;
+      line-height: 32px;
+      margin: 0 4px;
+      vertical-align: top;
+      display: inline-block;
+    }
+  }
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-nolib/src/webparts/helloWorld/HelloWorldWebPart.manifest.json
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-nolib/src/webparts/helloWorld/HelloWorldWebPart.manifest.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "../../../node_modules/@microsoft/sp-module-interfaces/lib/manifestSchemas/jsonSchemas/clientSideComponentManifestSchema.json",
+
+  "id": "d73f2bc8-80bb-4043-bacd-23384296c0d0",
+  "alias": "HelloWorldWebPart",
+  "componentType": "WebPart",
+  "version": "0.0.1",
+  "manifestVersion": 2,
+
+  "preconfiguredEntries": [{
+    "groupId": "d73f2bc8-80bb-4043-bacd-23384296c0d0",
+    "group": { "default": "Under Development" },
+    "title": { "default": "HelloWorld" },
+    "description": { "default": "HelloWorld description" },
+    "officeFabricIconFontName": "Page",
+    "properties": {
+      "description": "HelloWorld"
+    }
+  }]
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-nolib/src/webparts/helloWorld/HelloWorldWebPart.ts
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-nolib/src/webparts/helloWorld/HelloWorldWebPart.ts
@@ -1,0 +1,58 @@
+import { Version } from '@microsoft/sp-core-library';
+import {
+  BaseClientSideWebPart,
+  IPropertyPaneConfiguration,
+  PropertyPaneTextField
+} from '@microsoft/sp-webpart-base';
+import { escape } from '@microsoft/sp-lodash-subset';
+
+import styles from './HelloWorld.module.scss';
+import * as strings from 'helloWorldStrings';
+import { IHelloWorldWebPartProps } from './IHelloWorldWebPartProps';
+
+export default class HelloWorldWebPart extends BaseClientSideWebPart<IHelloWorldWebPartProps> {
+
+  public render(): void {
+    this.domElement.innerHTML = `
+      <div class="${styles.helloWorld}">
+        <div class="${styles.container}">
+          <div class="ms-Grid-row ms-bgColor-themeDark ms-fontColor-white ${styles.row}">
+            <div class="ms-Grid-col ms-u-lg10 ms-u-xl8 ms-u-xlPush2 ms-u-lgPush1">
+              <span class="ms-font-xl ms-fontColor-white">Welcome to SharePoint!</span>
+              <p class="ms-font-l ms-fontColor-white">Customize SharePoint experiences using Web Parts.</p>
+              <p class="ms-font-l ms-fontColor-white">${escape(this.properties.description)}</p>
+              <a href="https://aka.ms/spfx" class="${styles.button}">
+                <span class="${styles.label}">Learn more</span>
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>`;
+  }
+
+  protected get dataVersion(): Version {
+    return Version.parse('1.0');
+  }
+
+  protected getPropertyPaneConfiguration(): IPropertyPaneConfiguration {
+    return {
+      pages: [
+        {
+          header: {
+            description: strings.PropertyPaneDescription
+          },
+          groups: [
+            {
+              groupName: strings.BasicGroupName,
+              groupFields: [
+                PropertyPaneTextField('description', {
+                  label: strings.DescriptionFieldLabel
+                })
+              ]
+            }
+          ]
+        }
+      ]
+    };
+  }
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-nolib/src/webparts/helloWorld/IHelloWorldWebPartProps.ts
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-nolib/src/webparts/helloWorld/IHelloWorldWebPartProps.ts
@@ -1,0 +1,3 @@
+export interface IHelloWorldWebPartProps {
+  description: string;
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-nolib/src/webparts/helloWorld/loc/en-us.js
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-nolib/src/webparts/helloWorld/loc/en-us.js
@@ -1,0 +1,7 @@
+define([], function() {
+  return {
+    "PropertyPaneDescription": "Description",
+    "BasicGroupName": "Group Name",
+    "DescriptionFieldLabel": "Description Field"
+  }
+});

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-nolib/src/webparts/helloWorld/loc/mystrings.d.ts
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-nolib/src/webparts/helloWorld/loc/mystrings.d.ts
@@ -1,0 +1,10 @@
+declare interface IHelloWorldStrings {
+  PropertyPaneDescription: string;
+  BasicGroupName: string;
+  DescriptionFieldLabel: string;
+}
+
+declare module 'helloWorldStrings' {
+  const strings: IHelloWorldStrings;
+  export = strings;
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-nolib/src/webparts/helloWorld/tests/HelloWorld.test.ts
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-nolib/src/webparts/helloWorld/tests/HelloWorld.test.ts
@@ -1,0 +1,9 @@
+/// <reference types="mocha" />
+
+import { assert } from 'chai';
+
+describe('HelloWorldWebPart', () => {
+  it('should do something', () => {
+    assert.ok(true);
+  });
+});

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-nolib/tsconfig.json
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-nolib/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "forceConsistentCasingInFileNames": true,
+    "module": "commonjs",
+    "jsx": "react",
+    "declaration": true,
+    "sourceMap": true,
+    "types": [
+      "es6-promise",
+      "es6-collections",
+      "webpack-env"
+    ]
+  }
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-react/.editorconfig
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-react/.editorconfig
@@ -1,0 +1,25 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+
+[*]
+
+# change these settings to your own preference
+indent_style = space
+indent_size = 2
+
+# we recommend you to keep these unchanged
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[{package,bower}.json]
+indent_style = space
+indent_size = 2

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-react/.gitattributes
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-react/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-react/.gitignore
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-react/.gitignore
@@ -1,0 +1,32 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+
+# Dependency directories
+node_modules
+
+# Build generated files
+dist
+lib
+solution
+temp
+*.sppkg
+
+# Coverage directory used by tools like istanbul
+coverage
+
+# OSX
+.DS_Store
+
+# Visual Studio files
+.ntvs_analysis.dat
+.vs
+bin
+obj
+
+# Resx Generated Code
+*.resx.ts
+
+# Styles Generated Code
+*.scss.ts

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-react/.npmignore
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-react/.npmignore
@@ -1,0 +1,14 @@
+# Folders
+.vscode
+coverage
+node_modules
+sharepoint
+src
+temp
+
+# Files
+*.csproj
+.git*
+.yo-rc.json
+gulpfile.js
+tsconfig.json

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-react/.yo-rc.json
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-react/.yo-rc.json
@@ -1,0 +1,8 @@
+{
+  "@microsoft/generator-sharepoint": {
+    "libraryName": "spfx",
+    "framework": "react",
+    "version": "1.0.2",
+    "libraryId": "70dde3d0-6768-41ee-b1f7-fdb768370635"
+  }
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-react/README.md
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-react/README.md
@@ -1,0 +1,26 @@
+## spfx
+
+This is where you include your WebPart documentation.
+
+### Building the code
+
+```bash
+git clone the repo
+npm i
+npm i -g gulp
+gulp
+```
+
+This package produces the following:
+
+* lib/* - intermediate-stage commonjs build artifacts
+* dist/* - the bundled script, along with other resources
+* deploy/* - all resources which should be uploaded to a CDN.
+
+### Build options
+
+gulp clean - TODO
+gulp test - TODO
+gulp serve - TODO
+gulp bundle - TODO
+gulp package-solution - TODO

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-react/config/config.json
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-react/config/config.json
@@ -1,0 +1,13 @@
+{
+  "entries": [
+    {
+      "entry": "./lib/webparts/helloWorld/HelloWorldWebPart.js",
+      "manifest": "./src/webparts/helloWorld/HelloWorldWebPart.manifest.json",
+      "outputPath": "./dist/hello-world.bundle.js"
+    }
+  ],
+  "externals": {},
+  "localizedResources": {
+    "helloWorldStrings": "webparts/helloWorld/loc/{locale}.js"
+  }
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-react/config/copy-assets.json
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-react/config/copy-assets.json
@@ -1,0 +1,3 @@
+{
+  "deployCdnPath": "temp/deploy"
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-react/config/deploy-azure-storage.json
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-react/config/deploy-azure-storage.json
@@ -1,0 +1,6 @@
+{
+  "workingDir": "./temp/deploy/",
+  "account": "<!-- STORAGE ACCOUNT NAME -->",
+  "container": "spfx",
+  "accessKey": "<!-- ACCESS KEY -->"
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-react/config/package-solution.json
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-react/config/package-solution.json
@@ -1,0 +1,10 @@
+{
+  "solution": {
+    "name": "spfx-client-side-solution",
+    "id": "70dde3d0-6768-41ee-b1f7-fdb768370635",
+    "version": "1.0.0.0"
+  },
+  "paths": {
+    "zippedPackage": "solution/spfx.sppkg"
+  }
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-react/config/serve.json
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-react/config/serve.json
@@ -1,0 +1,9 @@
+{
+  "port": 4321,
+  "initialPage": "https://localhost:5432/workbench",
+  "https": true,
+  "api": {
+    "port": 5432,
+    "entryPath": "node_modules/@microsoft/sp-webpart-workbench/lib/api/"
+  }
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-react/config/tslint.json
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-react/config/tslint.json
@@ -1,0 +1,45 @@
+{
+  // Display errors as warnings
+  "displayAsWarning": true,
+  // The TSLint task may have been configured with several custom lint rules
+  // before this config file is read (for example lint rules from the tslint-microsoft-contrib
+  // project). If true, this flag will deactivate any of these rules.
+  "removeExistingRules": true,
+  // When true, the TSLint task is configured with some default TSLint "rules.":
+  "useDefaultConfigAsBase": false,
+  // Since removeExistingRules=true and useDefaultConfigAsBase=false, there will be no lint rules
+  // which are active, other than the list of rules below.
+  "lintConfig": {
+    // Opt-in to Lint rules which help to eliminate bugs in JavaScript
+    "rules": {
+      "class-name": false,
+      "export-name": false,
+      "forin": false,
+      "label-position": false,
+      "member-access": true,
+      "no-arg": false,
+      "no-console": false,
+      "no-construct": false,
+      "no-duplicate-case": true,
+      "no-duplicate-variable": true,
+      "no-eval": false,
+      "no-function-expression": true,
+      "no-internal-module": true,
+      "no-shadowed-variable": true,
+      "no-switch-case-fall-through": true,
+      "no-unnecessary-semicolons": true,
+      "no-unused-expression": true,
+      "no-unused-imports": true,
+      "no-use-before-declare": true,
+      "no-with-statement": true,
+      "semicolon": true,
+      "trailing-comma": false,
+      "typedef": false,
+      "typedef-whitespace": false,
+      "use-named-parameter": true,
+      "valid-typeof": true,
+      "variable-name": false,
+      "whitespace": false
+    }
+  }
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-react/config/write-manifests.json
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-react/config/write-manifests.json
@@ -1,0 +1,3 @@
+{
+  "cdnBasePath": "<!-- PATH TO CDN -->"
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-react/gulpfile.js
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-react/gulpfile.js
@@ -1,0 +1,6 @@
+'use strict';
+
+const gulp = require('gulp');
+const build = require('@microsoft/sp-build-web');
+
+build.initialize(gulp);

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-react/package.json
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-react/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "spfx",
+  "version": "0.0.1",
+  "private": true,
+  "engines": {
+    "node": ">=0.10.0"
+  },
+  "dependencies": {
+    "@microsoft/sp-client-base": "~1.0.0",
+    "@microsoft/sp-core-library": "~1.0.0",
+    "@microsoft/sp-webpart-base": "~1.0.0",
+    "@types/webpack-env": ">=1.12.1 <1.14.0"
+  },
+  "devDependencies": {
+    "@microsoft/sp-build-web": "~1.0.1",
+    "@microsoft/sp-module-interfaces": "~1.0.0",
+    "@microsoft/sp-webpart-workbench": "~1.0.0",
+    "gulp": "~3.9.1",
+    "@types/chai": ">=3.4.34 <3.6.0",
+    "@types/mocha": ">=2.2.33 <2.6.0"
+  },
+  "scripts": {
+    "build": "gulp bundle",
+    "clean": "gulp clean",
+    "test": "gulp test"
+  }
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-react/src/webparts/helloWorld/HelloWorldWebPart.manifest.json
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-react/src/webparts/helloWorld/HelloWorldWebPart.manifest.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "../../../node_modules/@microsoft/sp-module-interfaces/lib/manifestSchemas/jsonSchemas/clientSideComponentManifestSchema.json",
+
+  "id": "0bbe904a-454b-4d0e-b8be-555e63b46651",
+  "alias": "HelloWorldWebPart",
+  "componentType": "WebPart",
+  "version": "0.0.1",
+  "manifestVersion": 2,
+
+  "preconfiguredEntries": [{
+    "groupId": "0bbe904a-454b-4d0e-b8be-555e63b46651",
+    "group": { "default": "Under Development" },
+    "title": { "default": "HelloWorld" },
+    "description": { "default": "HelloWorld description" },
+    "officeFabricIconFontName": "Page",
+    "properties": {
+      "description": "HelloWorld"
+    }
+  }]
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-react/src/webparts/helloWorld/HelloWorldWebPart.ts
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-react/src/webparts/helloWorld/HelloWorldWebPart.ts
@@ -1,0 +1,53 @@
+import * as React from 'react';
+import * as ReactDom from 'react-dom';
+import { Version } from '@microsoft/sp-core-library';
+import {
+  BaseClientSideWebPart,
+  IPropertyPaneConfiguration,
+  PropertyPaneTextField
+} from '@microsoft/sp-webpart-base';
+
+import * as strings from 'helloWorldStrings';
+import HelloWorld from './components/HelloWorld';
+import { IHelloWorldProps } from './components/IHelloWorldProps';
+import { IHelloWorldWebPartProps } from './IHelloWorldWebPartProps';
+
+export default class HelloWorldWebPart extends BaseClientSideWebPart<IHelloWorldWebPartProps> {
+
+  public render(): void {
+    const element: React.ReactElement<IHelloWorldProps > = React.createElement(
+      HelloWorld,
+      {
+        description: this.properties.description
+      }
+    );
+
+    ReactDom.render(element, this.domElement);
+  }
+
+  protected get dataVersion(): Version {
+    return Version.parse('1.0');
+  }
+
+  protected getPropertyPaneConfiguration(): IPropertyPaneConfiguration {
+    return {
+      pages: [
+        {
+          header: {
+            description: strings.PropertyPaneDescription
+          },
+          groups: [
+            {
+              groupName: strings.BasicGroupName,
+              groupFields: [
+                PropertyPaneTextField('description', {
+                  label: strings.DescriptionFieldLabel
+                })
+              ]
+            }
+          ]
+        }
+      ]
+    };
+  }
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-react/src/webparts/helloWorld/IHelloWorldWebPartProps.ts
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-react/src/webparts/helloWorld/IHelloWorldWebPartProps.ts
@@ -1,0 +1,3 @@
+export interface IHelloWorldWebPartProps {
+  description: string;
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-react/src/webparts/helloWorld/components/HelloWorld.module.scss
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-react/src/webparts/helloWorld/components/HelloWorld.module.scss
@@ -1,0 +1,52 @@
+.helloWorld {
+  .container {
+    max-width: 700px;
+    margin: 0px auto;
+    box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.2), 0 25px 50px 0 rgba(0, 0, 0, 0.1);
+  }
+
+  .row {
+    padding: 20px;
+  }
+
+  .listItem {
+    max-width: 715px;
+    margin: 5px auto 5px auto;
+    box-shadow: 0 0 4px 0 rgba(0, 0, 0, 0.2), 0 25px 50px 0 rgba(0, 0, 0, 0.1);
+  }
+
+  .button {
+    // Our button
+    text-decoration: none;
+    height: 32px;
+
+    // Primary Button
+    min-width: 80px;
+    background-color: #0078d7;
+    border-color: #0078d7;
+    color: #ffffff;
+
+    // Basic Button
+    outline: transparent;
+    position: relative;
+    font-family: "Segoe UI WestEuropean","Segoe UI",-apple-system,BlinkMacSystemFont,Roboto,"Helvetica Neue",sans-serif;
+    -webkit-font-smoothing: antialiased;
+    font-size: 14px;
+    font-weight: 400;
+    border-width: 0;
+    text-align: center;
+    cursor: pointer;
+    display: inline-block;
+    padding: 0 16px;
+
+    .label {
+      font-weight: 600;
+      font-size: 14px;
+      height: 32px;
+      line-height: 32px;
+      margin: 0 4px;
+      vertical-align: top;
+      display: inline-block;
+    }
+  }
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-react/src/webparts/helloWorld/components/HelloWorld.tsx
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-react/src/webparts/helloWorld/components/HelloWorld.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react';
+import styles from './HelloWorld.module.scss';
+import { IHelloWorldProps } from './IHelloWorldProps';
+import { escape } from '@microsoft/sp-lodash-subset';
+
+export default class HelloWorld extends React.Component<IHelloWorldProps, void> {
+  public render(): React.ReactElement<IHelloWorldProps> {
+    return (
+      <div className={styles.helloWorld}>
+        <div className={styles.container}>
+          <div className={`ms-Grid-row ms-bgColor-themeDark ms-fontColor-white ${styles.row}`}>
+            <div className="ms-Grid-col ms-u-lg10 ms-u-xl8 ms-u-xlPush2 ms-u-lgPush1">
+              <span className="ms-font-xl ms-fontColor-white">Welcome to SharePoint!</span>
+              <p className="ms-font-l ms-fontColor-white">Customize SharePoint experiences using Web Parts.</p>
+              <p className="ms-font-l ms-fontColor-white">{escape(this.props.description)}</p>
+              <a href="https://aka.ms/spfx" className={styles.button}>
+                <span className={styles.label}>Learn more</span>
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-react/src/webparts/helloWorld/components/IHelloWorldProps.ts
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-react/src/webparts/helloWorld/components/IHelloWorldProps.ts
@@ -1,0 +1,3 @@
+export interface IHelloWorldProps {
+  description: string;
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-react/src/webparts/helloWorld/loc/en-us.js
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-react/src/webparts/helloWorld/loc/en-us.js
@@ -1,0 +1,7 @@
+define([], function() {
+  return {
+    "PropertyPaneDescription": "Description",
+    "BasicGroupName": "Group Name",
+    "DescriptionFieldLabel": "Description Field"
+  }
+});

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-react/src/webparts/helloWorld/loc/mystrings.d.ts
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-react/src/webparts/helloWorld/loc/mystrings.d.ts
@@ -1,0 +1,10 @@
+declare interface IHelloWorldStrings {
+  PropertyPaneDescription: string;
+  BasicGroupName: string;
+  DescriptionFieldLabel: string;
+}
+
+declare module 'helloWorldStrings' {
+  const strings: IHelloWorldStrings;
+  export = strings;
+}

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-react/src/webparts/helloWorld/tests/HelloWorld.test.ts
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-react/src/webparts/helloWorld/tests/HelloWorld.test.ts
@@ -1,0 +1,9 @@
+/// <reference types="mocha" />
+
+import { assert } from 'chai';
+
+describe('HelloWorldWebPart', () => {
+  it('should do something', () => {
+    assert.ok(true);
+  });
+});

--- a/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-react/tsconfig.json
+++ b/src/o365/spfx/commands/project/project-upgrade/test-projects/spfx-102-webpart-react/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "forceConsistentCasingInFileNames": true,
+    "module": "commonjs",
+    "jsx": "react",
+    "declaration": true,
+    "sourceMap": true,
+    "types": [
+      "es6-promise",
+      "es6-collections",
+      "webpack-env"
+    ]
+  }
+}

--- a/src/o365/spfx/commands/project/project-upgrade/upgrade-1.0.2.ts
+++ b/src/o365/spfx/commands/project/project-upgrade/upgrade-1.0.2.ts
@@ -1,0 +1,11 @@
+import { FN010201_CFG_TSL_preferConst } from "./rules/FN010201_CFG_TSL_preferConst";
+import { FN010001_YORC_version } from "./rules/FN010001_YORC_version";
+import { FN010203_DEP_knockout } from "./rules/FN010203_DEP_knockout";
+import { FN010202_DEP_types_knockout } from "./rules/FN010202_DEP_types_knockout";
+
+module.exports = [
+  new FN010201_CFG_TSL_preferConst(),
+  new FN010001_YORC_version('1.0.2'),
+  new FN010203_DEP_knockout('3.4.0'),
+  new FN010202_DEP_types_knockout('3.4.39')
+];


### PR DESCRIPTION
Solves #536 
@waldekmastykarz there's one thing I'm not sure about, it seems that from 1.0.1 to 1.0.2 for knockout projects the spfx team added types/knockout and knockout deps that were absent before.
I added the rules, unit tests are passing but at this point I'm not sure it's not going to recommend a react project to add knockout.
Could you double check? I'll also test on my side once 1.0.2 => 1.1.0 is done (+ your PR's for 1.1.0 and up are merged)
