### PR TITLE
Adds mapping for two more enums for the tenant setting list command

### DIFF
--- a/src/o365/spo/commands/tenant/tenant-settings-list.spec.ts
+++ b/src/o365/spo/commands/tenant/tenant-settings-list.spec.ts
@@ -261,6 +261,8 @@ describe(commands.TENANT_SETTINGS_LIST, () => {
         assert.equal(cmdInstanceLogSpy.lastCall.args[0]["FolderAnonymousLinkType"], 'Edit');
         assert.equal(cmdInstanceLogSpy.lastCall.args[0]["DefaultLinkPermission"], 'View');
         assert.equal(cmdInstanceLogSpy.lastCall.args[0]["ConditionalAccessPolicy"], 'AllowFullAccess');
+        assert.equal(cmdInstanceLogSpy.lastCall.args[0]["SpecialCharactersStateInFileFolderNames"], 'Allowed');
+        assert.equal(cmdInstanceLogSpy.lastCall.args[0]["LimitedAccessFileType"], 'WebPreviewableFiles');
         done();
       }
       catch (e) {

--- a/src/o365/spo/commands/tenant/tenant-settings-list.ts
+++ b/src/o365/spo/commands/tenant/tenant-settings-list.ts
@@ -83,6 +83,8 @@ class SpoTenantSettingsListCommand extends SpoCommand {
         const anonymousLinkType = ['None', 'View', 'Edit'];
         const sharingPermissionType = ['None', 'View', 'Edit'];
         const sPOConditionalAccessPolicyType = ['AllowFullAccess', 'AllowLimitedAccess', 'BlockAccess'];
+        const specialCharactersState = ['NoPreference', 'Allowed', 'Disallowed'];
+        const sPOLimitedAccessFileType = ['OfficeOnlineFilesOnly', 'WebPreviewableFiles', 'OtherFiles'];
 
         result['SharingCapability'] = sharingCapabilities[result['SharingCapability']];
         result['SharingDomainRestrictionMode'] = sharingDomainRestrictionModes[result['SharingDomainRestrictionMode']];
@@ -93,6 +95,8 @@ class SpoTenantSettingsListCommand extends SpoCommand {
         result['FolderAnonymousLinkType'] = anonymousLinkType[result['FolderAnonymousLinkType']];
         result['DefaultLinkPermission'] = sharingPermissionType[result['DefaultLinkPermission']];
         result['ConditionalAccessPolicy'] = sPOConditionalAccessPolicyType[result['ConditionalAccessPolicy']];
+        result['SpecialCharactersStateInFileFolderNames'] = specialCharactersState[result['SpecialCharactersStateInFileFolderNames']];
+        result['LimitedAccessFileType'] = sPOLimitedAccessFileType[result['LimitedAccessFileType']];
 
         cmd.log(result);
 


### PR DESCRIPTION
Adds mapping for two more enums. I couldn't catch those two additional enums with the previous pull request.