### PR TITLE
Proposed fix for spo customaction list #742

### DIFF
--- a/src/o365/spo/commands/customaction/customaction-list.spec.ts
+++ b/src/o365/spo/commands/customaction/customaction-list.spec.ts
@@ -613,6 +613,133 @@ describe(commands.CUSTOMACTION_LIST, () => {
     });
   });
 
+  it('correctly handles no scope entered (debug)', (done) => {
+    stubAuth();
+
+    sinon.stub(request, 'get').callsFake((opts) => {
+      if (opts.url.indexOf('/_api/Web/UserCustomActions') > -1) {
+        return Promise.resolve({
+          value: [
+            {
+              Id: "9f7ade35-0f8d-4c8a-82e1-5008ab42df55",
+              Location: "Microsoft.SharePoint.StandardMenu",
+              Name: "customaction1",
+              Scope: 3
+            }]
+        });
+      }
+
+      if (opts.url.indexOf('/_api/Site/UserCustomActions') > -1) {
+        return Promise.resolve({
+          value: [
+            {
+              Id: "9f7ade35-0f8d-4c8a-82e1-5008ab42df56",
+              Location: "Microsoft.SharePoint.StandardMenu",
+              Name: "customaction2",
+              Scope: 2
+            }
+          ]
+        });
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    auth.site = new Site();
+    auth.site.connected = true;
+    auth.site.url = 'https://contoso-admin.sharepoint.com';
+    auth.site.tenantId = 'abc';
+    cmdInstance.action = command.action();
+    cmdInstance.action({ 
+      options: { 
+        url: 'https://contoso.sharepoint.com/sites/abc',
+        debug: true 
+      } }, () => {
+      let correctLogStatement = false;
+      log.forEach(l => {
+        if (!l || typeof l !== 'string') {
+          return;
+        }
+
+        if (l.indexOf('Attempt to get custom actions list with scope: All') > -1) {
+          correctLogStatement = true;
+        }
+      })
+      try {
+        assert(correctLogStatement);
+        assert(cmdInstanceLogSpy.calledWith([
+          {
+            Name: 'customaction2',
+            Location: 'Microsoft.SharePoint.StandardMenu',
+            Scope: 'Site',
+            Id: '9f7ade35-0f8d-4c8a-82e1-5008ab42df56'
+          },
+          {
+            Name: 'customaction1',
+            Location: 'Microsoft.SharePoint.StandardMenu',
+            Scope: 'Web',
+            Id: '9f7ade35-0f8d-4c8a-82e1-5008ab42df55'
+          }]
+        ));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+      finally {
+        Utils.restore(request.get);
+        Utils.restore(request.post);
+      }
+    });
+  });
+
+  // it('correctly handles no scope entered (debug)', (done) => {
+  //   stubAuth();
+  //   sinon.stub(request, 'get').callsFake((opts) => {
+
+  //     if (opts.url.indexOf('/_api/Site/Features?$select=DisplayName,DefinitionId') > -1) {
+  //       return Promise.resolve(JSON.stringify({ value: [] }));
+  //     }
+  //     return Promise.reject('Invalid request');
+  //   });
+
+  //   auth.site = new Site();
+  //   auth.site.connected = true;
+  //   auth.site.url = 'https://contoso.sharepoint.com';
+  //   cmdInstance.action = command.action();
+
+  //   const options: Object = {
+  //     verbose: true,
+  //     debug: false,
+  //     url: 'https://contoso.sharepoint.com',
+  //     scope: 'Site',
+  //   }
+  //   cmdInstance.action({ options: options }, () => {
+  //     let correctLogStatement = false;
+  //     log.forEach(l => {
+  //       if (!l || typeof l !== 'string') {
+  //         return;
+  //       }
+
+  //       if (l.indexOf('No features found') > -1) {
+  //         correctLogStatement = true;
+  //       }
+  //     })
+  //     try {
+  //       assert(correctLogStatement);
+  //       done();
+  //     }
+  //     catch (e) {
+  //       done(e);
+  //     }
+  //     finally {
+  //       Utils.restore(request.post);
+  //       Utils.restore(request.get);
+  //     }
+  //   });
+  // });
+
+
   it('fails validation if the url option is not a valid SharePoint site URL', () => {
     const actual = (command.validate() as CommandValidate)({
       options:

--- a/src/o365/spo/commands/customaction/customaction-list.spec.ts
+++ b/src/o365/spo/commands/customaction/customaction-list.spec.ts
@@ -693,53 +693,6 @@ describe(commands.CUSTOMACTION_LIST, () => {
     });
   });
 
-  // it('correctly handles no scope entered (debug)', (done) => {
-  //   stubAuth();
-  //   sinon.stub(request, 'get').callsFake((opts) => {
-
-  //     if (opts.url.indexOf('/_api/Site/Features?$select=DisplayName,DefinitionId') > -1) {
-  //       return Promise.resolve(JSON.stringify({ value: [] }));
-  //     }
-  //     return Promise.reject('Invalid request');
-  //   });
-
-  //   auth.site = new Site();
-  //   auth.site.connected = true;
-  //   auth.site.url = 'https://contoso.sharepoint.com';
-  //   cmdInstance.action = command.action();
-
-  //   const options: Object = {
-  //     verbose: true,
-  //     debug: false,
-  //     url: 'https://contoso.sharepoint.com',
-  //     scope: 'Site',
-  //   }
-  //   cmdInstance.action({ options: options }, () => {
-  //     let correctLogStatement = false;
-  //     log.forEach(l => {
-  //       if (!l || typeof l !== 'string') {
-  //         return;
-  //       }
-
-  //       if (l.indexOf('No features found') > -1) {
-  //         correctLogStatement = true;
-  //       }
-  //     })
-  //     try {
-  //       assert(correctLogStatement);
-  //       done();
-  //     }
-  //     catch (e) {
-  //       done(e);
-  //     }
-  //     finally {
-  //       Utils.restore(request.post);
-  //       Utils.restore(request.get);
-  //     }
-  //   });
-  // });
-
-
   it('fails validation if the url option is not a valid SharePoint site URL', () => {
     const actual = (command.validate() as CommandValidate)({
       options:

--- a/src/o365/spo/commands/customaction/customaction-list.ts
+++ b/src/o365/spo/commands/customaction/customaction-list.ts
@@ -40,6 +40,7 @@ class SpoCustomActionListCommand extends SpoCommand {
   }
 
   public commandAction(cmd: CommandInstance, args: CommandArgs, cb: () => void): void {
+    const scope: string = args.options.scope ? args.options.scope : 'All';
     const resource: string = Auth.getResourceFromUrl(args.options.url);
     let siteAccessToken: string = '';
 
@@ -60,11 +61,11 @@ class SpoCustomActionListCommand extends SpoCommand {
           cmd.log(JSON.stringify(contextResponse));
           cmd.log('');
 
-          cmd.log(`Attempt to get custom actions list with scope: ${args.options.scope}`);
+          cmd.log(`Attempt to get custom actions list with scope: ${scope}`);
           cmd.log('');
         }
 
-        if (args.options.scope && args.options.scope.toLowerCase() !== "all") {
+        if (scope && scope.toLowerCase() !== "all") {
           return this.getCustomActions(args.options, siteAccessToken, cmd);
         }
         return this.searchAllScopes(args.options, siteAccessToken, cmd);


### PR DESCRIPTION
Proposed fix for spo customaction list #742 

- Changes to make a constant hold the scope `All` if scope not defined in options. No longer undefined in debug log.
- Added unit test to make sure it logs correcly while in debug mode, for no scope entered. This should default to `All` and logged as: `Attempt to get custom actions list with scope: All`