### PR TITLE
Remarks and doc updates for objectId escaping on aad set and remove

### DIFF
--- a/docs/manual/docs/cmd/aad/oauth2grant/oauth2grant-remove.md
+++ b/docs/manual/docs/cmd/aad/oauth2grant/oauth2grant-remove.md
@@ -27,6 +27,13 @@ To remove service principal's OAuth2 permissions, you have to first log in to Az
 
 Before you can remove service principal's OAuth2 permissions, you need to get the `objectId` of the permissions grant to remove. You can retrieve it using the [aad oauth2grant list](./oauth2grant-list.md) command.
 
+ If the `objectId` listed when using the [aad oauth2grant list](./oauth2grant-list.md) command has a minus sign ('-') prefix, you may receive an error indicating `--grantId` is missing.  To resolve this issue simply escape the leading '-'.  
+
+```sh 
+aad oauth2grant remove --grantId \\-Zc1JRY8REeLxmXz5KtixAYU3Q6noCBPlhwGiX7pxmU
+```   
+     
+
 ## Examples
 
 Remove the OAuth2 permission grant with ID _YgA60KYa4UOPSdc-lpxYEnQkr8KVLDpCsOXkiV8i-ek_

--- a/docs/manual/docs/cmd/aad/oauth2grant/oauth2grant-set.md
+++ b/docs/manual/docs/cmd/aad/oauth2grant/oauth2grant-set.md
@@ -28,6 +28,13 @@ To update service principal's OAuth2 permissions, you have to first log in to Az
 
 Before you can update service principal's OAuth2 permissions, you need to get the `objectId` of the permissions grant to update. You can retrieve it using the [aad oauth2grant list](./oauth2grant-list.md) command.
 
+ If the `objectId` listed when using the [aad oauth2grant list](./oauth2grant-list.md) command has a 
+    minus sign ('-') prefix, you may receive an error indicating `--grantId` is missing.  To resolve this issue simply escape the leading '-'.  
+    
+```sh 
+aad oauth2grant set --grantId \\-Zc1JRY8REeLxmXz5KtixAYU3Q6noCBPlhwGiX7pxmU
+```   
+
 ## Examples
 
 Update the existing OAuth2 permission grant with ID _YgA60KYa4UOPSdc-lpxYEnQkr8KVLDpCsOXkiV8i-ek_ to the _Calendars.Read Mail.Read_ permissions

--- a/src/o365/aad/commands/oauth2grant/oauth2grant-remove.ts
+++ b/src/o365/aad/commands/oauth2grant/oauth2grant-remove.ts
@@ -108,7 +108,12 @@ class Oauth2GrantRemoveCommand extends AadCommand {
 
     Before you can remove service principal's OAuth2 permissions, you need to get the ${chalk.grey('objectId')}
     of the permissions grant to remove. You can retrieve it using the ${chalk.blue(commands.OAUTH2GRANT_LIST)} command.
-   
+
+    If the ${chalk.grey('objectId')} listed when using the ${chalk.blue(commands.OAUTH2GRANT_LIST)} command has a 
+    minus sign ('-') prefix, you may receive an error indicating --grantId is missing.  To resolve this issue simply 
+    escape the leading '-'.  
+      e.g. ${chalk.blue(commands.OAUTH2GRANT_REMOVE)} --grantId \\-Zc1JRY8REeLxmXz5KtixAYU3Q6noCBPlhwGiX7pxmU     
+
   Examples:
   
     Remove the OAuth2 permission grant with ID ${chalk.grey('YgA60KYa4UOPSdc-lpxYEnQkr8KVLDpCsOXkiV8i-ek')}

--- a/src/o365/aad/commands/oauth2grant/oauth2grant-set.ts
+++ b/src/o365/aad/commands/oauth2grant/oauth2grant-set.ts
@@ -121,7 +121,12 @@ class Oauth2GrantSetCommand extends AadCommand {
 
     Before you can update service principal's OAuth2 permissions, you need to get the ${chalk.grey('objectId')}
     of the permissions grant to update. You can retrieve it using the ${chalk.blue(commands.OAUTH2GRANT_LIST)} command.
-   
+
+    If the ${chalk.grey('objectId')} listed when using the ${chalk.blue(commands.OAUTH2GRANT_LIST)} command has a 
+    minus sign ('-') prefix, you may receive an error indicating --grantId is missing.  To resolve this issue simply 
+    escape the leading '-'.  
+      e.g. ${chalk.blue(commands.OAUTH2GRANT_SET)} --grantId \\-Zc1JRY8REeLxmXz5KtixAYU3Q6noCBPlhwGiX7pxmU --scope 'Calendars.Read'     
+       
   Examples:
   
     Update the existing OAuth2 permission grant with ID ${chalk.grey('YgA60KYa4UOPSdc-lpxYEnQkr8KVLDpCsOXkiV8i-ek')}


### PR DESCRIPTION
Remarks and doc updates for objectId escaping on `aad set` and `aad remove`.  In rare situations, escaping an `objectId` may be required if the `objectId` contains a minus sign (-) prefix.  