### PR TITLE
Fixed bug with caching tokens for SPO commands

### DIFF
--- a/src/Auth.spec.ts
+++ b/src/Auth.spec.ts
@@ -457,9 +457,9 @@ describe('Auth', () => {
   it('gets access token using refresh token for the specified resource', (done) => {
     sinon.stub((auth as any).authCtx, 'acquireTokenWithRefreshToken').callsArgWith(3, undefined, { accessToken: 'acc' });
 
-    auth.getAccessToken(resource, 'ref', stdout).then((accessToken) => {
+    auth.getAccessTokenWithResponse(resource, 'ref', stdout).then((tokenResponse) => {
       try {
-        assert(accessToken, 'abc');
+        assert(tokenResponse.accessToken, 'abc');
         done();
       }
       catch (e) {
@@ -473,9 +473,9 @@ describe('Auth', () => {
   it('gets access token using refresh token for the specified resource (debug)', (done) => {
     sinon.stub((auth as any).authCtx, 'acquireTokenWithRefreshToken').callsArgWith(3, undefined, { accessToken: 'acc' });
 
-    auth.getAccessToken(resource, 'ref', stdout, true).then((accessToken) => {
+    auth.getAccessTokenWithResponse(resource, 'ref', stdout, true).then((tokenResponse) => {
       try {
-        assert(accessToken, 'abc');
+        assert(tokenResponse.accessToken, 'abc');
         done();
       }
       catch (e) {
@@ -489,7 +489,7 @@ describe('Auth', () => {
   it('handles error when getting access token using refresh token for the specified resource', (done) => {
     sinon.stub((auth as any).authCtx, 'acquireTokenWithRefreshToken').callsArgWith(3, { message: 'An error has occurred' }, undefined);
 
-    auth.getAccessToken(resource, 'ref', stdout).then((accessToken) => {
+    auth.getAccessTokenWithResponse(resource, 'ref', stdout).then((tokenResponse) => {
       done('Got access token');
     }, (err) => {
       try {
@@ -505,7 +505,7 @@ describe('Auth', () => {
   it('shows AAD error when getting access token using refresh token for the specified resource', (done) => {
     sinon.stub((auth as any).authCtx, 'acquireTokenWithRefreshToken').callsArgWith(3, { message: 'An error has occurred' }, { error_description: 'AADSTS00000 An error has occurred' });
 
-    auth.getAccessToken(resource, 'ref', stdout).then((accessToken) => {
+    auth.getAccessTokenWithResponse(resource, 'ref', stdout).then((tokenResponse) => {
       done('Got access token');
     }, (err) => {
       try {
@@ -521,7 +521,7 @@ describe('Auth', () => {
   it('logs the error message when getting access token using refresh token for the specified resource failed in debug mode', (done) => {
     sinon.stub((auth as any).authCtx, 'acquireTokenWithRefreshToken').callsArgWith(3, { message: 'An error has occurred' }, undefined);
 
-    auth.getAccessToken(resource, 'ref', stdout, true).then((accessToken) => {
+    auth.getAccessTokenWithResponse(resource, 'ref', stdout, true).then((tokenResponse) => {
       done('Got access token');
     }, (err) => {
       try {

--- a/src/Auth.ts
+++ b/src/Auth.ts
@@ -234,12 +234,12 @@ export abstract class Auth {
     }
   }
 
-  public getAccessToken(resource: string, refreshToken: string, stdout: Logger, debug: boolean = false): Promise<string> {
+  public getAccessTokenWithResponse(resource: string, refreshToken: string, stdout: Logger, debug: boolean = false): Promise<TokenResponse> {
     if (debug) {
-      stdout.log(`Starting Auth.getAccessToken. resource: ${resource}, refreshToken: ${refreshToken}, debug: ${debug}`);
+      stdout.log(`Starting Auth.getAccessTokenWithResponse. resource: ${resource}, refreshToken: ${refreshToken}, debug: ${debug}`);
     }
 
-    return new Promise<string>((resolve: (accessToken: string) => void, reject: (err: any) => void): void => {
+    return new Promise<TokenResponse>((resolve: (tokenResponse: TokenResponse) => void, reject: (err: any) => void): void => {
       if (debug) {
         stdout.log(`Retrieving access token for ${resource} using refresh token ${refreshToken}`);
       }
@@ -264,7 +264,7 @@ export abstract class Auth {
           }
 
           const tokenResponse: TokenResponse = <TokenResponse>response;
-          resolve(tokenResponse.accessToken);
+          resolve(tokenResponse);
         });
     });
   }

--- a/src/o365/spo/SpoAuth.spec.ts
+++ b/src/o365/spo/SpoAuth.spec.ts
@@ -310,7 +310,7 @@ describe('SpoAuth', () => {
       accessToken: 'ABC',
       expiresOn: expiresOn.toISOString()
     };
-    const authGetAccessTokenSpy = sinon.spy(Auth.prototype, 'getAccessToken');
+    const authGetAccessTokenSpy = sinon.spy(Auth.prototype, 'getAccessTokenWithResponse');
     auth
       .getAccessToken('https://contoso.sharepoint.com', 'ABC', stdout)
       .then((accessToken) => {
@@ -323,7 +323,7 @@ describe('SpoAuth', () => {
           done(e);
         }
         finally {
-          Utils.restore(Auth.prototype.getAccessToken);
+          Utils.restore(Auth.prototype.getAccessTokenWithResponse);
         }
       });
   });
@@ -339,7 +339,10 @@ describe('SpoAuth', () => {
       accessToken: 'ABC',
       expiresOn: expiresOn.toISOString()
     };
-    sinon.stub(Auth.prototype, 'getAccessToken').callsFake(() => Promise.resolve('DEF'));
+    sinon.stub(Auth.prototype, 'getAccessTokenWithResponse').callsFake(() => Promise.resolve({
+      accessToken: 'DEF',
+      expiresOn: new Date().toISOString()
+    }));
     sinon.stub(auth as any, 'setServiceConnectionInfo').callsFake(() => Promise.resolve());
     auth
       .getAccessToken('https://contoso.sharepoint.com', 'ABC', stdout)
@@ -353,7 +356,7 @@ describe('SpoAuth', () => {
         }
         finally {
           Utils.restore([
-            Auth.prototype.getAccessToken,
+            Auth.prototype.getAccessTokenWithResponse,
             (auth as any).setServiceConnectionInfo
           ]);
         }
@@ -366,7 +369,10 @@ describe('SpoAuth', () => {
     };
     auth.site = new Site();
     auth.site.accessTokens = {};
-    sinon.stub(Auth.prototype, 'getAccessToken').callsFake(() => Promise.resolve('DEF'));
+    sinon.stub(Auth.prototype, 'getAccessTokenWithResponse').callsFake(() => Promise.resolve({
+      accessToken: 'DEF',
+      expiresOn: new Date().toISOString()
+    }));
     sinon.stub(auth as any, 'setServiceConnectionInfo').callsFake(() => Promise.resolve());
     auth
       .getAccessToken('https://contoso.sharepoint.com', 'ABC', stdout)
@@ -380,7 +386,7 @@ describe('SpoAuth', () => {
         }
         finally {
           Utils.restore([
-            Auth.prototype.getAccessToken,
+            Auth.prototype.getAccessTokenWithResponse,
             (auth as any).setServiceConnectionInfo
           ]);
         }
@@ -393,7 +399,10 @@ describe('SpoAuth', () => {
     };
     auth.site = new Site();
     auth.site.accessTokens = {};
-    sinon.stub(Auth.prototype, 'getAccessToken').callsFake(() => Promise.resolve('DEF'));
+    sinon.stub(Auth.prototype, 'getAccessTokenWithResponse').callsFake(() => Promise.resolve({
+      accessToken: 'DEF',
+      expiresOn: new Date().toISOString()
+    }));
     sinon.stub(auth as any, 'setServiceConnectionInfo').callsFake(() => Promise.resolve());
     auth
       .getAccessToken('https://contoso.sharepoint.com', 'ABC', stdout)
@@ -407,7 +416,7 @@ describe('SpoAuth', () => {
         }
         finally {
           Utils.restore([
-            Auth.prototype.getAccessToken,
+            Auth.prototype.getAccessTokenWithResponse,
             (auth as any).setServiceConnectionInfo
           ]);
         }
@@ -420,7 +429,10 @@ describe('SpoAuth', () => {
     };
     auth.site = new Site();
     auth.site.accessTokens = {};
-    sinon.stub(Auth.prototype, 'getAccessToken').callsFake(() => Promise.resolve('DEF'));
+    sinon.stub(Auth.prototype, 'getAccessTokenWithResponse').callsFake(() => Promise.resolve({
+      accessToken: 'DEF',
+      expiresOn: new Date().toISOString()
+    }));
     sinon.stub(auth as any, 'setServiceConnectionInfo').callsFake(() => Promise.reject('An error has occurred'));
     auth
       .getAccessToken('https://contoso.sharepoint.com', 'ABC', stdout)
@@ -434,7 +446,7 @@ describe('SpoAuth', () => {
         }
         finally {
           Utils.restore([
-            Auth.prototype.getAccessToken,
+            Auth.prototype.getAccessTokenWithResponse,
             (auth as any).setServiceConnectionInfo
           ]);
         }
@@ -448,7 +460,7 @@ describe('SpoAuth', () => {
     auth.site = new Site();
     auth.site.accessTokens = {};
     const stdoutLogSpy = sinon.spy(stdout, 'log');
-    sinon.stub(Auth.prototype, 'getAccessToken').callsFake(() => Promise.resolve('DEF'));
+    sinon.stub(Auth.prototype, 'getAccessTokenWithResponse').callsFake(() => Promise.resolve('DEF'));
     sinon.stub(auth as any, 'setServiceConnectionInfo').callsFake(() => Promise.reject('An error has occurred'));
     auth
       .getAccessToken('https://contoso.sharepoint.com', 'ABC', stdout, true)
@@ -462,7 +474,7 @@ describe('SpoAuth', () => {
         }
         finally {
           Utils.restore([
-            Auth.prototype.getAccessToken,
+            Auth.prototype.getAccessTokenWithResponse,
             (auth as any).setServiceConnectionInfo
           ]);
         }
@@ -475,12 +487,12 @@ describe('SpoAuth', () => {
     };
     auth.site = new Site();
     auth.site.accessTokens = {};
-    sinon.stub(Auth.prototype, 'getAccessToken').callsFake(() => Promise.reject('An error has occurred'));
+    sinon.stub(Auth.prototype, 'getAccessTokenWithResponse').callsFake(() => Promise.reject('An error has occurred'));
     auth
       .getAccessToken('https://contoso.sharepoint.com', 'ABC', stdout, true)
       .then(() => {
         Utils.restore([
-          Auth.prototype.getAccessToken,
+          Auth.prototype.getAccessTokenWithResponse,
           (auth as any).setServiceConnectionInfo
         ]);
         fail('Failure expected but passed');
@@ -494,7 +506,7 @@ describe('SpoAuth', () => {
         }
         finally {
           Utils.restore([
-            Auth.prototype.getAccessToken,
+            Auth.prototype.getAccessTokenWithResponse,
             (auth as any).setServiceConnectionInfo
           ]);
         }


### PR DESCRIPTION
Fixed bug with caching tokens for SPO commands. Before this fix, access tokens to SPO sites had expiration date set to now which meant that each time they had to be renewed.