### PR TITLE
[Fix] Implemented guestGuidanceUrl solving #640

### DIFF
--- a/src/o365/graph/commands/siteclassification/SiteClassificationSettings.ts
+++ b/src/o365/graph/commands/siteclassification/SiteClassificationSettings.ts
@@ -1,5 +1,6 @@
 export class SiteClassificationSettings {
   UsageGuidelinesUrl: string = '';
+  GuestUsageGuidelinesUrl: string = '';
   Classifications: string[] = [];
   DefaultClassification: string = '';
 }

--- a/src/o365/graph/commands/siteclassification/siteclassification-get.spec.ts
+++ b/src/o365/graph/commands/siteclassification/siteclassification-get.spec.ts
@@ -471,7 +471,7 @@ describe(commands.SITECLASSIFICATION_GET, () => {
                   "value": "true"
                 },
                 {
-                  "name": "GuestUsageGuidelinesUrl",
+                  "name": "GuestUsageGuidelinesUrl_not_exist",
                   "value": ""
                 },
                 {

--- a/src/o365/graph/commands/siteclassification/siteclassification-get.spec.ts
+++ b/src/o365/graph/commands/siteclassification/siteclassification-get.spec.ts
@@ -292,7 +292,7 @@ describe(commands.SITECLASSIFICATION_GET, () => {
                 },
                 {
                   "name": "GuestUsageGuidelinesUrl",
-                  "value": ""
+                  "value": "https://test"
                 },
                 {
                   "name": "GroupCreationAllowedGroupId",
@@ -331,7 +331,8 @@ describe(commands.SITECLASSIFICATION_GET, () => {
         assert(cmdInstanceLogSpy.calledWith({
           "Classifications": ["TopSecret"],
           "DefaultClassification": "TopSecret",
-          "UsageGuidelinesUrl": "https://test"
+          "UsageGuidelinesUrl": "https://test",
+          "GuestUsageGuidelinesUrl": "https://test"
         }));
         done();
       }
@@ -420,7 +421,8 @@ describe(commands.SITECLASSIFICATION_GET, () => {
         assert(cmdInstanceLogSpy.calledWith({
           "Classifications": ["TopSecret", "HBI"],
           "DefaultClassification": "TopSecret",
-          "UsageGuidelinesUrl": "https://test"
+          "UsageGuidelinesUrl": "https://test",
+          "GuestUsageGuidelinesUrl": ""
         }));
         done();
       }
@@ -509,7 +511,8 @@ describe(commands.SITECLASSIFICATION_GET, () => {
         assert(cmdInstanceLogSpy.calledWith({
           "Classifications": [],
           "DefaultClassification": "",
-          "UsageGuidelinesUrl": ""
+          "UsageGuidelinesUrl": "",
+          "GuestUsageGuidelinesUrl": ""
         }));
         done();
       }

--- a/src/o365/graph/commands/siteclassification/siteclassification-get.ts
+++ b/src/o365/graph/commands/siteclassification/siteclassification-get.ts
@@ -93,6 +93,16 @@ class GraphO365SiteClassificationGetCommand extends GraphCommand {
           siteClassificationsSettings.UsageGuidelinesUrl = guidanceUrl[0].value;
         }
 
+        // Get the UsageGuidancelinesUrl
+        const guestGuidanceUrl: DirectorySettingValue[] = unifiedGroupSetting[0].values.filter((directorySetting: DirectorySettingValue): boolean => {
+          return directorySetting.name === 'GuestUsageGuidelinesUrl';
+        });
+
+        siteClassificationsSettings.GuestUsageGuidelinesUrl = "";
+        if (guestGuidanceUrl != null && guestGuidanceUrl.length > 0) {
+          siteClassificationsSettings.GuestUsageGuidelinesUrl = guestGuidanceUrl[0].value;
+        }
+
         // Get the DefaultClassification
         const defaultClassification: DirectorySettingValue[] = unifiedGroupSetting[0].values.filter((directorySetting: DirectorySettingValue): boolean => {
           return directorySetting.name === 'DefaultClassification';


### PR DESCRIPTION
Implemented the GuestGuidanceUrl option for `graph siteclassification get` solving #640. Updated tests to reflect this property.