### PR TITLE
Add command graph teams channel message get

### DIFF
--- a/docs/manual/docs/cmd/graph/teams/teams-channel-message-get.md
+++ b/docs/manual/docs/cmd/graph/teams/teams-channel-message-get.md
@@ -1,0 +1,41 @@
+# graph teams channel message get
+
+Retrieves a message from a channel in a Microsoft Teams team
+
+## Usage
+
+```sh
+graph teams channel message get [options]
+```
+
+## Options
+
+Option|Description
+------|-----------
+`--help`|output usage information
+`-i, --groupId <groupId>`|The ID of the team where the channel is located
+`-c, --channelId <channelId>`|The ID of the channel that contains the message
+`-m, --messageId <messageId>`|The ID of the message to retrieve
+`-o, --output [output]`|Output type. `json|text`. Default `text`
+`--verbose`|Runs command with verbose logging
+`--debug`|Runs command with debug logging
+
+!!! important
+    Before using this command, log in to the Microsoft Graph, using the [graph login](../login.md) command.
+
+## Remarks
+
+!!! attention
+    This command is based on an API that is currently in preview and is subject to change once the API reached general availability.
+
+To retrieve a message from a Microsoft Teams channel, you have to first log in to the Microsoft Graph using the [graph login](../login.md) command, eg. `graph login`.
+
+You can only retrieve a message from a Microsoft Teams team if you are a member of that team.
+
+## Examples
+
+Retrieve the specified message from a channel of the Microsoft Teams team
+
+```sh
+graph teams channel message get --groupId 5f5d7b71-1161-44d8-bcc1-3da710eb4171 --channelId 19:88f7e66a8dfe42be92db19505ae912a8@thread.skype --messageId 1540747442203
+```

--- a/docs/manual/mkdocs.yml
+++ b/docs/manual/mkdocs.yml
@@ -208,6 +208,7 @@ nav:
       - teams:
         - teams list: 'cmd/graph/teams/teams-list.md'
         - teams channel add: 'cmd/graph/teams/teams-channel-add.md'
+        - teams channel message get: 'cmd/graph/teams/teams-channel-message-get.md'
       - user:
         - user get: 'cmd/graph/user/user-get.md'
         - user list: 'cmd/graph/user/user-list.md'

--- a/src/o365/graph/commands.ts
+++ b/src/o365/graph/commands.ts
@@ -24,6 +24,7 @@ export default {
   STATUS: `${prefix} status`,
   TEAMS_LIST: `${prefix} teams list`,
   TEAMS_CHANNEL_ADD: `${prefix} teams channel add`,
+  TEAMS_CHANNEL_MESSAGE_GET: `${prefix} teams channel message get`,
   USER_GET: `${prefix} user get`,
   USER_LIST: `${prefix} user list`,
   USER_SENDMAIL: `${prefix} user sendmail`,

--- a/src/o365/graph/commands/teams/teams-channel-message-get.spec.ts
+++ b/src/o365/graph/commands/teams/teams-channel-message-get.spec.ts
@@ -1,0 +1,355 @@
+import commands from '../../commands';
+import Command, { CommandError, CommandOption, CommandValidate } from '../../../../Command';
+import * as sinon from 'sinon';
+import appInsights from '../../../../appInsights';
+import auth from '../../GraphAuth';
+const command: Command = require('./teams-channel-message-get');
+import * as assert from 'assert';
+import * as request from 'request-promise-native';
+import Utils from '../../../../Utils';
+import { Service } from '../../../../Auth';
+
+describe(commands.TEAMS_CHANNEL_MESSAGE_GET, () => {
+  let vorpal: Vorpal;
+  let log: string[];
+  let cmdInstance: any;
+  let cmdInstanceLogSpy: sinon.SinonSpy;
+  let trackEvent: any;
+  let telemetry: any;
+
+  before(() => {
+    sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
+    sinon.stub(auth, 'ensureAccessToken').callsFake(() => { return Promise.resolve('ABC'); });
+    trackEvent = sinon.stub(appInsights, 'trackEvent').callsFake((t) => {
+      telemetry = t;
+    });
+  });
+
+  beforeEach(() => {
+    vorpal = require('../../../../vorpal-init');
+    log = [];
+    cmdInstance = {
+      log: (msg: string) => {
+        log.push(msg);
+      }
+    };
+    cmdInstanceLogSpy = sinon.spy(cmdInstance, 'log');
+    auth.service = new Service('https://graph.microsoft.com');
+    telemetry = null;
+  });
+
+  afterEach(() => {
+    Utils.restore([
+      vorpal.find,
+      request.get,
+      global.setTimeout
+    ]);
+  });
+
+  after(() => {
+    Utils.restore([
+      appInsights.trackEvent,
+      auth.ensureAccessToken,
+      auth.restoreAuth
+    ]);
+  });
+
+  it('has correct name', () => {
+    assert.equal(command.name.startsWith(commands.TEAMS_CHANNEL_MESSAGE_GET), true);
+  });
+
+  it('has a description', () => {
+    assert.notEqual(command.description, null);
+  });
+
+  it('calls telemetry', (done) => {
+    cmdInstance.action = command.action();
+    cmdInstance.action({ options: {} }, () => {
+      try {
+        assert(trackEvent.called);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('logs correct telemetry event', (done) => {
+    cmdInstance.action = command.action();
+    cmdInstance.action({ options: {} }, () => {
+      try {
+        assert.equal(telemetry.name, commands.TEAMS_CHANNEL_MESSAGE_GET);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('aborts when not logged in to the Microsoft Graph', (done) => {
+    auth.service = new Service('https://graph.microsoft.com');
+    auth.service.connected = false;
+    cmdInstance.action = command.action();
+    cmdInstance.action({ options: { debug: true } }, (err?: any) => {
+      try {
+        assert.equal(JSON.stringify(err), JSON.stringify(new CommandError('Log in to the Microsoft Graph first')));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+
+  it('has help referring to the right command', () => {
+    const cmd: any = {
+      log: (msg: string) => { },
+      prompt: () => { },
+      helpInformation: () => { }
+    };
+    const find = sinon.stub(vorpal, 'find').callsFake(() => cmd);
+    cmd.help = command.help();
+    cmd.help({}, () => { });
+    assert(find.calledWith(commands.TEAMS_CHANNEL_MESSAGE_GET));
+  });
+
+  it('has help with examples', () => {
+    const _log: string[] = [];
+    const cmd: any = {
+      log: (msg: string) => {
+        _log.push(msg);
+      },
+      prompt: () => { },
+      helpInformation: () => { }
+    };
+    sinon.stub(vorpal, 'find').callsFake(() => cmd);
+    cmd.help = command.help();
+    cmd.help({}, () => { });
+    let containsExamples: boolean = false;
+    _log.forEach(l => {
+      if (l && l.indexOf('Examples:') > -1) {
+        containsExamples = true;
+      }
+    });
+    Utils.restore(vorpal.find);
+    assert(containsExamples);
+  });
+
+  it('fails validation if groupId, channelId and messageId are not specified', () => {
+    const actual = (command.validate() as CommandValidate)({
+      options: {
+        debug: false,
+      }
+    });
+    assert.notEqual(actual, true);
+  });
+
+  it('fails validation if channelId and messageId are not specified', () => {
+    const actual = (command.validate() as CommandValidate)({
+      options: {
+        debug: false,
+        groupId: "5f5d7b71-1161-44d8-bcc1-3da710eb4171"
+      }
+    });
+    assert.notEqual(actual, true);
+  });
+
+  it('fails validation if messageId is not specified', () => {
+    const actual = (command.validate() as CommandValidate)({
+      options: {
+        debug: false,
+        groupId: "5f5d7b71-1161-44d8-bcc1-3da710eb4171",
+        channelId: "19:88f7e66a8dfe42be92db19505ae912a8@thread.skype"
+      }
+    });
+    assert.notEqual(actual, true);
+  });
+
+  it('fails validation if the teamId is not a valid guid', () => {
+    const actual = (command.validate() as CommandValidate)({
+      options: {
+        groupId: "5f5d7b71-1161-44",
+        channelId: "19:88f7e66a8dfe42be92db19505ae912a8@thread.skype",
+        messageId: "1540911392778"
+      }
+    });
+    assert.notEqual(actual, true);
+  });
+
+  it('supports debug mode', () => {
+    const options = (command.options() as CommandOption[]);
+    let containsOption = false;
+    options.forEach(o => {
+      if (o.option === '--debug') {
+        containsOption = true;
+      }
+    });
+    assert(containsOption);
+  });
+
+  it('validates for a correct input', () => {
+    const actual = (command.validate() as CommandValidate)({
+      options: {
+        groupId: "5f5d7b71-1161-44d8-bcc1-3da710eb4171",
+        channelId: "19:88f7e66a8dfe42be92db19505ae912a8@thread.skype",
+        messageId: "1540911392778"
+      }
+    });
+    assert.equal(actual, true);
+  });
+  
+  it('retrieves the specified message (debug)', (done) => {
+    sinon.stub(request, 'get').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/beta/teams/5f5d7b71-1161-44d8-bcc1-3da710eb4171/channels/19:88f7e66a8dfe42be92db19505ae912a8@thread.skype/messages/1540911392778`) {
+        return Promise.resolve({
+          attachments         : [],
+          body                : {"contentType":"text","content":"Konnichiwa"},
+          createdDateTime     : "2018-10-28T15:56:25.116Z",
+          deleted             : false,
+          etag                : "1540742185116",
+          from                : {"application":null,"device":null,"user":{"id":"c500ecce-645d-4fe1-a2ea-b70f32416b51","displayName":"Arjen Bloemsma","identityProvider":"Aad"}},
+          id                  : "1540742185116",
+          importance          : "normal",
+          lastModifiedDateTime: null,
+          locale              : "en-us",
+          mentions            : [],
+          messageType         : "message",
+          policyViolation     : null,
+          reactions           : [],
+          replyToId           : null,
+          subject             : "",
+          summary             : null
+        });
+      }
+
+      return Promise.reject('Invalid Request');
+    });
+
+    auth.service = new Service('https://graph.microsoft.com');
+    auth.service.connected = true;
+    cmdInstance.action = command.action();
+    cmdInstance.action({ 
+      options: { 
+        debug: true, 
+        groupId: "5f5d7b71-1161-44d8-bcc1-3da710eb4171",
+        channelId: "19:88f7e66a8dfe42be92db19505ae912a8@thread.skype",
+        messageId: "1540911392778"
+      }
+    }, () => {
+      try {
+        assert(cmdInstanceLogSpy.calledWith({
+          attachments         : [],
+          body                : {"contentType":"text","content":"Konnichiwa"},
+          createdDateTime     : "2018-10-28T15:56:25.116Z",
+          deleted             : false,
+          etag                : "1540742185116",
+          from                : {"application":null,"device":null,"user":{"id":"c500ecce-645d-4fe1-a2ea-b70f32416b51","displayName":"Arjen Bloemsma","identityProvider":"Aad"}},
+          id                  : "1540742185116",
+          importance          : "normal",
+          lastModifiedDateTime: null,
+          locale              : "en-us",
+          mentions            : [],
+          messageType         : "message",
+          policyViolation     : null,
+          reactions           : [],
+          replyToId           : null,
+          subject             : "",
+          summary             : null
+        }));
+
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('retrieves the specified message', (done) => {
+    sinon.stub(request, 'get').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/beta/teams/5f5d7b71-1161-44d8-bcc1-3da710eb4171/channels/19:88f7e66a8dfe42be92db19505ae912a8@thread.skype/messages/1540911392778`) {
+        return Promise.resolve({
+          attachments         : [],
+          body                : {"contentType":"text","content":"Konnichiwa"},
+          createdDateTime     : "2018-10-28T15:56:25.116Z",
+          deleted             : false,
+          etag                : "1540742185116",
+          from                : {"application":null,"device":null,"user":{"id":"c500ecce-645d-4fe1-a2ea-b70f32416b51","displayName":"Arjen Bloemsma","identityProvider":"Aad"}},
+          id                  : "1540742185116",
+          importance          : "normal",
+          lastModifiedDateTime: null,
+          locale              : "en-us",
+          mentions            : [],
+          messageType         : "message",
+          policyViolation     : null,
+          reactions           : [],
+          replyToId           : null,
+          subject             : "",
+          summary             : null
+        });
+      }
+
+      return Promise.reject('Invalid Request');
+    });
+
+    auth.service = new Service('https://graph.microsoft.com');
+    auth.service.connected = true;
+    cmdInstance.action = command.action();
+    cmdInstance.action({ 
+      options: { 
+        debug: false, 
+        groupId: "5f5d7b71-1161-44d8-bcc1-3da710eb4171",
+        channelId: "19:88f7e66a8dfe42be92db19505ae912a8@thread.skype",
+        messageId: "1540911392778"
+      }
+    }, () => {
+      try {
+        assert(cmdInstanceLogSpy.calledWith({
+          attachments         : [],
+          body                : {"contentType":"text","content":"Konnichiwa"},
+          createdDateTime     : "2018-10-28T15:56:25.116Z",
+          deleted             : false,
+          etag                : "1540742185116",
+          from                : {"application":null,"device":null,"user":{"id":"c500ecce-645d-4fe1-a2ea-b70f32416b51","displayName":"Arjen Bloemsma","identityProvider":"Aad"}},
+          id                  : "1540742185116",
+          importance          : "normal",
+          lastModifiedDateTime: null,
+          locale              : "en-us",
+          mentions            : [],
+          messageType         : "message",
+          policyViolation     : null,
+          reactions           : [],
+          replyToId           : null,
+          subject             : "",
+          summary             : null
+        }));
+
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('correctly handles lack of valid access token', (done) => {
+    Utils.restore(auth.ensureAccessToken);
+    sinon.stub(auth, 'ensureAccessToken').callsFake(() => { return Promise.reject(new Error('Error getting access token')); });
+    auth.service = new Service('https://graph.microsoft.com');
+    auth.service.connected = true;
+    cmdInstance.action = command.action();
+    cmdInstance.action({ options: { debug: true } }, (err?: any) => {
+      try {
+        assert.equal(JSON.stringify(err), JSON.stringify(new CommandError('Error getting access token')));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+});

--- a/src/o365/graph/commands/teams/teams-channel-message-get.ts
+++ b/src/o365/graph/commands/teams/teams-channel-message-get.ts
@@ -27,7 +27,7 @@ class GraphTeamsChannelMessageGetCommand extends GraphCommand {
   }
 
   public get description(): string {
-    return 'Retreives a message from a channel in a Microsoft Teams team';
+    return 'Retrieves a message from a channel in a Microsoft Teams team';
   }
 
   public getTelemetryProperties(args: CommandArgs): any {
@@ -134,11 +134,11 @@ class GraphTeamsChannelMessageGetCommand extends GraphCommand {
     the Microsoft Graph using the ${chalk.blue(commands.LOGIN)} command,
     eg. ${chalk.grey(`${config.delimiter} ${commands.LOGIN}`)}.
 
-    You can only retreive a message from a Microsoft Teams team if you are a member of that team.
+    You can only retrieve a message from a Microsoft Teams team if you are a member of that team.
 
   Examples:
   
-    Retrieve the specified message from a channel of the specified Microsoft Teams team
+    Retrieve the specified message from a channel of the Microsoft Teams team
       ${chalk.grey(config.delimiter)} ${this.name} --groupId 5f5d7b71-1161-44d8-bcc1-3da710eb4171 --channelId 19:88f7e66a8dfe42be92db19505ae912a8@thread.skype --messageId 1540747442203
 `   );
   }

--- a/src/o365/graph/commands/teams/teams-channel-message-get.ts
+++ b/src/o365/graph/commands/teams/teams-channel-message-get.ts
@@ -1,0 +1,147 @@
+import auth from '../../GraphAuth';
+import config from '../../../../config';
+import commands from '../../commands';
+import GlobalOptions from '../../../../GlobalOptions';
+import {
+  CommandOption, CommandValidate
+} from '../../../../Command';
+import GraphCommand from "../../GraphCommand";
+import * as request from 'request-promise-native';
+import Utils from '../../../../Utils';
+
+const vorpal: Vorpal = require('../../../../vorpal-init');
+
+interface CommandArgs {
+  options: Options;
+}
+
+interface Options extends GlobalOptions {
+  groupId: string;
+  channelId: string;
+  messageId: string;
+}
+
+class GraphTeamsChannelMessageGetCommand extends GraphCommand {
+  public get name(): string {
+    return `${commands.TEAMS_CHANNEL_MESSAGE_GET}`;
+  }
+
+  public get description(): string {
+    return 'Retreives a message from a channel in a Microsoft Teams team';
+  }
+
+  public getTelemetryProperties(args: CommandArgs): any {
+    const telemetryProps: any = super.getTelemetryProperties(args);
+    telemetryProps.groupId = typeof args.options.groupId !== 'undefined';
+    telemetryProps.channelId = typeof args.options.channelId !== 'undefined';
+    telemetryProps.messageId = typeof args.options.messageId !== 'undefined';
+    return telemetryProps;
+  }
+
+  public commandAction(cmd: CommandInstance, args: CommandArgs, cb: () => void): void {
+    auth
+      .ensureAccessToken(auth.service.resource, cmd, this.debug)
+      .then((): request.RequestPromise => {
+        const requestOptions: any = {
+          url: `${auth.service.resource}/beta/teams/${args.options.groupId}/channels/${args.options.channelId}/messages/${args.options.messageId}`,
+          headers: Utils.getRequestHeaders({
+            authorization: `Bearer ${auth.service.accessToken}`,
+            accept: 'application/json;odata.metadata=none'
+          }),
+          json: true
+        };
+
+        if (this.debug) {
+          cmd.log('Executing web request...');
+          cmd.log(requestOptions);
+          cmd.log('');
+        }
+
+        return request.get(requestOptions);
+      })
+      .then((res: any): void => {
+        if (this.debug) {
+          cmd.log('Response:')
+          cmd.log(res);
+          cmd.log('');
+        }
+
+        cmd.log(res);
+        if (this.verbose) {
+          cmd.log(vorpal.chalk.green('DONE'));
+        }
+        cb();
+      }, (err: any): void => this.handleRejectedODataJsonPromise(err, cmd, cb));
+  }
+
+  public options(): CommandOption[] {
+    const options: CommandOption[] = [
+      {
+        option: '-i, --groupId <groupId>',
+        description: 'The ID of the team where the channel is located'
+      },
+      {
+        option: '-c, --channelId <channelId>',
+        description: 'The ID of the channel that contains the message'
+      },
+      {
+        option: '-m, --messageId <messageId>',
+        description: 'The ID of the message to retrieve'
+      }
+    ];
+
+    const parentOptions: CommandOption[] = super.options();
+    return options.concat(parentOptions);
+  }
+
+  public validate(): CommandValidate {
+    return (args: CommandArgs): boolean | string => {
+      if (!args.options.groupId) {
+        return 'Required parameter groupId missing';
+      }
+
+      if (!Utils.isValidGuid(args.options.groupId as string)) {
+        return `${args.options.groupId} is not a valid GUID`;
+      }
+
+      if (!args.options.channelId) {
+        return 'Required parameter channelId missing';
+      }
+
+      if (!args.options.messageId) {
+        return 'Required parameter messageId missing';
+      }
+
+      return true;
+    };
+  }
+
+
+  public commandHelp(args: {}, log: (help: string) => void): void {
+    const chalk = vorpal.chalk;
+    log(vorpal.find(this.name).helpInformation());
+    log(
+      `  ${chalk.yellow('Important:')} before using this command, log in to the Microsoft Graph
+    using the ${chalk.blue(commands.LOGIN)} command.
+          
+  Remarks:
+
+    ${chalk.yellow('Attention:')} This command is based on an API that is currently
+    in preview and is subject to change once the API reached general
+    availability.
+
+    To retrieve a message from a Microsoft Teams channel, you have to first log in to
+    the Microsoft Graph using the ${chalk.blue(commands.LOGIN)} command,
+    eg. ${chalk.grey(`${config.delimiter} ${commands.LOGIN}`)}.
+
+    You can only retreive a message from a Microsoft Teams team if you are a member of that team.
+
+  Examples:
+  
+    Retrieve the specified message from a channel of the specified Microsoft Teams team
+      ${chalk.grey(config.delimiter)} ${this.name} --groupId 5f5d7b71-1161-44d8-bcc1-3da710eb4171 --channelId 19:88f7e66a8dfe42be92db19505ae912a8@thread.skype --messageId 1540747442203
+`   );
+  }
+}
+
+module.exports = new GraphTeamsChannelMessageGetCommand();


### PR DESCRIPTION
Added the command 'graph teams channel message get' which retrieves the given message from a Microsoft Teams team channel. As specified in #589