### PR TITLE
Update command documentation and MPA

### DIFF
--- a/docs/guides/mpa.md
+++ b/docs/guides/mpa.md
@@ -31,6 +31,8 @@ If you renamed files:
 
 Office 365 CLI uses [MkDocs](http://www.mkdocs.org) to publish documentation pages. See more information about installing MkDocs on your operating system at http://www.mkdocs.org/#installation.
 
+MkDocs use `mkdocs-material` theme. See more information about installing mkdocs-material on your operating system at https://squidfunk.github.io/mkdocs-material.
+
 Once you have MkDocs installed on your machine, in the command line:
 
 - run `cd ./docs/manual` to change directory to where the manual pages are stored

--- a/docs/manual/docs/cmd/spo/site/site-appcatalog-add.md
+++ b/docs/manual/docs/cmd/spo/site/site-appcatalog-add.md
@@ -23,7 +23,7 @@ Option|Description
 
 ## Remarks
 
-To create a site collection app catalog, you have to first log in to a SharePoint site using the [spo login](../login.md) command, eg. `spo login https://contoso.sharepoint.com`.
+To create a site collection app catalog, you have to first log in to a SharePoint site using the [spo login](../login.md) command, eg. `spo login https://contoso-admin.sharepoint.com`.
 
 ## Examples
 

--- a/docs/manual/docs/cmd/spo/site/site-appcatalog-remove.md
+++ b/docs/manual/docs/cmd/spo/site/site-appcatalog-remove.md
@@ -23,7 +23,7 @@ Option|Description
 
 ## Remarks
 
-To remove an app catalog from a site collection, you have to first log in to a SharePoint site using the [spo login](../login.md) command, eg. `spo login https://contoso.sharepoint.com`.
+To remove an app catalog from a site collection, you have to first log in to a SharePoint site using the [spo login](../login.md) command, eg. `spo login https://contoso-admin.sharepoint.com`.
 
 While the command uses the term *"remove"*, like the PowerShell equivalent cmdlet, it does not remove the special library **Apps for SharePoint** from the site collection. It simply disables the site collection app catalog in that site. Packages deployed to the app catalog are not available within the site collection.
 


### PR DESCRIPTION
## Documentation

### spo site appcatalog add & spo site appcatalog remove

If spo login is https://contoso.sharepoint.com that's occur the following error :

```bash
Error: https://contoso.sharepoint.com is not a tenant admin site. Log in to your tenant admin site and try again
```

### MkDocs

Just to win some time for next contributors, install mkdocs-material to avoid error at the first build 😉 

```bash
INFO    -  Building documentation...
ERROR   -  Config value: 'theme'. Error: Unrecognised theme name: 'material'. The available installed themes are: readthedocs, mkdocs

Aborted with 1 Configuration Errors!
```

And thx for you great job 😄 👍🏻