### PR TITLE
Adds spo file add command

### DIFF
--- a/docs/manual/docs/cmd/spo/file/file-add.md
+++ b/docs/manual/docs/cmd/spo/file/file-add.md
@@ -1,0 +1,153 @@
+# spo file add
+
+Uploads file to the specified folder
+
+## Usage
+
+```sh
+spo file add [options]
+```
+
+## Options
+
+Option|Description
+------|-----------
+`--help`|output usage information
+`-w, --webUrl <webUrl>`|The URL of the site where the file should be uploaded to
+`-f, --folder <folder>`|Site-relative or Server-relative URL to the folder where the file should be uploaded
+`-p, --path <path>`|Local path to the file to upload
+`-c, --contentType [contentType]`|Content type name or ID to assign to the file
+`--checkOut [checkOut]`|If versioning is enabled, this will check out the file first if it exists, upload the file, then check it in again
+`--checkInComment [checkInComment]`|Comment to set when checking the file in
+`--approve [approve]`|Will automatically approve the uploaded file
+`--approveComment [approveComment]`|Comment to set when approving the file
+`--publish [publish]`|Will automatically publish the uploaded file
+`--publishComment [publishComment]`|Comment to set when publishing the file
+`-o, --output [output]`|Output type. `json|text`. Default `text`
+`--verbose`|Runs command with verbose logging
+`--debug`|Runs command with debug logging
+
+!!! important
+    Before using this command, log in to a SharePoint Online site, using the [spo login](../login.md) command.
+
+## Remarks
+
+To add a file, you have to first connect to SharePoint using the [spo login](../login.md) command, eg. `spo login https://contoso.sharepoint.com`.
+
+This command allows using unknown properties. Each property corresponds to the list item field that should be set when uploading the file. Command properties should be excluded from the SharePoint request.
+
+## Examples
+
+Adds file MS365.jpg to site 'https://contoso.sharepoint.com/sites/project-x' in folder 'Shared Documents'
+
+```sh
+spo file add --webUrl https://contoso.sharepoint.com/sites/project-x --folder 'Shared Documents' --path 'C:\MS365.jpg'
+```
+
+Adds file MS365.jpg to site 'https://contoso.sharepoint.com/sites/project-x' in sub folder 'Shared Documents/Sub Folder 1'
+
+```sh
+spo file add --webUrl https://contoso.sharepoint.com/sites/project-x --folder 'Shared Documents/Sub Folder 1' --path 'C:\MS365.jpg'
+```
+
+Adds file MS365.jpg to site 'https://contoso.sharepoint.com/sites/project-x' in folder 'Shared Documents' specifying server relative url for the --folder option
+
+```sh
+spo file add --webUrl https://contoso.sharepoint.com/sites/project-x --folder '/sites/project-x/Shared Documents' --path 'C:\MS365.jpg'
+```
+
+Adds file MS365.jpg to site 'https://contoso.sharepoint.com/sites/project-x' in folder 'Shared Documents' with specified content type
+
+```sh
+spo file add --webUrl https://contoso.sharepoint.com/sites/project-x --folder 'Shared Documents' --path 'C:\MS365.jpg' --contentType 'Picture'
+```
+
+Adds file MS365.jpg to site 'https://contoso.sharepoint.com/sites/project-x' in folder 'Shared Documents')}, but checks out existing file before the upload
+
+```sh
+spo file add --webUrl https://contoso.sharepoint.com/sites/project-x --folder 'Shared Documents' --path 'C:\MS365.jpg' --checkOut --checkInComment 'check in comment x'
+```
+
+Adds file MS365.jpg to site 'https://contoso.sharepoint.com/sites/project-x' in folder 'Shared Documents' and approves it (when list moderation is enabled)
+
+```sh
+spo file add --webUrl https://contoso.sharepoint.com/sites/project-x --folder 'Shared Documents' --path 'C:\MS365.jpg' --approve --approveComment 'approve comment x'
+```
+
+Adds file MS365.jpg to site 'https://contoso.sharepoint.com/sites/project-x' in folder 'Shared Documents' and publishes it
+
+```sh
+spo file add --webUrl https://contoso.sharepoint.com/sites/project-x --folder 'Shared Documents' --path 'C:\MS365.jpg' --publish --publishComment 'publish comment x'
+```
+
+Adds file MS365.jpg to site 'https://contoso.sharepoint.com/sites/project-x' in folder 'Shared Documents' and changes single text field value of the list item
+
+```sh
+spo file add --webUrl https://contoso.sharepoint.com/sites/project-x --folder 'Shared Documents' --path 'C:\MS365.jpg' --Title "New Title"
+```
+
+Adds file MS365.jpg to site 'https://contoso.sharepoint.com/sites/project-x' in folder 'Shared Documents' and changes person/gorup field and DateTime field values
+
+```sh
+spo file add --webUrl https://contoso.sharepoint.com/sites/project-x --folder 'Shared Documents' --path 'C:\MS365.jpg' --Editor "[{'Key':'i:0#.f|membership|john.smith@contoso.com'}]" --Modified '6/23/2018 10:15 PM'
+```
+
+Adds file MS365.jpg to site 'https://contoso.sharepoint.com/sites/project-x' in folder 'Shared Documents' and changes hyperlink or picture field
+
+```sh
+spo file add --webUrl https://contoso.sharepoint.com/sites/project-x --folder 'Shared Documents' --path 'C:\MS365.jpg' --URL 'https://contoso.com, Contoso'
+```
+
+Adds file MS365.jpg to site 'https://contoso.sharepoint.com/sites/project-x' in folder 'Shared Documents' and changes taxonomy field
+
+```sh
+spo file add --webUrl https://contoso.sharepoint.com/sites/project-x --folder 'Shared Documents' --path 'C:\MS365.jpg' --Topic "HR services|c17baaeb-67cd-4378-9389-9d97a945c701"
+```
+
+Adds file MS365.jpg to site 'https://contoso.sharepoint.com/sites/project-x' in folder 'Shared Documents' and changes taxonomy multi value field
+
+```sh
+spo file add --webUrl https://contoso.sharepoint.com/sites/project-x --folder 'Shared Documents' --path 'C:\MS365.jpg' --Topic "HR services|c17baaeb-67cd-4378-9389-9d97a945c701;Inclusion ＆ Diversity|66a67671-ed89-44a7-9be4-e80c06b41f35"
+```
+
+Adds file MS365.jpg to site 'https://contoso.sharepoint.com/sites/project-x' in folder 'Shared Documents' and changes choice field and multy choice field
+
+```sh
+spo file add --webUrl https://contoso.sharepoint.com/sites/project-x --folder 'Shared Documents' --path 'C:\MS365.jpg' --ChoiceField1 'Option3' --MultyChoiceField1 'Option2;#Option3'
+```
+
+Adds file MS365.jpg to site 'https://contoso.sharepoint.com/sites/project-x' in folder 'Shared Documents' and changes person/gorup field that allows multi user selection
+
+```sh
+spo file add --webUrl https://contoso.sharepoint.com/sites/project-x --folder 'Shared Documents' --path 'C:\MS365.jpg' --AllowedUsers "[{'Key':'i:0#.f|membership|john.smith@contoso.com'},{'Key':'i:0#.f|membership|velin.georgiev@contoso.com'}]"
+```
+
+Adds file MS365.jpg to site 'https://contoso.sharepoint.com/sites/project-x' in folder 'Shared Documents' and changes yes/no field
+
+```sh
+spo file add --webUrl https://contoso.sharepoint.com/sites/project-x --folder 'Shared Documents' --path 'C:\MS365.jpg' --HasCar true
+```
+
+Adds file MS365.jpg to site 'https://contoso.sharepoint.com/sites/project-x' in folder 'Shared Documents' and changes number field and currency field
+
+```sh
+spo file add --webUrl https://contoso.sharepoint.com/sites/project-x --folder 'Shared Documents' --path 'C:\MS365.jpg' --NumberField 100 --CurrencyField 20
+```
+
+Adds file MS365.jpg to site 'https://contoso.sharepoint.com/sites/project-x' in folder 'Shared Documents' and changes lookup field and multilookup field
+
+```sh
+spo file add --webUrl https://contoso.sharepoint.com/sites/project-x --folder 'Shared Documents' --path 'C:\MS365.jpg' --LookupField 1 --MultiLookupField "2;#;#3;#;#4;#"
+```
+      
+## More information
+
+- Reference to the PnP add file cmdlet:
+[https://docs.microsoft.com/en-us/powershell/module/sharepoint-pnp/add-pnpfile?view=sharepoint-ps](https://docs.microsoft.com/en-us/powershell/module/sharepoint-pnp/add-pnpfile?view=sharepoint-ps)
+        
+- Update file metadata with REST API using ValidateUpdateListItem method:
+[https://robertschouten.com/2018/04/30/update-file-metadata-with-rest-api-using-validateupdatelistitem-method/](https://robertschouten.com/2018/04/30/update-file-metadata-with-rest-api-using-validateupdatelistitem-method/)        
+
+- List Items System Update options in SharePoint Online:
+[https://www.linkedin.com/pulse/list-items-system-update-options-sharepoint-online-andrew-koltyakov/](https://www.linkedin.com/pulse/list-items-system-update-options-sharepoint-online-andrew-koltyakov/)
+        

--- a/docs/manual/mkdocs.yml
+++ b/docs/manual/mkdocs.yml
@@ -46,6 +46,7 @@ nav:
         - field add: 'cmd/spo/field/field-add.md'
         - field get: 'cmd/spo/field/field-get.md'
       - file:
+        - file add: 'cmd/spo/file/file-add.md'
         - file checkin: 'cmd/spo/file/file-checkin.md'
         - file checkout: 'cmd/spo/file/file-checkout.md'
         - file copy: 'cmd/spo/file/file-copy.md'

--- a/src/Utils.spec.ts
+++ b/src/Utils.spec.ts
@@ -343,4 +343,129 @@ describe('Utils', () => {
     const actual = Utils.getServerRelativePath('', 'Shared Documents');
     assert.equal(actual, '/Shared Documents');
   });
+
+  it('should get relative path when https://contoso.sharepoint.com/sites/site1 and /sites/site1/Shared Documents', () => {
+    const actual = Utils.getServerRelativePath('https://contoso.sharepoint.com/sites/site1', '/sites/site1/Shared Documents');
+    assert.equal(actual, '/sites/site1/Shared Documents');
+  });
+
+  it('should get relative path when https://contoso.sharepoint.com/sites/site1 and sites/site1/Shared Documents', () => {
+    const actual = Utils.getServerRelativePath('https://contoso.sharepoint.com/sites/site1', 'sites/site1/Shared Documents');
+    assert.equal(actual, '/sites/site1/Shared Documents');
+  });
+
+  it('should get relative path when https://contoso.sharepoint.com/sites/site1/ and /sites/site1/Shared Documents', () => {
+    const actual = Utils.getServerRelativePath('https://contoso.sharepoint.com/sites/site1/', '/sites/site1/Shared Documents');
+    assert.equal(actual, '/sites/site1/Shared Documents');
+  });
+
+  it('should get relative path when https://contoso.sharepoint.com/sites/site1 and sites/site1/Shared Documents/', () => {
+    const actual = Utils.getServerRelativePath('https://contoso.sharepoint.com/sites/site1', 'sites/site1/Shared Documents/');
+    assert.equal(actual, '/sites/site1/Shared Documents');
+  });
+
+  it('should get relative path when https://contoso.sharepoint.com/sites/site1/ and /sites/site1/Shared Documents/', () => {
+    const actual = Utils.getServerRelativePath('https://contoso.sharepoint.com/sites/site1/', '/sites/site1/Shared Documents/');
+    assert.equal(actual, '/sites/site1/Shared Documents');
+  });
+
+  it('should get relative path when https://contoso.sharepoint.com/sites/site1 and /sites/site1/Shared Documents/', () => {
+    const actual = Utils.getServerRelativePath('https://contoso.sharepoint.com/sites/site1', '/sites/site1/Shared Documents/');
+    assert.equal(actual, '/sites/site1/Shared Documents');
+  });
+
+  it('should get relative path when https://contoso.sharepoint.com/sites/site1/ and sites/site1/Shared Documents/', () => {
+    const actual = Utils.getServerRelativePath('https://contoso.sharepoint.com/sites/site1/', 'sites/site1/Shared Documents/');
+    assert.equal(actual, '/sites/site1/Shared Documents');
+  });
+
+  it('should get relative path when https://contoso.sharepoint.com/sites/site1 and /sites/site1/Shared Documents', () => {
+    const actual = Utils.getServerRelativePath('https://contoso.sharepoint.com/sites/site1', '/sites/site1/Shared Documents');
+    assert.equal(actual, '/sites/site1/Shared Documents');
+  });
+
+  it('should get relative path when https://contoso.sharepoint.com/sites/site1 and sites/site1/Shared Documents', () => {
+    const actual = Utils.getServerRelativePath('https://contoso.sharepoint.com/sites/site1', 'sites/site1/Shared Documents');
+    assert.equal(actual, '/sites/site1/Shared Documents');
+  });
+
+  it('should get relative path when /sites/site1/ and /sites/site1/Shared Documents', () => {
+    const actual = Utils.getServerRelativePath('/sites/site1/', '/sites/site1/Shared Documents');
+    assert.equal(actual, '/sites/site1/Shared Documents');
+  });
+
+  it('should get relative path when sites/site1/ and /sites/site1/Shared Documents', () => {
+    const actual = Utils.getServerRelativePath('sites/site1', '/sites/site1/Shared Documents');
+    assert.equal(actual, '/sites/site1/Shared Documents');
+  });
+
+  it('should get relative path when /sites/site1 and /sites/site1/Shared Documents', () => {
+    const actual = Utils.getServerRelativePath('/sites/site1', '/sites/site1/Shared Documents');
+    assert.equal(actual, '/sites/site1/Shared Documents');
+  });
+
+  it('should get relative path when sites/site1 and /sites/site1/Shared Documents', () => {
+    const actual = Utils.getServerRelativePath('sites/site1', '/sites/site1/Shared Documents');
+    assert.equal(actual, '/sites/site1/Shared Documents');
+  });
+
+  it('should get relative path when /sites/site1/ and sites/site1/Shared Documents', () => {
+    const actual = Utils.getServerRelativePath('/sites/site1/', 'sites/site1/Shared Documents');
+    assert.equal(actual, '/sites/site1/Shared Documents');
+  });
+
+  it('should get relative path when sites/site1/ and sites/site1/Shared Documents', () => {
+    const actual = Utils.getServerRelativePath('sites/site1', 'sites/site1/Shared Documents');
+    assert.equal(actual, '/sites/site1/Shared Documents');
+  });
+
+  it('should get relative path when /sites/site1 and sites/site1/Shared Documents', () => {
+    const actual = Utils.getServerRelativePath('/sites/site1', 'sites/site1/Shared Documents');
+    assert.equal(actual, '/sites/site1/Shared Documents');
+  });
+
+  it('should get relative path when sites/site1 and sites/site1/Shared Documents', () => {
+    const actual = Utils.getServerRelativePath('sites/site1', 'sites/site1/Shared Documents');
+    assert.equal(actual, '/sites/site1/Shared Documents');
+  });
+
+  it('should get relative path when /sites/site1/ and /sites/site1/Shared Documents/', () => {
+    const actual = Utils.getServerRelativePath('/sites/site1/', '/sites/site1/Shared Documents/');
+    assert.equal(actual, '/sites/site1/Shared Documents');
+  });
+
+  it('should get relative path when sites/site1/ and /sites/site1/Shared Documents/', () => {
+    const actual = Utils.getServerRelativePath('sites/site1', '/sites/site1/Shared Documents/');
+    assert.equal(actual, '/sites/site1/Shared Documents');
+  });
+
+  it('should get relative path when /sites/site1 and /sites/site1/Shared Documents/', () => {
+    const actual = Utils.getServerRelativePath('/sites/site1', '/sites/site1/Shared Documents/');
+    assert.equal(actual, '/sites/site1/Shared Documents');
+  });
+
+  it('should get relative path when sites/site1 and /sites/site1/Shared Documents/', () => {
+    const actual = Utils.getServerRelativePath('sites/site1', '/sites/site1/Shared Documents/');
+    assert.equal(actual, '/sites/site1/Shared Documents');
+  });
+
+  it('should get relative path when /sites/site1/ and sites/site1/Shared Documents/', () => {
+    const actual = Utils.getServerRelativePath('/sites/site1/', 'sites/site1/Shared Documents/');
+    assert.equal(actual, '/sites/site1/Shared Documents');
+  });
+
+  it('should get relative path when sites/site1/ and sites/site1/Shared Documents/', () => {
+    const actual = Utils.getServerRelativePath('sites/site1', 'sites/site1/Shared Documents/');
+    assert.equal(actual, '/sites/site1/Shared Documents');
+  });
+
+  it('should get relative path when /sites/site1 and sites/site1/Shared Documents/', () => {
+    const actual = Utils.getServerRelativePath('/sites/site1', 'sites/site1/Shared Documents/');
+    assert.equal(actual, '/sites/site1/Shared Documents');
+  });
+
+  it('should get relative path when sites/site1 and sites/site1/Shared Documents/', () => {
+    const actual = Utils.getServerRelativePath('sites/site1', 'sites/site1/Shared Documents/');
+    assert.equal(actual, '/sites/site1/Shared Documents');
+  });
 });

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -182,7 +182,7 @@ export default class Utils {
   /**
    * Returns server relative path.
    * @param webUrl web full or web relative url e.g. https://contoso.sharepoint.com/sites/team1
-   * @param siteRelativePath site relative path e.g. /Shared Documents
+   * @param folderRelativePath folder relative path e.g. /Shared Documents
    * @example
    * // returns "/sites/team1"
    * Utils.getServerRelativePath("https://contoso.sharepoint.com/sites/team1");
@@ -193,13 +193,19 @@ export default class Utils {
    * // returns "/sites/team1/Shared Documents"
    * Utils.getServerRelativePath("/sites/team1/", "/Shared Documents");
    */
-  public static getServerRelativePath(webUrl: string, siteRelativePath: string = ""): string {
+  public static getServerRelativePath(webUrl: string, folderRelativePath: string = ""): string {
     const tenantUrl: string = `${url.parse(webUrl).protocol}//${url.parse(webUrl).hostname}`;
     let webRelativePath: string = webUrl.replace(tenantUrl, '');
+    
+    // will be used to remove relative path from the folderRelativePath
+    // in case the web relative url is included
+    let relativePathToRemove: string = webRelativePath; 
 
     // add '/' at 0
     if (webRelativePath.charAt(0) !== '/') {
       webRelativePath = `/${webRelativePath}`;
+    } else {
+      relativePathToRemove = webRelativePath.substring(1);
     }
 
     // remove last '/' of webRelativePath
@@ -208,25 +214,29 @@ export default class Utils {
       webRelativePath = webRelativePath.substring(0, webRelativePath.length - 1);
     }
 
-    if (siteRelativePath !== '') {
+    // remove the web relative path if it is contained in the folder relative path
+    folderRelativePath = folderRelativePath.replace(relativePathToRemove, '');
+
+    if (folderRelativePath !== '') {
+
       // add '/' at 0 for siteRelativePath 
-      if (siteRelativePath.charAt(0) !== '/') {
-        siteRelativePath = `/${siteRelativePath}`;
+      if (folderRelativePath.charAt(0) !== '/') {
+        folderRelativePath = `/${folderRelativePath}`;
       }
 
       // remove last '/' of siteRelativePath
-      if (siteRelativePath.lastIndexOf('/') === siteRelativePath.length - 1) {
-        siteRelativePath = siteRelativePath.substring(0, siteRelativePath.length - 1);
+      if (folderRelativePath.lastIndexOf('/') === folderRelativePath.length - 1) {
+        folderRelativePath = folderRelativePath.substring(0, folderRelativePath.length - 1);
       }
 
-      if (webRelativePath === '/' && siteRelativePath !== '') {
-        webRelativePath = siteRelativePath;
+      if (webRelativePath === '/' && folderRelativePath !== '') {
+        webRelativePath = folderRelativePath;
       }
       else {
-        webRelativePath = `${webRelativePath}${siteRelativePath}`;
+        webRelativePath = `${webRelativePath}${folderRelativePath}`;
       }
     }
 
-    return webRelativePath;
+    return webRelativePath.replace('//','/');
   }
 }

--- a/src/o365/spo/commands.ts
+++ b/src/o365/spo/commands.ts
@@ -31,6 +31,7 @@ export default {
   EXTERNALUSER_LIST: `${prefix} externaluser list`,
   FIELD_ADD: `${prefix} field add`,
   FIELD_GET: `${prefix} field get`,
+  FILE_ADD: `${prefix} file add`,
   FILE_CHECKIN: `${prefix} file checkin`,
   FILE_CHECKOUT: `${prefix} file checkout`,
   FILE_COPY: `${prefix} file copy`,

--- a/src/o365/spo/commands/file/file-add.spec.ts
+++ b/src/o365/spo/commands/file/file-add.spec.ts
@@ -1,0 +1,1055 @@
+import commands from '../../commands';
+import Command, { CommandOption, CommandValidate, CommandError } from '../../../../Command';
+import * as sinon from 'sinon';
+import appInsights from '../../../../appInsights';
+import auth, { Site } from '../../SpoAuth';
+const command: Command = require('./file-add');
+import * as assert from 'assert';
+import * as request from 'request-promise-native';
+import Utils from '../../../../Utils';
+import * as fs from 'fs';
+import { FolderExtensions } from '../folder/FolderExtensions';
+
+describe(commands.FILE_ADD, () => {
+  let vorpal: Vorpal;
+  let log: any[];
+  let cmdInstance: any;
+  let cmdInstanceLogSpy: sinon.SinonSpy;
+  let trackEvent: any;
+  let telemetry: any;
+  let ensureFolderStub: sinon.SinonStub;
+
+  let stubPostResponses: any = (
+    checkoutResp = null,
+    fileAddResp = null,
+    validateUpdateListItemResp = null,
+    approveResp = null,
+    publishResp = null,
+    undoCheckOut = null,
+    checkinResp = null
+  ) => {
+    return sinon.stub(request, 'post').callsFake((opts) => {
+
+      if (opts.url.indexOf('/common/oauth2/token') > -1) {
+
+        return Promise.resolve('abc');
+
+      } else if (opts.url.indexOf('/_api/web/GetFolderByServerRelativeUrl(') > -1) {
+
+        if (opts.url.indexOf('/CheckOut') > -1) {
+
+          if(checkoutResp) {
+            return checkoutResp;
+          } else {
+            return Promise.resolve({"odata.null":true});
+          }
+
+        } else if (opts.url.indexOf('Add') > -1) {
+
+          if(fileAddResp) {
+            return fileAddResp;
+          } else {
+
+            return Promise.resolve({"CheckInComment":"","CheckOutType":0,"ContentTag":"{B0BC16BB-C8D9-4A24-BC04-FB52045F8BEF},428,159","CustomizedPageStatus":0,"ETag":"\"{B0BC16BB-C8D9-4A24-BC04-FB52045F8BEF},428\"","Exists":true,"IrmEnabled":false,"Length":"165114","Level":255,"LinkingUri":null,"LinkingUrl":"","MajorVersion":51,"MinorVersion":15,"Name":"MS365.jpg","ServerRelativeUrl":"/sites/VelinDev/Shared Documents/t1/MS365.jpg","TimeCreated":"2018-10-21T21:46:08Z","TimeLastModified":"2018-10-25T23:49:52Z","Title":"title4","UIVersion":26127,"UIVersionLabel":"51.15","UniqueId":"b0bc16bb-c8d9-4a24-bc04-fb52045f8bef"});
+          }
+
+        } else if (opts.url.indexOf('ValidateUpdateListItem') > -1) {
+
+          if(validateUpdateListItemResp) {
+            return validateUpdateListItemResp;
+          } else {
+            return Promise.resolve({"value":[{"ErrorMessage":null,"FieldName":"Title","FieldValue":"title4","HasException":false,"ItemId":212}]});
+          }
+
+        } else if (opts.url.indexOf('approve') > -1) {
+
+          if (approveResp) {
+            return approveResp;
+          } else {
+            return Promise.resolve({"odata.null":true});
+          }
+        } else if (opts.url.indexOf('publish') > -1) {
+
+          if (publishResp) {
+            return publishResp;
+          } else {
+            return Promise.resolve({"odata.null":true});
+          }
+        } else if (opts.url.indexOf('UndoCheckOut') > -1) {
+
+          if(undoCheckOut) {
+            return undoCheckOut;
+          } else {
+            return Promise.resolve({"odata.null":true});
+          }
+        } else if (opts.url.indexOf('CheckIn') > -1) {
+
+          if(checkinResp) {
+            return checkinResp;
+          } else {
+            return Promise.resolve({"odata.null":true});
+          }
+
+        }
+      }
+      return Promise.reject('Invalid request');
+    });
+  }
+
+  let stubGetResponses: any = (
+    getFolderByServerRelativeUrlResp = null,
+    getFileResp = null,
+    parentListResp = null,
+    getContentTypesResp = null
+  ) => {
+    return sinon.stub(request, 'get').callsFake((opts) => {
+
+      if (opts.url.indexOf('/_api/web/GetFolderByServerRelativeUrl(') > -1) {
+        if(opts.url.indexOf('ParentList') > -1){
+          
+          if(parentListResp) {
+            return parentListResp;
+          } else {
+            return Promise.resolve({"EnableMinorVersions":true,"EnableModeration":false,"EnableVersioning":true,"Id":"0c7dc8ec-5871-4ac9-962c-f856102b917b"});
+          }
+          
+        } else if (opts.url.indexOf('/Files') > -1) {
+
+          if(getFileResp) {
+            return getFileResp;
+          } else {
+            return Promise.resolve({"CheckInComment":"test checkin 33","CheckOutType":2,"ContentTag":"{B0BC16BB-C8D9-4A24-BC04-FB52045F8BEF},409,152","CustomizedPageStatus":0,"ETag":"\"{B0BC16BB-C8D9-4A24-BC04-FB52045F8BEF},409\"","Exists":true,"IrmEnabled":false,"Length":"165114","Level":2,"LinkingUri":null,"LinkingUrl":"","MajorVersion":51,"MinorVersion":8,"Name":"MS365.jpg","ServerRelativeUrl":"/sites/VelinDev/Shared Documents/t1/MS365.jpg","TimeCreated":"2018-10-21T21:46:08Z","TimeLastModified":"2018-10-25T23:38:11Z","Title":"title4","UIVersion":26120,"UIVersionLabel":"51.8","UniqueId":"b0bc16bb-c8d9-4a24-bc04-fb52045f8bef"});
+          }
+
+        } else {
+
+          if (getFolderByServerRelativeUrlResp) {
+            return getFolderByServerRelativeUrlResp;
+          } else {
+            return Promise.resolve({"Exists":true,"IsWOPIEnabled":false,"ItemCount":1,"Name":"t1","ProgID":null,"ServerRelativeUrl":"/sites/VelinDev/Shared Documents/t1","TimeCreated":"2018-10-21T21:46:07Z","TimeLastModified":"2018-10-21T21:46:08Z","UniqueId":"b60f36ef-6425-4961-a515-327191b5ca8f","WelcomePage":""});
+          }
+        }
+      } else if (opts.url.indexOf('contenttypes') > -1) {
+
+        if(getContentTypesResp){
+          return getContentTypesResp;
+        } else {
+          return Promise.resolve({ value: [{"Id":{"StringValue":"0x010100B8255567D591B64D8E99AB920B147A39"},"Name":"Document"},{"Id":{"StringValue":"0x0120001EE53A8A89A10E459930CBB9B7B596A1"},"Name":"Folder"},{"Id":{"StringValue":"0x01010200AE588D214ED1CF439DD4ED66926E5FB2"},"Name":"Picture"}] });
+        }
+      }
+      return Promise.reject('Invalid request');
+    });
+  }
+
+  before(() => {
+    sinon.stub(fs, 'readFileSync').returns(new Buffer('abc'));
+    ensureFolderStub = sinon.stub(FolderExtensions.prototype, 'ensureFolder').resolves();
+    sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
+    sinon.stub(auth, 'getAccessToken').callsFake(() => { return Promise.resolve('ABC'); });
+    trackEvent = sinon.stub(appInsights, 'trackEvent').callsFake((t) => {
+      telemetry = t;
+    });
+
+  });
+
+  beforeEach(() => {
+    vorpal = require('../../../../vorpal-init');
+    log = [];
+    cmdInstance = {
+      log: (msg: string) => {
+        log.push(msg);
+      }
+    };
+    cmdInstanceLogSpy = sinon.spy(cmdInstance, 'log');
+    auth.site = new Site();
+    telemetry = null;
+  });
+
+  afterEach(() => {
+    Utils.restore([
+      vorpal.find,
+      request.post,
+      request.get,
+      fs.existsSync
+    ]);
+  });
+
+  after(() => {
+    Utils.restore([
+      appInsights.trackEvent,
+      auth.getAccessToken,
+      auth.restoreAuth,
+      fs.readFileSync,
+      fs.existsSync,
+      FolderExtensions.prototype.ensureFolder
+    ]);
+  });
+
+  it('has correct name', () => {
+    assert.equal(command.name, commands.FILE_ADD);
+  });
+
+  it('allows unknown options', () => {
+    const actual = command.allowUnknownOptions();
+    assert.equal(actual, true);
+  });
+
+  it('has a description', () => {
+    assert.notEqual(command.description, null);
+  });
+
+  it('calls telemetry', (done) => {
+    cmdInstance.action = command.action();
+    cmdInstance.action({ options: {} }, () => {
+      try {
+        assert(trackEvent.called);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('logs correct telemetry event', (done) => {
+    cmdInstance.action = command.action();
+    cmdInstance.action({ options: {} }, () => {
+      try {
+        assert.equal(telemetry.name, commands.FILE_ADD);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('aborts when not logged in to a SharePoint site', (done) => {
+    auth.site = new Site();
+    auth.site.connected = false;
+    cmdInstance.action = command.action();
+    cmdInstance.action({ options: { debug: false, webUrl: 'https://contoso.sharepoint.com' } }, (err?: any) => {
+      try {
+        assert.equal(JSON.stringify(err), JSON.stringify(new CommandError('Log in to a SharePoint Online site first')));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('should call ensure folder when folder not found', (done) => {
+    const expectedError: any = JSON.stringify({"odata.error":{"code":"-2130575338, Microsoft.SharePoint.SPException","message":{"lang":"en-US","value":"Error: Not Found."}}});
+    const getFolderByServerRelativeUrlResp: any = new Promise<any>((resolve, reject) => {
+      return reject(expectedError);
+    });
+    stubPostResponses();
+    stubGetResponses(getFolderByServerRelativeUrlResp);
+
+    auth.site = new Site();
+    auth.site.connected = true;
+    auth.site.url = 'https://contoso.sharepoint.com';
+    cmdInstance.action = command.action();
+
+    cmdInstance.action({
+      options: {
+        webUrl: 'https://contoso.sharepoint.com/sites/project-x',
+        folder: 'Shared%20Documents/t1',
+        path: 'C:\Users\Velin\Desktop\MS365.jpg',
+        debug: true,
+        verbose: true
+      }
+    }, () => {
+
+      try {
+        assert.equal(ensureFolderStub.called, true);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('should proceed with no error if file does not exist in the folder', (done) => {
+    const expectedError: any = JSON.stringify({"odata.error":{"code":"-2130575338, Microsoft.SharePoint.SPException","message":{"lang":"en-US","value":"Error: File not found."}}});
+    const fileNotFoundResp: any = new Promise<any>((resolve, reject) => {
+      return reject(expectedError);
+    });
+    stubPostResponses();
+    stubGetResponses(null, fileNotFoundResp);
+
+    auth.site = new Site();
+    auth.site.connected = true;
+    auth.site.url = 'https://contoso.sharepoint.com';
+    cmdInstance.action = command.action();
+
+    cmdInstance.action({
+      options: {
+        webUrl: 'https://contoso.sharepoint.com/sites/project-x',
+        folder: 'Shared%20Documents/t1',
+        path: 'C:\Users\Velin\Desktop\MS365.jpg',
+        checkOut: true
+      }}, () => {
+
+      try {
+        assert.equal(cmdInstanceLogSpy.notCalled, true);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('should handle checkout error', (done) => {
+    const expectedError: any = JSON.stringify({"odata.error":{"code":"-2130575338, Microsoft.SharePoint.SPException","message":{"lang":"en-US","value":"Error: Checkout Error."}}});
+    const checkoutResp: any = new Promise<any>((resolve, reject) => {
+      return reject(expectedError);
+    });
+    stubPostResponses(checkoutResp);
+    stubGetResponses();
+
+    auth.site = new Site();
+    auth.site.connected = true;
+    auth.site.url = 'https://contoso.sharepoint.com';
+    cmdInstance.action = command.action();
+
+    cmdInstance.action({
+      options: {
+        webUrl: 'https://contoso.sharepoint.com/sites/project-x',
+        folder: 'Shared%20Documents/t1',
+        path: 'C:\Users\Velin\Desktop\MS365.jpg',
+        checkOut: true,
+        debug: true
+      }}, (err: any) => {
+
+      try {
+        assert.equal(JSON.stringify(err), JSON.stringify(new CommandError(expectedError)));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('should handle file add error', (done) => {
+    const expectedError: any = JSON.stringify({"odata.error":{"code":"-2130575338, Microsoft.SharePoint.SPException","message":{"lang":"en-US","value":"Error: File add error."}}});
+    const fileAddResp: any = new Promise<any>((resolve, reject) => {
+      return reject(expectedError);
+    });
+    stubPostResponses(null, fileAddResp);
+    stubGetResponses();
+
+    auth.site = new Site();
+    auth.site.connected = true;
+    auth.site.url = 'https://contoso.sharepoint.com';
+    cmdInstance.action = command.action();
+
+    cmdInstance.action({
+      options: {
+        webUrl: 'https://contoso.sharepoint.com/sites/project-x',
+        folder: 'Shared%20Documents/t1',
+        path: 'C:\Users\Velin\Desktop\MS365.jpg',
+        checkOut: true,
+        debug: true
+      }}, (err: any) => {
+
+      try {
+        assert.equal(JSON.stringify(err), JSON.stringify(new CommandError(expectedError)));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('should handle get list response error', (done) => {
+    const expectedError: any = JSON.stringify({"odata.error":{"code":"-2130575338, Microsoft.SharePoint.SPException","message":{"lang":"en-US","value":"Error: List does not exist."}}});
+    const listResp: any = new Promise<any>((resolve, reject) => {
+      return reject(expectedError);
+    });
+    stubPostResponses();
+    stubGetResponses(null, null, listResp);
+
+    auth.site = new Site();
+    auth.site.connected = true;
+    auth.site.url = 'https://contoso.sharepoint.com';
+    cmdInstance.action = command.action();
+
+    cmdInstance.action({
+      options: {
+        webUrl: 'https://contoso.sharepoint.com/sites/project-x',
+        folder: 'Shared%20Documents/t1',
+        path: 'C:\Users\Velin\Desktop\MS365.jpg',
+        contentType: 'abc',
+        debug: true
+      }}, (err: any) => {
+
+      try {
+        assert.equal(JSON.stringify(err), JSON.stringify(new CommandError(expectedError)));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('should handle content type response error', (done) => {
+    const expectedError: any = JSON.stringify({"odata.error":{"code":"-2130575338, Microsoft.SharePoint.SPException","message":{"lang":"en-US","value":"Error: ContentType does not exist."}}});
+    const contentTypeResp: any = new Promise<any>((resolve, reject) => {
+      return reject(expectedError);
+    });
+    stubPostResponses();
+    stubGetResponses(null, null, null, contentTypeResp);
+
+    auth.site = new Site();
+    auth.site.connected = true;
+    auth.site.url = 'https://contoso.sharepoint.com';
+    cmdInstance.action = command.action();
+
+    cmdInstance.action({
+      options: {
+        webUrl: 'https://contoso.sharepoint.com/sites/project-x',
+        folder: 'Shared%20Documents/t1',
+        path: 'C:\Users\Velin\Desktop\MS365.jpg',
+        contentType: 'abc',
+        debug: true
+      }}, (err: any) => {
+
+      try {
+        assert.equal(JSON.stringify(err), JSON.stringify(new CommandError(expectedError)));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('should resolve server relative url specified for the folder option', (done) => {
+    stubPostResponses();
+    stubGetResponses();
+
+    const folderServerRelativePath: string = '/sites/project-x/Shared%20Documents/t1';
+
+    auth.site = new Site();
+    auth.site.connected = true;
+    auth.site.url = 'https://contoso.sharepoint.com';
+    cmdInstance.action = command.action();
+
+    cmdInstance.action({
+      options: {
+        webUrl: 'https://contoso.sharepoint.com/sites/project-x',
+        folder: folderServerRelativePath,
+        path: 'C:\Users\Velin\Desktop\MS365.jpg',
+        contentType: 'abc',
+        debug: true
+      }}, (err: any) => {
+
+      try {
+        assert.equal(cmdInstanceLogSpy.calledWith(`folder path: ${folderServerRelativePath}...`), true);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('should handle non existing content type', (done) => {
+    stubPostResponses();
+    stubGetResponses();
+
+    auth.site = new Site();
+    auth.site.connected = true;
+    auth.site.url = 'https://contoso.sharepoint.com';
+    cmdInstance.action = command.action();
+
+    cmdInstance.action({
+      options: {
+        webUrl: 'https://contoso.sharepoint.com/sites/project-x',
+        folder: 'Shared%20Documents/t1',
+        path: 'C:\Users\Velin\Desktop\MS365.jpg',
+        contentType: 'abc',
+        debug: true
+      }}, (err: any) => {
+
+      try {
+        assert.equal(JSON.stringify(err), JSON.stringify(new CommandError('Specified content type \'abc\' doesn\'t exist on the target list')));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('should handle list item update response error', (done) => {
+    const expectedError: any = JSON.stringify({"odata.error":{"code":"-2130575338, Microsoft.SharePoint.SPException","message":{"lang":"en-US","value":"Error: Item update error."}}});
+    const validateUpdateListItemResp: any = new Promise<any>((resolve, reject) => {
+      return reject(expectedError);
+    });
+    stubPostResponses(null, null, validateUpdateListItemResp);
+    stubGetResponses();
+
+    auth.site = new Site();
+    auth.site.connected = true;
+    auth.site.url = 'https://contoso.sharepoint.com';
+    cmdInstance.action = command.action();
+
+    cmdInstance.action({
+      options: {
+        webUrl: 'https://contoso.sharepoint.com/sites/project-x',
+        folder: 'Shared%20Documents/t1',
+        path: 'C:\Users\Velin\Desktop\MS365.jpg',
+        contentType: 'Picture',
+        debug: true
+      }}, (err: any) => {
+
+      try {
+        assert.equal(JSON.stringify(err), JSON.stringify(new CommandError(expectedError)));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('should handle list item field value update response error', (done) => {
+    const expectedResult: any = {"value":[{"ErrorMessage":null,"FieldName":"Title","FieldValue":"fsd","HasException":false,"ItemId":120},{"ErrorMessage":"check in comment x","FieldName":"_CheckinComment","FieldValue":"check in comment x","HasException":true,"ItemId":120}]};
+    const validateUpdateListItemResp: any = new Promise<any>((resolve, reject) => {
+      return resolve(expectedResult);
+    });
+    stubPostResponses(null, null, validateUpdateListItemResp);
+    stubGetResponses();
+
+    auth.site = new Site();
+    auth.site.connected = true;
+    auth.site.url = 'https://contoso.sharepoint.com';
+    cmdInstance.action = command.action();
+
+    cmdInstance.action({
+      options: {
+        webUrl: 'https://contoso.sharepoint.com/sites/project-x',
+        folder: 'Shared%20Documents/t1',
+        path: 'C:\Users\Velin\Desktop\MS365.jpg',
+        contentType: 'Picture',
+        debug: true
+      }}, (err: any) => {
+
+      try {
+        const error: string = `Update field value error: ${JSON.stringify(expectedResult.value)}`;
+        assert.equal(JSON.stringify(err), JSON.stringify(new CommandError(error)));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('should handle file checkin error', (done) => {
+    const expectedError: any = JSON.stringify({"odata.error":{"code":"-2130575338, Microsoft.SharePoint.SPException","message":{"lang":"en-US","value":"Error: Checkin error."}}});
+    const checkinResp: any = new Promise<any>((resolve, reject) => {
+      return reject(expectedError);
+    });
+    stubPostResponses(null, null, null, null, null, null, checkinResp);
+    stubGetResponses();
+
+    auth.site = new Site();
+    auth.site.connected = true;
+    auth.site.url = 'https://contoso.sharepoint.com';
+    cmdInstance.action = command.action();
+
+    cmdInstance.action({
+      options: {
+        webUrl: 'https://contoso.sharepoint.com/sites/project-x',
+        folder: 'Shared%20Documents/t1',
+        path: 'C:\Users\Velin\Desktop\MS365.jpg',
+        checkOut: true,
+        checkInComment: 'abc',
+        debug: true
+      }}, (err: any) => {
+
+      try {
+        assert.equal(JSON.stringify(err), JSON.stringify(new CommandError(expectedError)));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('should handle approve list item response error', (done) => {
+    const expectedError: any = JSON.stringify({"odata.error":{"code":"-2130575338, Microsoft.SharePoint.SPException","message":{"lang":"en-US","value":"Error: Approve error."}}});
+    const aproveResp: any = new Promise<any>((resolve, reject) => {
+      return reject(expectedError);
+    });
+    stubPostResponses(null, null, null, aproveResp);
+    stubGetResponses();
+
+    auth.site = new Site();
+    auth.site.connected = true;
+    auth.site.url = 'https://contoso.sharepoint.com';
+    cmdInstance.action = command.action();
+
+    cmdInstance.action({
+      options: {
+        webUrl: 'https://contoso.sharepoint.com/sites/project-x',
+        folder: 'Shared%20Documents/t1',
+        path: 'C:\Users\Velin\Desktop\MS365.jpg',
+        approve: true,
+        verbose: true,
+        debug: true
+      }}, (err: any) => {
+
+      try {
+        assert.equal(JSON.stringify(err), JSON.stringify(new CommandError(expectedError)));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('should handle publish list item response error', (done) => {
+    const expectedError: any = JSON.stringify({"odata.error":{"code":"-2130575338, Microsoft.SharePoint.SPException","message":{"lang":"en-US","value":"Error: Publish error."}}});
+    const publishResp: any = new Promise<any>((resolve, reject) => {
+      return reject(expectedError);
+    });
+    stubPostResponses(null, null, null, null, publishResp);
+    stubGetResponses();
+
+    auth.site = new Site();
+    auth.site.connected = true;
+    auth.site.url = 'https://contoso.sharepoint.com';
+    cmdInstance.action = command.action();
+
+    cmdInstance.action({
+      options: {
+        webUrl: 'https://contoso.sharepoint.com/sites/project-x',
+        folder: 'Shared%20Documents/t1',
+        path: 'C:\Users\Velin\Desktop\MS365.jpg',
+        publish: true,
+        verbose: true,
+        debug: true
+      }}, (err: any) => {
+
+      try {
+        assert.equal(JSON.stringify(err), JSON.stringify(new CommandError(expectedError)));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('should error when --publish used, but list moderation and minor ver enabled', (done) => {
+    const listSettingsResp: any = new Promise<any>((resolve, reject) => {
+      return resolve({"EnableMinorVersions":true,"EnableModeration":true,"EnableVersioning":true,"Id":"0c7dc8ec-5871-4ac9-962c-f856102b917b"})
+    });
+    
+    stubPostResponses();
+    stubGetResponses(null, null, listSettingsResp);
+
+    auth.site = new Site();
+    auth.site.connected = true;
+    auth.site.url = 'https://contoso.sharepoint.com';
+    cmdInstance.action = command.action();
+
+    cmdInstance.action({
+      options: {
+        webUrl: 'https://contoso.sharepoint.com/sites/project-x',
+        folder: 'Shared%20Documents/t1',
+        path: 'C:\Users\Velin\Desktop\MS365.jpg',
+        publish: true
+      }}, (err: any) => {
+
+      try {
+        assert.equal(JSON.stringify(err), JSON.stringify(new CommandError('The file cannot be published without approval. Moderation for this list is enabled. Use the --approve option instead of --publish to approve and publish the file')));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('should call "DONE" when in verbose', (done) => {
+    stubPostResponses();
+    stubGetResponses();
+
+    auth.site = new Site();
+    auth.site.connected = true;
+    auth.site.url = 'https://contoso.sharepoint.com';
+    cmdInstance.action = command.action();
+
+    cmdInstance.action({
+      options: {
+        webUrl: 'https://contoso.sharepoint.com/sites/project-x',
+        folder: 'Shared%20Documents/t1',
+        path: 'C:\Users\Velin\Desktop\MS365.jpg',
+        debug: true,
+        verbose: true
+      }
+    }, () => {
+
+      try {
+        assert.equal(cmdInstanceLogSpy.lastCall.args[0], 'DONE');
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('should succeed updating list item metadata (verbose)', (done) => {
+    stubPostResponses();
+    stubGetResponses();
+
+    auth.site = new Site();
+    auth.site.connected = true;
+    auth.site.url = 'https://contoso.sharepoint.com';
+    cmdInstance.action = command.action();
+
+    cmdInstance.action({
+      options: {
+        webUrl: 'https://contoso.sharepoint.com/sites/project-x',
+        folder: 'Shared%20Documents/t1',
+        path: 'C:\Users\Velin\Desktop\MS365.jpg',
+        contentType: 'Picture',
+        Title: 'abc',
+        publish: true,
+        verbose: true,
+        debug: true
+      }
+    }, () => {
+
+      try {
+        assert.equal(cmdInstanceLogSpy.lastCall.args[0], 'DONE');
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('should succeed updating list item metadata', (done) => {
+    stubPostResponses();
+    stubGetResponses();
+
+    auth.site = new Site();
+    auth.site.connected = true;
+    auth.site.url = 'https://contoso.sharepoint.com';
+    cmdInstance.action = command.action();
+
+    cmdInstance.action({
+      options: {
+        webUrl: 'https://contoso.sharepoint.com/sites/project-x',
+        folder: 'Shared%20Documents/t1',
+        path: 'C:\Users\Velin\Desktop\MS365.jpg',
+        contentType: 'Picture',
+        Title: 'abc',
+        publish: true
+      }
+    }, () => {
+
+      try {
+        assert.equal(cmdInstanceLogSpy.notCalled, true);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('should succeed approve', (done) => {
+    stubPostResponses();
+    stubGetResponses();
+
+    auth.site = new Site();
+    auth.site.connected = true;
+    auth.site.url = 'https://contoso.sharepoint.com';
+    cmdInstance.action = command.action();
+
+    cmdInstance.action({
+      options: {
+        webUrl: 'https://contoso.sharepoint.com/sites/project-x',
+        folder: 'Shared%20Documents/t1',
+        path: 'C:\Users\Velin\Desktop\MS365.jpg',
+        approve: true
+      }}, (err: any) => {
+
+      try {
+        assert.equal(cmdInstanceLogSpy.notCalled, true);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('should succeed when with checkout option', (done) => {
+    stubPostResponses();
+    stubGetResponses();
+
+    auth.site = new Site();
+    auth.site.connected = true;
+    auth.site.url = 'https://contoso.sharepoint.com';
+    cmdInstance.action = command.action();
+
+    cmdInstance.action({
+      options: {
+        webUrl: 'https://contoso.sharepoint.com/sites/project-x',
+        folder: 'Shared%20Documents/t1',
+        path: 'C:\Users\Velin\Desktop\MS365.jpg',
+        checkOut: true
+      }}, (err: any) => {
+
+      try {
+        assert.equal(cmdInstanceLogSpy.notCalled, true);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('should error if cannot rollback checkout (verbose)', (done) => {
+
+    const expectedFileAddError: any = JSON.stringify({"odata.error":{"code":"-2130575338, Microsoft.SharePoint.SPException","message":{"lang":"en-US","value":"Error: File add error."}}});
+    const fileAddResp: any = new Promise<any>((resolve, reject) => {
+      return reject(expectedFileAddError);
+    });
+
+    const expectedError: any = JSON.stringify({"odata.error":{"code":"-2130575338, Microsoft.SharePoint.SPException","message":{"lang":"en-US","value":"Error: Checkout Error."}}});
+    const rollbackCheckoutResp: any = new Promise<any>((resolve, reject) => {
+      return reject(expectedError);
+    });
+
+    stubPostResponses(null, fileAddResp, null, null, null, rollbackCheckoutResp);
+    stubGetResponses();
+
+    auth.site = new Site();
+    auth.site.connected = true;
+    auth.site.url = 'https://contoso.sharepoint.com';
+    cmdInstance.action = command.action();
+
+    cmdInstance.action({
+      options: {
+        webUrl: 'https://contoso.sharepoint.com/sites/project-x',
+        folder: 'Shared%20Documents/t1',
+        path: 'C:\Users\Velin\Desktop\MS365.jpg',
+        checkOut: true,
+        debug: true,
+        verbose: true
+      }}, (err: any) => {
+
+      try {
+        //assert.equal(JSON.stringify(err), JSON.stringify(new CommandError(expectedFileAddError)));
+        assert.equal(JSON.stringify(err), JSON.stringify(new CommandError(expectedFileAddError)));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('should error if cannot rollback checkout', (done) => {
+
+    const expectedFileAddError: any = JSON.stringify({"odata.error":{"code":"-2130575338, Microsoft.SharePoint.SPException","message":{"lang":"en-US","value":"Error: File add error."}}});
+    const fileAddResp: any = new Promise<any>((resolve, reject) => {
+      return reject(expectedFileAddError);
+    });
+
+    const expectedError: any = JSON.stringify({"odata.error":{"code":"-2130575338, Microsoft.SharePoint.SPException","message":{"lang":"en-US","value":"Error: Checkout Error."}}});
+    const rollbackCheckoutResp: any = new Promise<any>((resolve, reject) => {
+      return reject(expectedError);
+    });
+
+    stubPostResponses(null, fileAddResp, null, null, null, rollbackCheckoutResp);
+    stubGetResponses();
+
+    auth.site = new Site();
+    auth.site.connected = true;
+    auth.site.url = 'https://contoso.sharepoint.com';
+    cmdInstance.action = command.action();
+
+    cmdInstance.action({
+      options: {
+        webUrl: 'https://contoso.sharepoint.com/sites/project-x',
+        folder: 'Shared%20Documents/t1',
+        path: 'C:\Users\Velin\Desktop\MS365.jpg',
+        checkOut: true,
+      }}, (err: any) => {
+
+      try {
+        //assert.equal(JSON.stringify(err), JSON.stringify(new CommandError(expectedFileAddError)));
+        assert.equal(JSON.stringify(err), JSON.stringify(new CommandError(expectedFileAddError)));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('fails validation if the webUrl option not specified', () => {
+    const actual = (command.validate() as CommandValidate)({ options: {} });
+    assert.notEqual(actual, true);
+  });
+
+  it('fails validation if the webUrl option not valid url', () => {
+    const actual = (command.validate() as CommandValidate)({ options: { webUrl: 'abc'} });
+    assert.notEqual(actual, true);
+  });
+
+  it('fails validation if the path option not specified', () => {
+    const actual = (command.validate() as CommandValidate)({ options: { webUrl: 'https://contoso.sharepoint.com', folder: 'abc'} });
+    assert.notEqual(actual, true);
+  });
+
+  it('fails validation if the folder option not specified', () => {
+    const actual = (command.validate() as CommandValidate)({ options: { webUrl: 'https://contoso.sharepoint.com', path: 'abc'} });
+    assert.notEqual(actual, true);
+  });
+
+
+  it('fails validation if the wrong path option specified', () => {
+    sinon.stub(fs, 'existsSync').returns(false);
+    const actual = (command.validate() as CommandValidate)({ options: { 
+      webUrl: 'https://contoso.sharepoint.com',
+      folder: 'abc',
+      path: 'abc'
+    } });
+    assert.notEqual(actual, true);
+  });
+
+  it('fails validation if --approveComment specified, but not --approve', () => {
+    sinon.stub(fs, 'existsSync').returns(true);
+    const actual = (command.validate() as CommandValidate)({ options: { 
+      webUrl: 'https://contoso.sharepoint.com',
+      folder: 'abc',
+      path: 'abc',
+      approveComment: 'abc'
+    } });
+    assert.notEqual(actual, true);
+  });
+
+  it('fails validation if --publishComment specified, but not --publish', () => {
+    sinon.stub(fs, 'existsSync').returns(true);
+    const actual = (command.validate() as CommandValidate)({ options: { 
+      webUrl: 'https://contoso.sharepoint.com',
+      folder: 'abc',
+      path: 'abc',
+      publishComment: 'abc'
+    } });
+    assert.notEqual(actual, true);
+  });
+
+  it('passed validation if options correct', () => {
+    sinon.stub(fs, 'existsSync').returns(true);
+    const actual = (command.validate() as CommandValidate)({ options: { 
+      webUrl: 'https://contoso.sharepoint.com',
+      folder: 'abc',
+      path: 'abc'
+    } });
+    assert.equal(actual, true);
+  });
+
+  it('supports debug mode', () => {
+    const options = (command.options() as CommandOption[]);
+    let containsDebugOption = false;
+    options.forEach(o => {
+      if (o.option === '--debug') {
+        containsDebugOption = true;
+      }
+    });
+    assert(containsDebugOption);
+  });
+
+  it('supports specifying URL', () => {
+    const options = (command.options() as CommandOption[]);
+    let containsTypeOption = false;
+    options.forEach(o => {
+      if (o.option.indexOf('<webUrl>') > -1) {
+        containsTypeOption = true;
+      }
+    });
+    assert(containsTypeOption);
+  });
+
+  it('has help referring to the right command', () => {
+    const cmd: any = {
+      log: (msg: string) => { },
+      prompt: () => { },
+      helpInformation: () => { }
+    };
+    const find = sinon.stub(vorpal, 'find').callsFake(() => cmd);
+    cmd.help = command.help();
+    cmd.help({}, () => { });
+    assert(find.calledWith(commands.FILE_ADD));
+  });
+
+  it('has help with examples', () => {
+    const _log: string[] = [];
+    const cmd: any = {
+      log: (msg: string) => {
+        _log.push(msg);
+      },
+      prompt: () => { },
+      helpInformation: () => { }
+    };
+    sinon.stub(vorpal, 'find').callsFake(() => cmd);
+    cmd.help = command.help();
+    cmd.help({}, () => { });
+    let containsExamples: boolean = false;
+    _log.forEach(l => {
+      if (l && l.indexOf('Examples:') > -1) {
+        containsExamples = true;
+      }
+    });
+    Utils.restore(vorpal.find);
+    assert(containsExamples);
+  });
+
+  it('correctly handles lack of valid access token', (done) => {
+    Utils.restore(auth.getAccessToken);
+    sinon.stub(auth, 'getAccessToken').callsFake(() => { return Promise.reject(new Error('Error getting access token')); });
+    auth.site = new Site();
+    auth.site.connected = true;
+    auth.site.url = 'https://contoso.sharepoint.com';
+    cmdInstance.action = command.action();
+    cmdInstance.action({
+      options: {
+        webUrl: 'https://contoso.sharepoint.com/sites/project-x',
+        folder: 'Shared%20Documents/t1',
+        path: 'C:\Users\Velin\Desktop\MS365.jpg',
+        debug: false
+      }
+    }, (err?: any) => {
+      try {
+        assert.equal(JSON.stringify(err), JSON.stringify(new CommandError('Error getting access token')));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+});

--- a/src/o365/spo/commands/file/file-add.ts
+++ b/src/o365/spo/commands/file/file-add.ts
@@ -161,8 +161,7 @@ class SpoFileAddCommand extends SpoCommand {
             authorization: `Bearer ${siteAccessToken}`,
             'accept': 'application/json;odata=nometadata',
             'content-length': bodyLength
-          }),
-          json: true
+          })
         };
 
         return request.post(requestOptions);

--- a/src/o365/spo/commands/file/file-add.ts
+++ b/src/o365/spo/commands/file/file-add.ts
@@ -1,0 +1,721 @@
+import auth from '../../SpoAuth';
+import config from '../../../../config';
+import commands from '../../commands';
+import GlobalOptions from '../../../../GlobalOptions';
+import * as request from 'request-promise-native';
+import {
+  CommandOption,
+  CommandValidate
+} from '../../../../Command';
+import SpoCommand from '../../SpoCommand';
+import Utils from '../../../../Utils';
+import { Auth } from '../../../../Auth';
+import * as fs from 'fs';
+import * as path from 'path';
+import { FolderExtensions } from '../folder/FolderExtensions';
+
+const vorpal: Vorpal = require('../../../../vorpal-init');
+
+interface CommandArgs {
+  options: Options;
+}
+
+interface Options extends GlobalOptions {
+  webUrl: string;
+  folder: string;
+  path: string;
+  contentType?: string;
+  checkOut?: boolean;
+  checkInComment?: string;
+  approve?: boolean;
+  approveComment?: string;
+  publish?: boolean;
+  publishComment?: string;
+}
+
+interface FieldValue {
+  FieldName: string;
+  FieldValue: any;
+}
+
+interface FieldValueResult extends FieldValue {
+  ErrorMessage: string;
+  HasException: boolean;
+  ItemId: number;
+}
+
+interface ListSettings {
+  Id: string;
+  EnableVersioning: boolean;
+  EnableModeration: boolean;
+  EnableMinorVersions: boolean;
+}
+
+class SpoFileAddCommand extends SpoCommand {
+
+  public get name(): string {
+    return commands.FILE_ADD;
+  }
+
+  public get description(): string {
+    return 'Uploads file to the specified folder';
+  }
+
+  public allowUnknownOptions(): boolean | undefined {
+    return true;
+  }
+
+  public getTelemetryProperties(args: CommandArgs): any {
+    const telemetryProps: any = super.getTelemetryProperties(args);
+    telemetryProps.contentType = (!(!args.options.contentType)).toString();
+    telemetryProps.checkOut = args.options.checkOut || false;
+    telemetryProps.checkInComment = (!(!args.options.checkInComment)).toString();
+    telemetryProps.approve = args.options.approve || false;
+    telemetryProps.approveComment = (!(!args.options.approveComment)).toString();
+    telemetryProps.publish = args.options.publish || false;
+    telemetryProps.publishComment = (!(!args.options.publishComment)).toString();
+    return telemetryProps;
+  }
+
+  public commandAction(cmd: CommandInstance, args: CommandArgs, cb: () => void): void {
+    const resource: string = Auth.getResourceFromUrl(args.options.webUrl);
+    const folderPath: string = Utils.getServerRelativePath(args.options.webUrl, args.options.folder);
+    const fullPath: string = path.resolve(args.options.path);
+    const fileName: string = path.basename(fullPath);
+    const folderExtensions: FolderExtensions = new FolderExtensions(cmd, this.debug);
+
+    let siteAccessToken: string = '';
+    let isCheckedOut: boolean = false;
+    let listSettings: ListSettings;
+
+    if (this.debug) {
+      cmd.log(`folder path: ${folderPath}...`);
+      cmd.log(`Retrieving access token for ${resource}...`);
+    }
+
+    auth
+      .getAccessToken(resource, auth.service.refreshToken as string, cmd, this.debug)
+      .then((accessToken: string): any => {
+        siteAccessToken = accessToken;
+
+        if (this.debug) {
+          cmd.log('Check if the specified folder exists.')
+          cmd.log('');
+        }
+
+        const requestOptions: any = {
+          url: `${args.options.webUrl}/_api/web/GetFolderByServerRelativeUrl('${encodeURIComponent(folderPath)}')`,
+          headers: Utils.getRequestHeaders({
+            authorization: `Bearer ${siteAccessToken}`,
+            'accept': 'application/json;odata=nometadata'
+          })
+        };
+
+        return request.get(requestOptions).catch((err: string): Promise<void> => {
+
+          // folder does not exist so will attempt to create the folder tree
+          return folderExtensions.ensureFolder(args.options.webUrl, folderPath, siteAccessToken);
+
+        });
+      })
+      .then((res: any): Promise<void> => {
+
+        if (this.debug) {
+          cmd.log('Target folder exists ...');
+          cmd.log(res);
+          cmd.log('');
+        }
+
+        if (args.options.checkOut) {
+
+          return this.fileCheckOut(fileName, args.options.webUrl, folderPath, siteAccessToken, cmd)
+            .then((res: any) => {
+
+              // flag the file is checkedOut by the command 
+              // so in case of command failure we can try check it in
+              isCheckedOut = true;
+
+              return Promise.resolve();
+            })
+            .catch((err: any) => {
+
+              return Promise.reject(err);
+            });
+        }
+
+        return Promise.resolve();
+      })
+      .then((res: any): request.RequestPromise => {
+
+        if (this.verbose) {
+          cmd.log(`Upload file to site ${args.options.webUrl}...`);
+        }
+
+        const fileBody: Buffer = fs.readFileSync(fullPath);
+        const bodyLength: number = fileBody.byteLength;
+
+        const requestOptions: any = {
+          url: `${args.options.webUrl}/_api/web/GetFolderByServerRelativeUrl('${encodeURIComponent(folderPath)}')/Files/Add(url='${encodeURIComponent(fileName)}', overwrite=true)`,
+          body: fileBody,
+          headers: Utils.getRequestHeaders({
+            authorization: `Bearer ${siteAccessToken}`,
+            'accept': 'application/json;odata=nometadata',
+            'content-length': bodyLength
+          }),
+          json: true
+        };
+
+        return request.post(requestOptions);
+      })
+      .then((res: any): request.RequestPromise | Promise<void> => {
+
+        if (this.debug) {
+          cmd.log('File added ...');
+          cmd.log(JSON.stringify(res));
+          cmd.log('');
+        }
+
+        if (args.options.contentType || args.options.publish || args.options.approve) {
+
+          return this.getFileParentList(fileName, args.options.webUrl, folderPath, siteAccessToken, cmd)
+          .then((listSettingsResp: ListSettings) => {
+            
+            if (this.debug) {
+              cmd.log('List details response...');
+              cmd.log(JSON.stringify(listSettingsResp));
+              cmd.log('');
+            }
+  
+            listSettings = listSettingsResp;
+  
+            if (args.options.contentType) {
+  
+              return this.listHasContentType(args.options.contentType, args.options.webUrl, listSettings, siteAccessToken, cmd);
+            }
+
+            return Promise.resolve();
+          });
+        }
+
+        return Promise.resolve();
+      })
+      .then((res: any): request.RequestPromise | Promise<void> => {
+
+        // check if there are unknown options 
+        // and map them as fields to update
+        let fieldsToUpdate: FieldValue[] = this.mapUnknownOptionsAsFieldValue(args.options);
+
+        if (args.options.contentType) {
+
+          fieldsToUpdate.push({
+            FieldName: 'ContentType',
+            FieldValue: args.options.contentType
+          });
+        }
+
+        if (fieldsToUpdate.length > 0) {
+
+          // perform list item update and checkin
+          return this.validateUpdateListItem(args.options.webUrl, folderPath, fileName, fieldsToUpdate, siteAccessToken, cmd, args.options.checkInComment);
+
+        } else if (isCheckedOut) {
+
+          // perform checkin
+          return this.fileCheckIn(args, fileName, siteAccessToken, cmd);
+        }
+
+        return Promise.resolve();
+      })
+      .then((res: any): request.RequestPromise | Promise<void> => {
+
+        // approve and publish cannot be used together 
+        // when approve is used it will automatically publish the file
+        // so then no need to publish afterwards
+        if (args.options.approve) {
+
+          if (this.verbose) {
+            cmd.log(`Approve file ${fileName}`);
+          }
+
+          // approve the existing file with given comment
+          const requestOptions: any = {
+            url: `${args.options.webUrl}/_api/web/GetFolderByServerRelativeUrl('${encodeURIComponent(folderPath)}')/Files('${encodeURIComponent(fileName)}')/approve(comment='${encodeURIComponent(args.options.approveComment || '')}')`,
+            headers: Utils.getRequestHeaders({
+              authorization: `Bearer ${siteAccessToken}`,
+              'accept': 'application/json;odata=nometadata'
+            }),
+            json: true
+          };
+
+          if (this.debug) {
+            cmd.log('Approve paylaod ...');
+            cmd.log(requestOptions);
+            cmd.log('');
+          }
+
+          return request.post(requestOptions);
+
+        } else if (args.options.publish) {
+
+          if (listSettings.EnableModeration && listSettings.EnableMinorVersions) {
+
+            return Promise.reject('The file cannot be published without approval. Moderation for this list is enabled. Use the --approve option instead of --publish to approve and publish the file');
+          }
+
+          if (this.verbose) {
+            cmd.log(`Publish file ${fileName}`);
+          }
+
+          // publish the existing file with given comment
+          const requestOptions: any = {
+            url: `${args.options.webUrl}/_api/web/GetFolderByServerRelativeUrl('${encodeURIComponent(folderPath)}')/Files('${encodeURIComponent(fileName)}')/publish(comment='${encodeURIComponent(args.options.publishComment || '')}')`,
+            headers: Utils.getRequestHeaders({
+              authorization: `Bearer ${siteAccessToken}`,
+              'accept': 'application/json;odata=nometadata'
+            }),
+            json: true
+          };
+
+          if (this.debug) {
+            cmd.log('Publish paylaod ...');
+            cmd.log(requestOptions);
+            cmd.log('');
+          }
+
+          return request.post(requestOptions);
+        }
+
+        return Promise.resolve();
+      })
+      .then((res: any): void => {
+
+        if (this.debug) {
+          cmd.log('Approve or publish response ...');
+          cmd.log(JSON.stringify(res));
+          cmd.log('');
+        }
+
+        if (this.verbose) {
+          cmd.log('DONE');
+        }
+
+        cb();
+      }, (err: any): void => {
+
+        if (isCheckedOut) {
+          // in a case the command has done checkout
+          // then have to rollback the checkout
+
+          const requestOptions: any = {
+            url: `${args.options.webUrl}/_api/web/GetFolderByServerRelativeUrl('${encodeURIComponent(folderPath)}')/Files('${encodeURIComponent(fileName)}')/UndoCheckOut()`,
+            headers: Utils.getRequestHeaders({
+              authorization: `Bearer ${siteAccessToken}`
+            })
+          };
+
+          request.post(requestOptions)
+            .then(_ => this.handleRejectedODataJsonPromise(err, cmd, cb))
+            .catch(checkoutError => {
+
+              if (this.verbose) {
+                cmd.log('Could not rollback file checkout');
+                cmd.log(checkoutError);
+                cmd.log('');
+              }
+
+              this.handleRejectedODataJsonPromise(err, cmd, cb);
+            });
+        } else {
+
+          this.handleRejectedODataJsonPromise(err, cmd, cb);
+        }
+      });
+  }
+
+  public options(): CommandOption[] {
+    const options: CommandOption[] = [
+      {
+        option: '-w, --webUrl <webUrl>',
+        description: 'The URL of the site where the file should be uploaded to'
+      },
+      {
+        option: '-f, --folder <folder>',
+        description: 'Site-relative or Server-relative URL to the folder where the file should be uploaded'
+      },
+      {
+        option: '-p, --path <path>',
+        description: 'Local path to the file to upload'
+      },
+      {
+        option: '-c, --contentType [contentType]',
+        description: 'Content type name or ID to assign to the file'
+      },
+      {
+        option: '--checkOut',
+        description: 'If versioning is enabled, this will check out the file first if it exists, upload the file, then check it in again'
+      },
+      {
+        option: '--checkInComment [checkInComment]',
+        description: 'Comment to set when checking the file in'
+      },
+      {
+        option: '--approve',
+        description: 'Will automatically approve the uploaded file'
+      },
+      {
+        option: '--approveComment [approveComment]',
+        description: 'Comment to set when approving the file'
+      },
+      {
+        option: '--publish',
+        description: 'Will automatically publish the uploaded file'
+      },
+      {
+        option: '--publishComment [publishComment]',
+        description: 'Comment to set when publishing the file'
+      }
+    ];
+
+    const parentOptions: CommandOption[] = super.options();
+    return options.concat(parentOptions);
+  }
+
+  public validate(): CommandValidate {
+    return (args: CommandArgs): boolean | string => {
+      if (!args.options.webUrl) {
+
+        return 'Required parameter webUrl missing';
+      }
+
+      const isValidSharePointUrl: boolean | string = SpoCommand.isValidSharePointUrl(args.options.webUrl);
+      if (isValidSharePointUrl !== true) {
+
+        return isValidSharePointUrl;
+      }
+
+      if (!args.options.folder) {
+
+        return 'Required parameter folder missing';
+      }
+
+      if (!args.options.path) {
+
+        return 'Required parameter path missing';
+      }
+
+      if (args.options.path && !fs.existsSync(args.options.path)) {
+
+        return 'Specified path of the file to add does not exits';
+      }
+
+      if (args.options.publishComment && !args.options.publish) {
+
+        return '--publishComment cannot be used without --publish';
+      }
+
+      if (args.options.approveComment && !args.options.approve) {
+
+        return '--approveComment cannot be used without --approve';
+      }
+
+      return true;
+    };
+  }
+
+  public commandHelp(args: {}, log: (help: string) => void): void {
+    const chalk = vorpal.chalk;
+    log(vorpal.find(this.name).helpInformation());
+    log(
+      `  ${chalk.yellow('Important:')} before using this command, connect to a SharePoint Online site,
+    using the ${chalk.blue(commands.CONNECT)} command.
+  
+  Remarks:
+  
+    To add a file, you have to first connect to SharePoint using the
+    ${chalk.blue(commands.CONNECT)} command, eg. ${chalk.grey(`${config.delimiter} ${commands.CONNECT} https://contoso.sharepoint.com`)}.
+        
+  Examples:
+
+    Adds file MS365.jpg to site ${chalk.grey('https://contoso.sharepoint.com/sites/project-x')} 
+    in folder ${chalk.grey('Shared Documents')}
+      ${chalk.grey(config.delimiter)} ${commands.FILE_ADD} --webUrl https://contoso.sharepoint.com/sites/project-x --folder 'Shared Documents' --path 'C:\MS365.jpg'
+
+    Adds file MS365.jpg to site ${chalk.grey('https://contoso.sharepoint.com/sites/project-x')} 
+    in sub folder ${chalk.grey('Shared Documents/Sub Folder 1')}
+      ${chalk.grey(config.delimiter)} ${commands.FILE_ADD} --webUrl https://contoso.sharepoint.com/sites/project-x --folder 'Shared Documents/Sub Folder 1' --path 'C:\MS365.jpg'
+
+    Adds file MS365.jpg to site ${chalk.grey('https://contoso.sharepoint.com/sites/project-x')} 
+    in folder ${chalk.grey('Shared Documents')} specifying server relative url for the --folder option
+      ${chalk.grey(config.delimiter)} ${commands.FILE_ADD} --webUrl https://contoso.sharepoint.com/sites/project-x --folder '/sites/project-x/Shared Documents' --path 'C:\MS365.jpg'
+
+    Adds file MS365.jpg to site ${chalk.grey('https://contoso.sharepoint.com/sites/project-x')} 
+    in folder ${chalk.grey('Shared Documents')} with specified content type
+      ${chalk.grey(config.delimiter)} ${commands.FILE_ADD} --webUrl https://contoso.sharepoint.com/sites/project-x --folder 'Shared Documents' --path 'C:\MS365.jpg' --contentType 'Picture'
+
+    Adds file MS365.jpg to site ${chalk.grey('https://contoso.sharepoint.com/sites/project-x')} 
+    in folder ${chalk.grey('Shared Documents')}, but checks out existing file before the upload
+      ${chalk.grey(config.delimiter)} ${commands.FILE_ADD} --webUrl https://contoso.sharepoint.com/sites/project-x --folder 'Shared Documents' --path 'C:\MS365.jpg' --checkOut --checkInComment 'check in comment x'
+
+    Adds file MS365.jpg to site ${chalk.grey('https://contoso.sharepoint.com/sites/project-x')} 
+    in folder ${chalk.grey('Shared Documents')} and approves it (when list moderation is enabled)
+      ${chalk.grey(config.delimiter)} ${commands.FILE_ADD} --webUrl https://contoso.sharepoint.com/sites/project-x --folder 'Shared Documents' --path 'C:\MS365.jpg' --approve --approveComment 'approve comment x'
+
+    Adds file MS365.jpg to site ${chalk.grey('https://contoso.sharepoint.com/sites/project-x')} 
+    in folder ${chalk.grey('Shared Documents')} and publishes it
+      ${chalk.grey(config.delimiter)} ${commands.FILE_ADD} --webUrl https://contoso.sharepoint.com/sites/project-x --folder 'Shared Documents' --path 'C:\MS365.jpg' --publish --publishComment 'publish comment x'
+
+    Adds file MS365.jpg to site ${chalk.grey('https://contoso.sharepoint.com/sites/project-x')} 
+    in folder ${chalk.grey('Shared Documents')} and changes single text field value of the list item
+      ${chalk.grey(config.delimiter)} ${commands.FILE_ADD} --webUrl https://contoso.sharepoint.com/sites/project-x --folder 'Shared Documents' --path 'C:\MS365.jpg' --Title "New Title"
+
+    Adds file MS365.jpg to site ${chalk.grey('https://contoso.sharepoint.com/sites/project-x')} 
+    in folder ${chalk.grey('Shared Documents')} and changes person/gorup field and DateTime field values
+      ${chalk.grey(config.delimiter)} ${commands.FILE_ADD} --webUrl https://contoso.sharepoint.com/sites/project-x --folder 'Shared Documents' --path 'C:\MS365.jpg' --Editor "[{'Key':'i:0#.f|membership|john.smith@contoso.com'}]" --Modified '6/23/2018 10:15 PM'
+
+    Adds file MS365.jpg to site ${chalk.grey('https://contoso.sharepoint.com/sites/project-x')} 
+    in folder ${chalk.grey('Shared Documents')} and changes hyperlink or picture field
+      ${chalk.grey(config.delimiter)} ${commands.FILE_ADD} --webUrl https://contoso.sharepoint.com/sites/project-x --folder 'Shared Documents' --path 'C:\MS365.jpg' --URL 'https://contoso.com, Contoso'
+
+    Adds file MS365.jpg to site ${chalk.grey('https://contoso.sharepoint.com/sites/project-x')} 
+    in folder ${chalk.grey('Shared Documents')} and changes taxonomy field
+      ${chalk.grey(config.delimiter)} ${commands.FILE_ADD} --webUrl https://contoso.sharepoint.com/sites/project-x --folder 'Shared Documents' --path 'C:\MS365.jpg' --Topic "HR services|c17baaeb-67cd-4378-9389-9d97a945c701"
+
+    Adds file MS365.jpg to site ${chalk.grey('https://contoso.sharepoint.com/sites/project-x')} 
+    in folder ${chalk.grey('Shared Documents')} and changes taxonomy multi value field
+      ${chalk.grey(config.delimiter)} ${commands.FILE_ADD} --webUrl https://contoso.sharepoint.com/sites/project-x --folder 'Shared Documents' --path 'C:\MS365.jpg' --Topic "HR services|c17baaeb-67cd-4378-9389-9d97a945c701;Inclusion ＆ Diversity|66a67671-ed89-44a7-9be4-e80c06b41f35"
+  
+    Adds file MS365.jpg to site ${chalk.grey('https://contoso.sharepoint.com/sites/project-x')} 
+    in folder ${chalk.grey('Shared Documents')} and changes choice field and multy choice field
+      ${chalk.grey(config.delimiter)} ${commands.FILE_ADD} --webUrl https://contoso.sharepoint.com/sites/project-x --folder 'Shared Documents' --path 'C:\MS365.jpg' --ChoiceField1 'Option3' --MultyChoiceField1 'Option2;#Option3'
+
+    Adds file MS365.jpg to site ${chalk.grey('https://contoso.sharepoint.com/sites/project-x')} 
+    in folder ${chalk.grey('Shared Documents')} and changes person/gorup field that allows multi user selection
+      ${chalk.grey(config.delimiter)} ${commands.FILE_ADD} --webUrl https://contoso.sharepoint.com/sites/project-x --folder 'Shared Documents' --path 'C:\MS365.jpg' --AllowedUsers "[{'Key':'i:0#.f|membership|john.smith@contoso.com'},{'Key':'i:0#.f|membership|velin.georgiev@contoso.com'}]"
+
+    Adds file MS365.jpg to site ${chalk.grey('https://contoso.sharepoint.com/sites/project-x')} 
+    in folder ${chalk.grey('Shared Documents')} and changes yes/no field
+      ${chalk.grey(config.delimiter)} ${commands.FILE_ADD} --webUrl https://contoso.sharepoint.com/sites/project-x --folder 'Shared Documents' --path 'C:\MS365.jpg' --HasCar true
+
+    Adds file MS365.jpg to site ${chalk.grey('https://contoso.sharepoint.com/sites/project-x')} 
+    in folder ${chalk.grey('Shared Documents')} and changes number field and currency field
+      ${chalk.grey(config.delimiter)} ${commands.FILE_ADD} --webUrl https://contoso.sharepoint.com/sites/project-x --folder 'Shared Documents' --path 'C:\MS365.jpg' --NumberField 100 --CurrencyField 20
+
+    Adds file MS365.jpg to site ${chalk.grey('https://contoso.sharepoint.com/sites/project-x')} 
+    in folder ${chalk.grey('Shared Documents')} and changes lookup field and multilookup field
+      ${chalk.grey(config.delimiter)} ${commands.FILE_ADD} --webUrl https://contoso.sharepoint.com/sites/project-x --folder 'Shared Documents' --path 'C:\MS365.jpg' --LookupField 1 --MultiLookupField "2;#;#3;#;#4;#"
+      
+    More information:
+
+      Reference to the PnP add file cmdlet:
+        https://docs.microsoft.com/en-us/powershell/module/sharepoint-pnp/add-pnpfile?view=sharepoint-ps
+
+      Update file metadata with REST API using ValidateUpdateListItem method:
+        https://robertschouten.com/2018/04/30/update-file-metadata-with-rest-api-using-validateupdatelistitem-method/
+
+      List Items System Update options in SharePoint Online:
+        https://www.linkedin.com/pulse/list-items-system-update-options-sharepoint-online-andrew-koltyakov/
+      `);
+  }
+
+  private listHasContentType(contentType: string, webUrl: string, listSettings: ListSettings, siteAccessToken: string, cmd: any): Promise<void> {
+
+    if (this.verbose) {
+      cmd.log(`Getting list available content types ...`);
+    }
+
+    const requestOptions: any = {
+      url: `${webUrl}/_api/web/lists('${listSettings.Id}')/contenttypes?$select=Name,Id`,
+      headers: Utils.getRequestHeaders({
+        authorization: `Bearer ${siteAccessToken}`,
+        'accept': 'application/json;odata=nometadata'
+      }),
+      json: true
+    };
+
+    return request.get(requestOptions).then(response => {
+      // check if the specified content type is in the list
+
+      if (this.debug) {
+        cmd.log('Content type lookup response ...');
+        cmd.log(response);
+      }
+
+      for (const ct of response.value) {
+        if (ct.Id.StringValue === contentType || ct.Name === contentType) {
+          return Promise.resolve();
+        }
+      }
+      return Promise.reject(`Specified content type '${contentType}' doesn't exist on the target list`);
+    });
+  }
+
+  private fileCheckOut(fileName: string, webUrl: string, folder: string, siteAccessToken: string, cmd: any): Promise<void> {
+
+    // check if file already exists, otherwise it can't be checked out
+    const requestOptions: any = {
+      url: `${webUrl}/_api/web/GetFolderByServerRelativeUrl('${encodeURIComponent(folder)}')/Files('${encodeURIComponent(fileName)}')`,
+      headers: Utils.getRequestHeaders({
+        authorization: `Bearer ${siteAccessToken}`,
+        'accept': 'application/json;odata=nometadata'
+      })
+    };
+
+    return request.get(requestOptions)
+      .then((res: any) => {
+
+        if (this.debug) {
+          cmd.log('File exists response...');
+          cmd.log(res);
+          cmd.log('');
+        }
+
+        // checkout the existing file
+        const requestOptions: any = {
+          url: `${webUrl}/_api/web/GetFolderByServerRelativeUrl('${encodeURIComponent(folder)}')/Files('${encodeURIComponent(fileName)}')/CheckOut()`,
+          headers: Utils.getRequestHeaders({
+            authorization: `Bearer ${siteAccessToken}`,
+            'accept': 'application/json;odata=nometadata',
+          }),
+          json: true
+        };
+
+        if (this.debug) {
+          cmd.log(`Checkout file ${fileName}`);
+          cmd.log(requestOptions);
+          cmd.log('');
+        }
+
+        return request.post(requestOptions);
+      });
+  }
+
+  private getFileParentList(fileName: string, webUrl: string, folder: string, siteAccessToken: string, cmd: any): request.RequestPromise {
+
+    if (this.verbose) {
+      cmd.log(`Getting list details in order to get its available content types afterwards...`);
+    }
+
+    const requestOptions: any = {
+      url: `${webUrl}/_api/web/GetFolderByServerRelativeUrl('${encodeURIComponent(folder)}')/Files('${encodeURIComponent(fileName)}')/ListItemAllFields/ParentList?$Select=Id,EnableModeration,EnableVersioning,EnableMinorVersions`,
+      headers: Utils.getRequestHeaders({
+        authorization: `Bearer ${siteAccessToken}`,
+        'accept': 'application/json;odata=nometadata'
+      }),
+      json: true
+    };
+
+    if (this.debug) {
+      cmd.log('Get ParentList web request...');
+      cmd.log(requestOptions);
+      cmd.log('');
+    }
+
+    return request.get(requestOptions);
+  }
+
+  private validateUpdateListItem(webUrl: string, folderPath: string, fileName: string, fieldsToUpdate: FieldValue[], siteAccessToken: string, cmd: any, checkInComment?: string): Promise<void> {
+
+    if (this.verbose) {
+      cmd.log(`Validate and update list item values for file ${fileName}`);
+    }
+
+    const requestBody: any = {
+      formValues: fieldsToUpdate,
+      bNewDocumentUpdate: true, // true = will automatically checkin the item, but we will use it to perform system update and also do a checkin
+      checkInComment: checkInComment || ''
+    };
+
+    if (this.debug) {
+      cmd.log('ValidateUpdateListItem will perform the checkin ...');
+      cmd.log('');
+    }
+
+    // update the existing file list item fields
+    const requestOptions: any = {
+      url: `${webUrl}/_api/web/GetFolderByServerRelativeUrl('${encodeURIComponent(folderPath)}')/Files('${encodeURIComponent(fileName)}')/ListItemAllFields/ValidateUpdateListItem()`,
+      headers: Utils.getRequestHeaders({
+        authorization: `Bearer ${siteAccessToken}`,
+        'accept': 'application/json;odata=nometadata'
+      }),
+      body: requestBody,
+      json: true
+    };
+
+    if (this.debug) {
+      cmd.log('ValidateUpdateListItem payload ...');
+      cmd.log(requestOptions);
+      cmd.log('');
+    }
+
+    return request.post(requestOptions)
+      .then((res: any) => {
+
+        if (this.debug) {
+          cmd.log('ValidateUpdateListItem response ...');
+          cmd.log(res);
+          cmd.log('');
+        }
+
+        // check for field value update for errors
+        const fieldValues: FieldValueResult[] = res.value;
+        for (const fieldValue of fieldValues) {
+          if (fieldValue.HasException) {
+            return Promise.reject(`Update field value error: ${JSON.stringify(fieldValues)}`);
+          }
+        }
+        return Promise.resolve();
+      })
+      .catch((err: any) => {
+
+        return Promise.reject(err);
+      });
+  }
+
+  private fileCheckIn(args: any, fileName: string, siteAccessToken: string, cmd: any): request.RequestPromise {
+
+    const requestOptions: any = {
+      url: `${args.options.webUrl}/_api/web/GetFolderByServerRelativeUrl('${encodeURIComponent(args.options.folder)}')/Files('${encodeURIComponent(fileName)}')/CheckIn(comment='${encodeURIComponent(args.options.checkInComment || '')}',checkintype=0)`,
+      headers: Utils.getRequestHeaders({
+        authorization: `Bearer ${siteAccessToken}`,
+        'accept': 'application/json;odata=nometadata'
+      }),
+      json: true
+    };
+
+    if (this.debug) {
+      cmd.log(`File ${fileName} check in`);
+      cmd.log(requestOptions);
+      cmd.log('');
+    }
+
+    return request.post(requestOptions);
+  }
+
+  private mapUnknownOptionsAsFieldValue(options: Options): FieldValue[] {
+    const result: any = [];
+    const excludeOptions: string[] = [
+      'weburl',
+      'folder',
+      'path',
+      'contenttype',
+      'checkout',
+      'checkincomment',
+      'approve',
+      'approvecomment',
+      'publish',
+      'publishcomment',
+      'debug',
+      'verbose'
+    ];
+
+    Object.keys(options).forEach(key => {
+      if (excludeOptions.indexOf(key.toLowerCase()) === -1) {
+        result.push({ FieldName: key, FieldValue: (<any>options)[key].toString() });
+      }
+    });
+
+    return result;
+  }
+}
+
+module.exports = new SpoFileAddCommand();

--- a/src/o365/spo/commands/folder/FolderExtensions.spec.ts
+++ b/src/o365/spo/commands/folder/FolderExtensions.spec.ts
@@ -1,0 +1,279 @@
+
+import * as assert from 'assert';
+import * as request from 'request-promise-native';
+import Utils from '../../../../Utils';
+import * as sinon from 'sinon';
+import { FolderExtensions } from './FolderExtensions'
+
+
+describe('FolderExtensions', () => {
+
+  let folderExtensions: FolderExtensions;
+  let log: any[];
+  let cmdInstance: any;
+  let cmdInstanceLogSpy: sinon.SinonSpy;
+
+  let stubPostResponses: any = (
+    folderAddResp = null
+  ) => {
+    return sinon.stub(request, 'post').callsFake((opts) => {
+
+      if (opts.url.indexOf('/_api/web/folders') > -1) {
+        if (folderAddResp) {
+          return folderAddResp;
+        } else {
+          return Promise.resolve({ "Exists": true, "IsWOPIEnabled": false, "ItemCount": 0, "Name": "4t4", "ProgID": null, "ServerRelativeUrl": "/sites/VelinDev/Shared Documents/4t4", "TimeCreated": "2018-10-26T22:50:27Z", "TimeLastModified": "2018-10-26T22:50:27Z", "UniqueId": "3f5428e2-b0a8-4d35-87df-89621ed5b457", "WelcomePage": "" });
+        }
+
+      }
+      return Promise.reject('Invalid request');
+    });
+  }
+
+  let stubGetResponses: any = (
+    getFolderByServerRelativeUrlResp = null
+  ) => {
+    return sinon.stub(request, 'get').callsFake((opts) => {
+
+      if (opts.url.indexOf('/_api/web/GetFolderByServerRelativeUrl(') > -1) {
+
+        if (getFolderByServerRelativeUrlResp) {
+          return getFolderByServerRelativeUrlResp;
+        } else {
+          return Promise.resolve({ "Exists": true, "IsWOPIEnabled": false, "ItemCount": 1, "Name": "f", "ProgID": null, "ServerRelativeUrl": "/sites/VelinDev/Shared Documents/4t4/f", "TimeCreated": "2018-10-26T22:54:19Z", "TimeLastModified": "2018-10-26T22:54:20Z", "UniqueId": "0d680f20-53da-4516-b3f6-ed98b1d928e8", "WelcomePage": "" });
+        }
+      }
+      return Promise.reject('Invalid request');
+    });
+  }
+
+  beforeEach(() => {
+    log = [];
+    cmdInstance = {
+      log: (msg: string) => {
+        log.push(msg);
+      }
+    };
+    cmdInstanceLogSpy = sinon.spy(cmdInstance, 'log');
+  });
+
+  afterEach(() => {
+    Utils.restore([
+      request.post,
+      request.get,
+      cmdInstance.log
+    ]);
+  });
+
+  it('should reject if wrong url param', (done) => { 
+
+    folderExtensions = new FolderExtensions(cmdInstance, true);
+
+    folderExtensions.ensureFolder("abc", "abc", "abc")
+    .then(res => {
+      
+      done('Sould reject, not resolve');
+      
+    },  (err:any) => {
+      
+      assert.equal(err, 'webFullUrl is not a valid URL');
+      done();
+    });
+  });
+
+  it('should reject if empty folder param', (done) => { 
+
+    folderExtensions = new FolderExtensions(cmdInstance, true);
+
+    folderExtensions.ensureFolder("https://contoso.sharepoint.com", "", "abc")
+    .then(res => {
+      
+      done('Sould reject, not resolve');
+
+    },  (err:any) => {
+      
+      assert.equal(err, 'folderToEnsure cannot be empty');
+      done();
+    });
+  });
+
+  it('should reject if empty siteAccessToken param', (done) => { 
+
+    folderExtensions = new FolderExtensions(cmdInstance, true);
+
+    folderExtensions.ensureFolder("https://contoso.sharepoint.com", "abc", "")
+    .then(res => {
+      
+      done('Sould reject, not resolve');
+      
+    },  (err:any) => {
+      
+      assert.equal(err, 'siteAccessToken cannot be empty');
+      done();
+    });
+  });
+
+  it('should handle folder creation faliure', (done) => {
+    
+    const folderDoesNotExistErrorResp: any = new Promise<any>((resolve, reject) => {
+      return reject(JSON.stringify({"odata.error":{"code":"-2130575338, Microsoft.SharePoint.SPException","message":{"lang":"en-US","value":"Error: Not found."}}}));
+    });
+
+    const expectedError = JSON.stringify({"odata.error":{"code":"-2130575338, Microsoft.SharePoint.SPException","message":{"lang":"en-US","value":"Error: Cannot create folder."}}});
+
+    const folderCreationErrorResp: any = new Promise<any>((resolve, reject) => {
+      return reject(expectedError);
+    });
+
+    stubGetResponses(folderDoesNotExistErrorResp);
+    stubPostResponses(folderCreationErrorResp); 
+
+    folderExtensions = new FolderExtensions(cmdInstance, false);
+
+    folderExtensions.ensureFolder("https://contoso.sharepoint.com", "abc", "abc")
+    .then(res => {
+      done('Should not resolve, but reject');
+    },  (err:any) => {
+      
+      assert.equal(JSON.stringify(err), JSON.stringify(expectedError));
+      done();
+    });
+  });
+
+  it('should handle folder creation faliure (debug)', (done) => {
+    
+    const folderDoesNotExistErrorResp: any = new Promise<any>((resolve, reject) => {
+      return reject(JSON.stringify({"odata.error":{"code":"-2130575338, Microsoft.SharePoint.SPException","message":{"lang":"en-US","value":"Error: Not found."}}}));
+    });
+
+    const expectedError = JSON.stringify({"odata.error":{"code":"-2130575338, Microsoft.SharePoint.SPException","message":{"lang":"en-US","value":"Error: Cannot create folder."}}});
+
+    const folderCreationErrorResp: any = new Promise<any>((resolve, reject) => {
+      return reject(expectedError);
+    });
+
+    stubGetResponses(folderDoesNotExistErrorResp);
+    stubPostResponses(folderCreationErrorResp); 
+
+    folderExtensions = new FolderExtensions(cmdInstance, true);
+
+    folderExtensions.ensureFolder("https://contoso.sharepoint.com", "abc", "abc")
+    .then(res => {
+      done('Should not resolve, but reject');
+    },  (err:any) => {
+      
+      assert.equal(JSON.stringify(err), JSON.stringify(expectedError));
+      done();
+    });
+  });
+
+  it('should succeed in adding folder if it does not exist (debug)', (done) => {
+    const folderDoesNotExistErrorResp: any = new Promise<any>((resolve, reject) => {
+      return reject(JSON.stringify({"odata.error":{"code":"-2130575338, Microsoft.SharePoint.SPException","message":{"lang":"en-US","value":"Error: Not found."}}}));
+    });
+    stubGetResponses(folderDoesNotExistErrorResp);
+    stubPostResponses();
+    
+    folderExtensions = new FolderExtensions(cmdInstance, true);
+
+    folderExtensions.ensureFolder("https://contoso.sharepoint.com", "abc", "abc")
+    .then(res => {
+      
+      assert.equal(cmdInstanceLogSpy.lastCall.args[0], 'All sub-folders exist');
+      done();
+
+    },  (err:any) => {
+      done(err);
+    });
+  });
+
+  it('should succeed in adding folder if it does not exist', (done) => {
+    const folderDoesNotExistErrorResp: any = new Promise<any>((resolve, reject) => {
+      return reject(JSON.stringify({"odata.error":{"code":"-2130575338, Microsoft.SharePoint.SPException","message":{"lang":"en-US","value":"Error: Not found."}}}));
+    });
+    stubGetResponses(folderDoesNotExistErrorResp);
+    stubPostResponses();
+    
+    folderExtensions = new FolderExtensions(cmdInstance, false);
+
+    folderExtensions.ensureFolder("https://contoso.sharepoint.com", "abc", "abc")
+    .then(res => {
+      
+      assert.equal(cmdInstanceLogSpy.notCalled, true);
+      done();
+
+    },  (err:any) => {
+      done(err);
+    });
+  });
+
+  it('should succeed if all folders exist (debug)', (done) => {
+    stubPostResponses();
+    stubGetResponses();
+    
+    folderExtensions = new FolderExtensions(cmdInstance, true);
+
+    folderExtensions.ensureFolder("https://contoso.sharepoint.com", "abc", "abc")
+    .then(res => {
+      
+      assert.equal(cmdInstanceLogSpy.called, true);
+      done();
+
+    },  (err:any) => {
+      done(err);
+    });
+  });
+
+  it('should succeed if all folders exist', (done) => {
+    stubPostResponses();
+    stubGetResponses();
+
+    folderExtensions = new FolderExtensions(cmdInstance, false);
+
+    folderExtensions.ensureFolder("https://contoso.sharepoint.com", "abc", "abc")
+    .then(res => {
+      
+      assert.equal(cmdInstanceLogSpy.called, false);
+      done();
+
+    },  (err:any) => {
+      done(err);
+    });
+  });
+
+  it('should remove end / from folder path', (done) => { 
+    stubPostResponses();
+    stubGetResponses();
+
+    folderExtensions = new FolderExtensions(cmdInstance, true);
+
+    folderExtensions.ensureFolder("https://contoso.sharepoint.com", "folder1/folder2/", "abc")
+    .then(res => {
+      
+      assert.equal(cmdInstanceLogSpy.calledWith('folder1/folder2'), true);
+      done();
+      
+    },  (err:any) => {
+      
+      done(err);
+    });
+  });
+
+  it('should remove end / from folder path', (done) => { 
+    stubPostResponses();
+    stubGetResponses();
+    
+    folderExtensions = new FolderExtensions(cmdInstance, true);
+
+    folderExtensions.ensureFolder("https://contoso.sharepoint.com", "/folder2/folder3", "abc")
+    .then(res => {
+      
+      assert.equal(cmdInstanceLogSpy.calledWith('folder2/folder3'), true);
+      done();
+      
+    },  (err:any) => {
+      
+      done(err);
+    });
+  });
+});

--- a/src/o365/spo/commands/folder/FolderExtensions.ts
+++ b/src/o365/spo/commands/folder/FolderExtensions.ts
@@ -1,0 +1,147 @@
+import * as request from 'request-promise-native';
+import Utils from '../../../../Utils';
+import * as url from 'url';
+
+/**
+ * Folder methods that are shared among multiple commands.
+ */
+export class FolderExtensions {
+
+  public constructor(private cmd: CommandInstance, private debug: boolean) {
+  }
+
+  public ensureFolder(webFullUrl: string, folderToEnsure: string, siteAccessToken: string): Promise<void> {
+
+    const webUrl = url.parse(webFullUrl);
+    if(!webUrl.protocol || !webUrl.hostname) {
+      return new Promise<void>((resolve: any, reject:any) => {
+          return reject('webFullUrl is not a valid URL');
+      });
+    }
+
+    if(!folderToEnsure){
+      return new Promise<void>((resolve: any, reject:any) => {
+          return reject('folderToEnsure cannot be empty');
+      });
+    }
+
+    if(!siteAccessToken){
+      return new Promise<void>((resolve: any, reject:any) => {
+          return reject('siteAccessToken cannot be empty');
+      });
+    }
+
+    // remove the end '/' in the folder path
+    if (folderToEnsure[folderToEnsure.length - 1] === '/') {
+      folderToEnsure = folderToEnsure.substring(0, folderToEnsure.length - 1);
+    }
+
+    const tenantUrl: string = `${url.parse(webFullUrl).protocol}//${url.parse(webFullUrl).hostname}`;
+    const webRelativePath: string = webFullUrl.replace(tenantUrl, '');
+
+    // remove the web relative path from the folder path
+    folderToEnsure = folderToEnsure.replace(webRelativePath, '')
+
+    // remove the leading '/' so we are left with e.g. Shared%20Documents/22/54/55
+    if (folderToEnsure[0] === '/') {
+      folderToEnsure = folderToEnsure.substring(1);
+    }
+
+    if (this.debug) {
+      this.cmd.log(`folderToEnsure`);
+      this.cmd.log(folderToEnsure);
+      this.cmd.log('');
+    }
+
+    // build array of folders e.g. ["Shared%20Documents","22","54","55"]
+    let folders: string[] = folderToEnsure.split('/');
+    let nextFolder: string = '';
+    let folderIndex: number = 0;
+
+    // recursive function
+    const checkOrAddFolder = (resolve: () => void, reject: (error: any) => void): void => {
+
+      if (folderIndex == folders.length) {
+
+        if (this.debug) {
+          this.cmd.log(`All sub-folders exist`);
+        }
+
+        return resolve();
+      }
+
+      // append the next sub-folder to the folder path and check if it exists
+      nextFolder += `/${folders[folderIndex]}`;
+      const folderServerRelativeUrl = `${webRelativePath}${nextFolder}`;
+
+      const requestOptions: any = {
+        url: `${webFullUrl}/_api/web/GetFolderByServerRelativeUrl('${encodeURIComponent(folderServerRelativeUrl)}')`,
+        headers: Utils.getRequestHeaders({
+          authorization: `Bearer ${siteAccessToken}`,
+          'accept': 'application/json;odata=nometadata'
+        })
+      };
+
+      if (this.debug) {
+        this.cmd.log(`Check if ${nextFolder} exists`);
+        this.cmd.log(requestOptions);
+        this.cmd.log('');
+      }
+
+      request.get(requestOptions)
+        .then((res: any) => {
+
+          if (this.debug) {
+            this.cmd.log(`${nextFolder} exists. Moving to the next one`);
+            this.cmd.log(res);
+            this.cmd.log('');
+          }
+
+          folderIndex++;
+          checkOrAddFolder(resolve, reject);
+        })
+        .catch((err: any) => {
+          
+          const requestOptions: any = {
+            url: `${webFullUrl}/_api/web/folders`,
+            headers: Utils.getRequestHeaders({
+              authorization: `Bearer ${siteAccessToken}`,
+              'accept': 'application/json;odata=nometadata',
+            }),
+            body: {
+              'ServerRelativeUrl': folderServerRelativeUrl
+            },
+            json: true
+          };
+
+          if (this.debug) {
+            this.cmd.log(`Add folder ${folderServerRelativeUrl}`);
+            this.cmd.log(requestOptions);
+            this.cmd.log('');
+          }
+
+          return request.post(requestOptions)
+            .then((res: any) => {
+
+              if (this.debug) {
+                this.cmd.log(`Folder ${folderServerRelativeUrl} added`);
+                this.cmd.log(JSON.stringify(res));
+                this.cmd.log('');
+              }
+
+              folderIndex++;
+              checkOrAddFolder(resolve, reject);
+            })
+            .catch((err: any) => {
+
+              if (this.debug) {
+                this.cmd.log(`Could not create sub-folder ${folderServerRelativeUrl}`);
+              }
+
+              reject(err); 
+            });
+        });
+    }
+    return new Promise<void>(checkOrAddFolder);
+  }
+}

--- a/src/o365/spo/commands/folder/FolderExtensions.ts
+++ b/src/o365/spo/commands/folder/FolderExtensions.ts
@@ -14,21 +14,15 @@ export class FolderExtensions {
 
     const webUrl = url.parse(webFullUrl);
     if(!webUrl.protocol || !webUrl.hostname) {
-      return new Promise<void>((resolve: any, reject:any) => {
-          return reject('webFullUrl is not a valid URL');
-      });
+      return Promise.reject('webFullUrl is not a valid URL');
     }
 
     if(!folderToEnsure){
-      return new Promise<void>((resolve: any, reject:any) => {
-          return reject('folderToEnsure cannot be empty');
-      });
+      return Promise.reject('folderToEnsure cannot be empty');
     }
 
     if(!siteAccessToken){
-      return new Promise<void>((resolve: any, reject:any) => {
-          return reject('siteAccessToken cannot be empty');
-      });
+      return Promise.reject('siteAccessToken cannot be empty');
     }
 
     // remove the end '/' in the folder path
@@ -61,7 +55,7 @@ export class FolderExtensions {
     // recursive function
     const checkOrAddFolder = (resolve: () => void, reject: (error: any) => void): void => {
 
-      if (folderIndex == folders.length) {
+      if (folderIndex === folders.length) {
 
         if (this.debug) {
           this.cmd.log(`All sub-folders exist`);


### PR DESCRIPTION
- Adds spo file add command solving https://github.com/pnp/office365-cli/issues/283
- FolderExstensions class created with its first shared method ensureFolder
- Util.getServerRelativePath method enhanced, so file-add supports server-relative, but also site-relative url for the folder option

@waldekmastykarz, please let me know if any questions.