### PR TITLE
Changed commands to be lazy-loaded

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,16 +17,10 @@ const readdirR = (dir: string): string | string[] => {
   return fs.statSync(dir).isDirectory()
     ? Array.prototype.concat(...fs.readdirSync(dir).map(f => readdirR(path.join(dir, f))))
     : dir;
-}
+};
 
-appInsights.trackEvent({
-  name: 'started'
-});
-
-updateNotifier({ pkg: packageJSON }).notify({ defer: false });
-
-fs.realpath(__dirname, (err: NodeJS.ErrnoException, resolvedPath: string): void => {
-  const commandsDir: string = path.join(resolvedPath, './o365');
+const loadAllCommands = (rootFolder: string): void => {
+  const commandsDir: string = path.join(rootFolder, './o365');
   const files: string[] = readdirR(commandsDir) as string[];
 
   files.forEach(file => {
@@ -42,16 +36,61 @@ fs.realpath(__dirname, (err: NodeJS.ErrnoException, resolvedPath: string): void 
       catch { }
     }
   });
+};
 
+const loadCommandFromArgs = (args: string[], rootFolder: string): void => {
+  if (args.length <= 3) {
+    loadAllCommands(rootFolder);
+    return;
+  }
+
+  let cliArgs: string[] = args.slice(2);
+  const pos: number = cliArgs.findIndex(p => p.startsWith('-'));
+  if (pos > -1) {
+    cliArgs = cliArgs.slice(0, pos);
+  }
+
+  const commandFilePath: string = cliArgs.length === 2 ?
+    path.join(rootFolder, 'o365', cliArgs[0], 'commands', `${cliArgs[1]}.js`) :
+    path.join(rootFolder, 'o365', cliArgs[0], 'commands', cliArgs[1], cliArgs.slice(1).join('-') + '.js');
+  if (!fs.existsSync(commandFilePath)) {
+    loadAllCommands(rootFolder);
+    return;
+  }
+
+  try {
+    const cmd: any = require(commandFilePath);
+    if (cmd instanceof Command) {
+      cmd.init(vorpal);
+    }
+    else {
+      loadAllCommands(rootFolder);
+    }
+  }
+  catch {
+    loadAllCommands(rootFolder);
+  }
+}
+
+appInsights.trackEvent({
+  name: 'started'
+});
+
+updateNotifier({ pkg: packageJSON }).notify({ defer: false });
+
+fs.realpath(__dirname, (err: NodeJS.ErrnoException, resolvedPath: string): void => {
   if (process.argv.indexOf('--completion:clink:generate') > -1) {
+    loadAllCommands(resolvedPath);
     console.log(autocomplete.getClinkCompletion(vorpal));
     process.exit();
   }
   if (process.argv.indexOf('--completion:sh:generate') > -1) {
+    loadAllCommands(resolvedPath);
     autocomplete.generateShCompletion(vorpal);
     process.exit();
   }
   if (process.argv.indexOf('--completion:sh:setup') > -1) {
+    loadAllCommands(resolvedPath);
     autocomplete.generateShCompletion(vorpal);
     autocomplete.setupShCompletion();
     process.exit();
@@ -90,8 +129,10 @@ fs.realpath(__dirname, (err: NodeJS.ErrnoException, resolvedPath: string): void 
         }
       });
     }
-    v = vorpal.parse(process.argv);
 
+    loadCommandFromArgs(process.argv, resolvedPath);
+    v = vorpal.parse(process.argv);
+    
     // if no command has been passed/match, run immersive mode
     if (!v._command) {
       vorpal


### PR DESCRIPTION
This PR changes commands to be lazy-loaded when running the CLI in non-immersive mode which speeds up starting the CLI in non-immersive mode by over 50%.

## Rationale

Originally, when starting the CLI, we'd parse all files from the `o365` folder and try to load available commands. If you started the CLI in the immersive mode (meaning, you execute `o365` or `office365` without specifying any command), this would be necessary, because you want to have access to all commands. If you however, use the CLI in the non-immersive mode (eg. you execute `o365 spo app list` or any other command), then still all commands would be loaded even though you only need to execute the specified one command. With the 180 commands we have now, loading commands takes between 1,3s and 1,8s and the time-to-command (time from the first line of code in the CLI to the moment when the specified command is ready to be executed) is ~2,3s. As we'd be adding more commands in the future, you could expect the CLI to load slower.

This PR includes a change to how commands are loaded. If any command-line arguments are specified when executing the CLI, it will try to determine if the specified arguments refer to a valid command or not. If so, then it will load and instantiate only that command. If no related command can be deducted from the arguments or there is an error loading the command, then all commands will be loaded. This change decreases the time-to-command to 0,8s which you notice immediately when using the CLI in the non-immersive mode. There is no difference in how the CLI works in the immersive mode.

It would be helpful if you guys could have a look if it's working as expected and if I haven't missed any particular case. /cc: @VelinGeorgiev @mpowney @phawrylak @arjenbloemsma @baywet 