### PR TITLE
Added option includeAssociatedSites to spo hubsite list command

### DIFF
--- a/docs/manual/docs/cmd/spo/hubsite/hubsite-list.md
+++ b/docs/manual/docs/cmd/spo/hubsite/hubsite-list.md
@@ -16,6 +16,7 @@ spo hubsite list [options]
 Option|Description
 ------|-----------
 `--help`|output usage information
+`-i, --includeAssociatedSites`|Include the associated sites in the result
 `-o, --output [output]`|Output type. `json|text`. Default `text`
 `--verbose`|Runs command with verbose logging
 `--debug`|Runs command with debug logging
@@ -35,6 +36,12 @@ List hub sites in the current tenant
 
 ```sh
 spo hubsite list
+```
+
+List hub sites, including their associated sites, in the current tenant
+
+```sh
+spo hubsite list --includeAssociatedSites
 ```
 
 ## More information

--- a/docs/manual/docs/cmd/spo/hubsite/hubsite-list.md
+++ b/docs/manual/docs/cmd/spo/hubsite/hubsite-list.md
@@ -16,7 +16,7 @@ spo hubsite list [options]
 Option|Description
 ------|-----------
 `--help`|output usage information
-`-i, --includeAssociatedSites`|Include the associated sites in the result
+`-i, --includeAssociatedSites`|Include the associated sites in the result (only in JSON output)
 `-o, --output [output]`|Output type. `json|text`. Default `text`
 `--verbose`|Runs command with verbose logging
 `--debug`|Runs command with debug logging
@@ -38,10 +38,10 @@ List hub sites in the current tenant
 spo hubsite list
 ```
 
-List hub sites, including their associated sites, in the current tenant
+List hub sites, including their associated sites, in the current tenant. Associated site info is only shown in JSON output.
 
 ```sh
-spo hubsite list --includeAssociatedSites
+spo hubsite list --includeAssociatedSites --output json
 ```
 
 ## More information

--- a/src/o365/spo/commands/hubsite/AssociatedSite.ts
+++ b/src/o365/spo/commands/hubsite/AssociatedSite.ts
@@ -1,0 +1,4 @@
+export interface AssociatedSite {
+  Title: string;
+  SiteUrl: string;
+}

--- a/src/o365/spo/commands/hubsite/HubSite.ts
+++ b/src/o365/spo/commands/hubsite/HubSite.ts
@@ -1,3 +1,5 @@
+import { AssociatedSite } from './AssociatedSite';
+
 export interface HubSite {
   Description: string;
   ID: string;
@@ -7,4 +9,5 @@ export interface HubSite {
   Targets: string;
   TenantInstanceId: string;
   Title: string;
+  AssociatedSites: AssociatedSite[];
 }

--- a/src/o365/spo/commands/hubsite/QueryListResult.ts
+++ b/src/o365/spo/commands/hubsite/QueryListResult.ts
@@ -1,0 +1,10 @@
+export interface QueryListResult {
+  FilterLink: string;
+  FirstRow: number;
+  FolderPermissions: string;
+  ForceNoHierarchy: string;
+  HierarchyHasIndention: string | null;
+  LastRow: number;
+  Row: any[];
+  RowLimit: number;
+}

--- a/src/o365/spo/commands/hubsite/QueryListResult.ts
+++ b/src/o365/spo/commands/hubsite/QueryListResult.ts
@@ -6,5 +6,6 @@ export interface QueryListResult {
   HierarchyHasIndention: string | null;
   LastRow: number;
   Row: any[];
+  NextHref: string | null;
   RowLimit: number;
 }

--- a/src/o365/spo/commands/hubsite/hubsite-list.spec.ts
+++ b/src/o365/spo/commands/hubsite/hubsite-list.spec.ts
@@ -40,7 +40,8 @@ describe(commands.HUBSITE_LIST, () => {
   afterEach(() => {
     Utils.restore([
       vorpal.find,
-      request.get
+      request.get,
+      request.post
     ]);
   });
 
@@ -275,6 +276,372 @@ describe(commands.HUBSITE_LIST, () => {
             "Targets": null,
             "TenantInstanceId": "00000000-0000-0000-0000-000000000000",
             "Title": "Travel Programs"
+          }
+        ]));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('lists hub sites including their associated sites', (done) => {
+    sinon.stub(request, 'get').resolves({
+      value: [
+        {
+          "Description": null,
+          "ID": "389d0d83-40bb-40ad-b92a-534b7cb37d0b",
+          "LogoUrl": "http://contoso.com/__siteIcon__.jpg",
+          "SiteId": "389d0d83-40bb-40ad-b92a-534b7cb37d0b",
+          "SiteUrl": "https://contoso.sharepoint.com/sites/Sales",
+          "Targets": null,
+          "TenantInstanceId": "00000000-0000-0000-0000-000000000000",
+          "Title": "Sales"
+        },
+        {
+          "Description": null,
+          "ID": "b2c94ca1-0957-4bdd-b549-b7d365edc10f",
+          "LogoUrl": "http://contoso.com/__siteIcon__.jpg",
+          "SiteId": "b2c94ca1-0957-4bdd-b549-b7d365edc10f",
+          "SiteUrl": "https://contoso.sharepoint.com/sites/travelprograms",
+          "Targets": null,
+          "TenantInstanceId": "00000000-0000-0000-0000-000000000000",
+          "Title": "Travel Programs"
+        }
+      ]
+    });
+    sinon.stub(request, 'post').callsFake((opts) => {
+      if (opts.url.indexOf(`/_api/web/lists/GetByTitle('DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECOLLECTIONS')/RenderListDataAsStream`) > -1
+        && JSON.stringify(opts.body) === JSON.stringify({
+          parameters: {
+            ViewXml: "<View><Query><Where><And><And><IsNull><FieldRef Name=\"TimeDeleted\"/></IsNull><Neq><FieldRef Name=\"State\"/><Value Type='Integer'>0</Value></Neq></And><Neq><FieldRef Name=\"HubSiteId\"/><Value Type='Text'>{00000000-0000-0000-0000-000000000000}</Value></Neq></And></Where><OrderBy><FieldRef Name='Title' Ascending='true' /></OrderBy></Query><ViewFields><FieldRef Name=\"Title\"/><FieldRef Name=\"SiteUrl\"/><FieldRef Name=\"SiteId\"/><FieldRef Name=\"HubSiteId\"/></ViewFields><RowLimit Paged=\"TRUE\">100</RowLimit></View>",
+            DatesInUtc: true
+          }
+        })
+      ) {
+        return Promise.resolve({
+          FilterLink: "?",
+          FirstRow: 1,
+          FolderPermissions: "0x7fffffffffffffff",
+          ForceNoHierarchy: 1,
+          HierarchyHasIndention: null,
+          LastRow: 5,
+          Row: [{
+            "ID": "25",
+            "PermMask": "0x7fffffffffffffff",
+            "FSObjType": "0",
+            "ContentTypeId": "0x0100F14AFE642BCF6347882B6B8ABA3E15E3",
+            "FileRef": "/Lists/DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECO/25_.000",
+            "FileRef.urlencode": "%2FLists%2FDO%5FNOT%5FDELETE%5FSPLIST%5FTENANTADMIN%5FAGGREGATED%5FSITECO%2F25%5F%2E000",
+            "FileRef.urlencodeasurl": "/Lists/DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECO/25_.000",
+            "FileRef.urlencoding": "/Lists/DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECO/25_.000",
+            "ItemChildCount": "0",
+            "FolderChildCount": "0",
+            "SMTotalSize": "494",
+            "Title": "North",
+            "SiteUrl": "https://contoso.sharepoint.com/sites/north",
+            "HubSiteId": "{389D0D83-40BB-40AD-B92A-534B7CB37D0B}",
+            "TimeDeleted": "",
+            "State": "",
+            "State.": ""
+          }, {
+            "ID": "28",
+            "PermMask": "0x7fffffffffffffff",
+            "FSObjType": "0",
+            "ContentTypeId": "0x0100F14AFE642BCF6347882B6B8ABA3E15E3",
+            "FileRef": "/Lists/DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECO/28_.000",
+            "FileRef.urlencode": "%2FLists%2FDO%5FNOT%5FDELETE%5FSPLIST%5FTENANTADMIN%5FAGGREGATED%5FSITECO%2F28%5F%2E000",
+            "FileRef.urlencodeasurl": "/Lists/DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECO/28_.000",
+            "FileRef.urlencoding": "/Lists/DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECO/28_.000",
+            "ItemChildCount": "0",
+            "FolderChildCount": "0",
+            "SMTotalSize": "526",
+            "Title": "South",
+            "SiteUrl": "https://contoso.sharepoint.com/sites/south",
+            "HubSiteId": "{389D0D83-40BB-40AD-B92A-534B7CB37D0B}",
+            "TimeDeleted": "",
+            "State": "",
+            "State.": ""
+          }, {
+            "ID": "29",
+            "PermMask": "0x7fffffffffffffff",
+            "FSObjType": "0",
+            "ContentTypeId": "0x0100F14AFE642BCF6347882B6B8ABA3E15E3",
+            "FileRef": "/Lists/DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECO/29_.000",
+            "FileRef.urlencode": "%2FLists%2FDO%5FNOT%5FDELETE%5FSPLIST%5FTENANTADMIN%5FAGGREGATED%5FSITECO%2F29%5F%2E000",
+            "FileRef.urlencodeasurl": "/Lists/DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECO/29_.000",
+            "FileRef.urlencoding": "/Lists/DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECO/29_.000",
+            "ItemChildCount": "0",
+            "FolderChildCount": "0",
+            "SMTotalSize": "494",
+            "Title": "Europe",
+            "SiteUrl": "https://contoso.sharepoint.com/sites/europe",
+            "HubSiteId": "{B2C94CA1-0957-4BDD-B549-B7D365EDC10F}",
+            "TimeDeleted": "",
+            "State": "",
+            "State.": ""
+          }, {
+            "ID": "27",
+            "PermMask": "0x7fffffffffffffff",
+            "FSObjType": "0",
+            "ContentTypeId": "0x0100F14AFE642BCF6347882B6B8ABA3E15E3",
+            "FileRef": "/Lists/DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECO/27_.000",
+            "FileRef.urlencode": "%2FLists%2FDO%5FNOT%5FDELETE%5FSPLIST%5FTENANTADMIN%5FAGGREGATED%5FSITECO%2F27%5F%2E000",
+            "FileRef.urlencodeasurl": "/Lists/DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECO/27_.000",
+            "FileRef.urlencoding": "/Lists/DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECO/27_.000",
+            "ItemChildCount": "0",
+            "FolderChildCount": "0",
+            "SMTotalSize": "526",
+            "Title": "Asia",
+            "SiteUrl": "https://contoso.sharepoint.com/sites/asia",
+            "HubSiteId": "{B2C94CA1-0957-4BDD-B549-B7D365EDC10F}",
+            "TimeDeleted": "",
+            "State": "",
+            "State.": ""
+          }, {
+            "ID": "24",
+            "PermMask": "0x7fffffffffffffff",
+            "FSObjType": "0",
+            "ContentTypeId": "0x0100F14AFE642BCF6347882B6B8ABA3E15E3",
+            "FileRef": "/Lists/DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECO/24_.000",
+            "FileRef.urlencode": "%2FLists%2FDO%5FNOT%5FDELETE%5FSPLIST%5FTENANTADMIN%5FAGGREGATED%5FSITECO%2F24%5F%2E000",
+            "FileRef.urlencodeasurl": "/Lists/DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECO/24_.000",
+            "FileRef.urlencoding": "/Lists/DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECO/24_.000",
+            "ItemChildCount": "0",
+            "FolderChildCount": "0",
+            "SMTotalSize": "490",
+            "Title": "America",
+            "SiteUrl": "https://contoso.sharepoint.com/sites/america",
+            "HubSiteId": "{B2C94CA1-0957-4BDD-B549-B7D365EDC10F}",
+            "TimeDeleted": "",
+            "State": "",
+            "State.": ""
+          }],
+          RowLimit: 100
+        });
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    auth.site = new Site();
+    auth.site.connected = true;
+    auth.site.url = 'https://contoso.sharepoint.com';
+    cmdInstance.action = command.action();
+    cmdInstance.action({ options: { debug: false, includeAssociatedSites: true } }, () => {
+      try {
+        assert(cmdInstanceLogSpy.calledWith([
+          {
+            "AssociatedSites": ["North", "South"],
+            "ID": "389d0d83-40bb-40ad-b92a-534b7cb37d0b",
+            "SiteUrl": "https://contoso.sharepoint.com/sites/Sales",
+            "Title": "Sales"
+          },
+          {
+            "AssociatedSites": ["Europe", "Asia", "America"],
+            "ID": "b2c94ca1-0957-4bdd-b549-b7d365edc10f",
+            "SiteUrl": "https://contoso.sharepoint.com/sites/travelprograms",
+            "Title": "Travel Programs"
+          }
+        ]));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('lists hub sites, including associated sites, with all properties for JSON output', (done) => {
+    sinon.stub(request, 'get').resolves({
+      value: [
+        {
+          "Description": null,
+          "ID": "389d0d83-40bb-40ad-b92a-534b7cb37d0b",
+          "LogoUrl": "http://contoso.com/__siteIcon__.jpg",
+          "SiteId": "389d0d83-40bb-40ad-b92a-534b7cb37d0b",
+          "SiteUrl": "https://contoso.sharepoint.com/sites/Sales",
+          "Targets": null,
+          "TenantInstanceId": "00000000-0000-0000-0000-000000000000",
+          "Title": "Sales"
+        },
+        {
+          "Description": null,
+          "ID": "b2c94ca1-0957-4bdd-b549-b7d365edc10f",
+          "LogoUrl": "http://contoso.com/__siteIcon__.jpg",
+          "SiteId": "b2c94ca1-0957-4bdd-b549-b7d365edc10f",
+          "SiteUrl": "https://contoso.sharepoint.com/sites/travelprograms",
+          "Targets": null,
+          "TenantInstanceId": "00000000-0000-0000-0000-000000000000",
+          "Title": "Travel Programs"
+        }
+      ]
+    });
+    sinon.stub(request, 'post').callsFake((opts) => {
+      if (opts.url.indexOf(`/_api/web/lists/GetByTitle('DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECOLLECTIONS')/RenderListDataAsStream`) > -1
+        && JSON.stringify(opts.body) === JSON.stringify({
+          parameters: {
+            ViewXml: "<View><Query><Where><And><And><IsNull><FieldRef Name=\"TimeDeleted\"/></IsNull><Neq><FieldRef Name=\"State\"/><Value Type='Integer'>0</Value></Neq></And><Neq><FieldRef Name=\"HubSiteId\"/><Value Type='Text'>{00000000-0000-0000-0000-000000000000}</Value></Neq></And></Where><OrderBy><FieldRef Name='Title' Ascending='true' /></OrderBy></Query><ViewFields><FieldRef Name=\"Title\"/><FieldRef Name=\"SiteUrl\"/><FieldRef Name=\"SiteId\"/><FieldRef Name=\"HubSiteId\"/></ViewFields><RowLimit Paged=\"TRUE\">100</RowLimit></View>",
+            DatesInUtc: true
+          }
+        })
+      ) {
+        return Promise.resolve({
+          FilterLink: "?",
+          FirstRow: 1,
+          FolderPermissions: "0x7fffffffffffffff",
+          ForceNoHierarchy: 1,
+          HierarchyHasIndention: null,
+          LastRow: 5,
+          Row: [{
+            "ID": "25",
+            "PermMask": "0x7fffffffffffffff",
+            "FSObjType": "0",
+            "ContentTypeId": "0x0100F14AFE642BCF6347882B6B8ABA3E15E3",
+            "FileRef": "/Lists/DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECO/25_.000",
+            "FileRef.urlencode": "%2FLists%2FDO%5FNOT%5FDELETE%5FSPLIST%5FTENANTADMIN%5FAGGREGATED%5FSITECO%2F25%5F%2E000",
+            "FileRef.urlencodeasurl": "/Lists/DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECO/25_.000",
+            "FileRef.urlencoding": "/Lists/DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECO/25_.000",
+            "ItemChildCount": "0",
+            "FolderChildCount": "0",
+            "SMTotalSize": "494",
+            "Title": "North",
+            "SiteUrl": "https://contoso.sharepoint.com/sites/north",
+            "HubSiteId": "{389D0D83-40BB-40AD-B92A-534B7CB37D0B}",
+            "TimeDeleted": "",
+            "State": "",
+            "State.": ""
+          }, {
+            "ID": "28",
+            "PermMask": "0x7fffffffffffffff",
+            "FSObjType": "0",
+            "ContentTypeId": "0x0100F14AFE642BCF6347882B6B8ABA3E15E3",
+            "FileRef": "/Lists/DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECO/28_.000",
+            "FileRef.urlencode": "%2FLists%2FDO%5FNOT%5FDELETE%5FSPLIST%5FTENANTADMIN%5FAGGREGATED%5FSITECO%2F28%5F%2E000",
+            "FileRef.urlencodeasurl": "/Lists/DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECO/28_.000",
+            "FileRef.urlencoding": "/Lists/DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECO/28_.000",
+            "ItemChildCount": "0",
+            "FolderChildCount": "0",
+            "SMTotalSize": "526",
+            "Title": "South",
+            "SiteUrl": "https://contoso.sharepoint.com/sites/south",
+            "HubSiteId": "{389D0D83-40BB-40AD-B92A-534B7CB37D0B}",
+            "TimeDeleted": "",
+            "State": "",
+            "State.": ""
+          }, {
+            "ID": "29",
+            "PermMask": "0x7fffffffffffffff",
+            "FSObjType": "0",
+            "ContentTypeId": "0x0100F14AFE642BCF6347882B6B8ABA3E15E3",
+            "FileRef": "/Lists/DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECO/29_.000",
+            "FileRef.urlencode": "%2FLists%2FDO%5FNOT%5FDELETE%5FSPLIST%5FTENANTADMIN%5FAGGREGATED%5FSITECO%2F29%5F%2E000",
+            "FileRef.urlencodeasurl": "/Lists/DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECO/29_.000",
+            "FileRef.urlencoding": "/Lists/DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECO/29_.000",
+            "ItemChildCount": "0",
+            "FolderChildCount": "0",
+            "SMTotalSize": "494",
+            "Title": "Europe",
+            "SiteUrl": "https://contoso.sharepoint.com/sites/europe",
+            "HubSiteId": "{B2C94CA1-0957-4BDD-B549-B7D365EDC10F}",
+            "TimeDeleted": "",
+            "State": "",
+            "State.": ""
+          }, {
+            "ID": "27",
+            "PermMask": "0x7fffffffffffffff",
+            "FSObjType": "0",
+            "ContentTypeId": "0x0100F14AFE642BCF6347882B6B8ABA3E15E3",
+            "FileRef": "/Lists/DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECO/27_.000",
+            "FileRef.urlencode": "%2FLists%2FDO%5FNOT%5FDELETE%5FSPLIST%5FTENANTADMIN%5FAGGREGATED%5FSITECO%2F27%5F%2E000",
+            "FileRef.urlencodeasurl": "/Lists/DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECO/27_.000",
+            "FileRef.urlencoding": "/Lists/DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECO/27_.000",
+            "ItemChildCount": "0",
+            "FolderChildCount": "0",
+            "SMTotalSize": "526",
+            "Title": "Asia",
+            "SiteUrl": "https://contoso.sharepoint.com/sites/asia",
+            "HubSiteId": "{B2C94CA1-0957-4BDD-B549-B7D365EDC10F}",
+            "TimeDeleted": "",
+            "State": "",
+            "State.": ""
+          }, {
+            "ID": "24",
+            "PermMask": "0x7fffffffffffffff",
+            "FSObjType": "0",
+            "ContentTypeId": "0x0100F14AFE642BCF6347882B6B8ABA3E15E3",
+            "FileRef": "/Lists/DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECO/24_.000",
+            "FileRef.urlencode": "%2FLists%2FDO%5FNOT%5FDELETE%5FSPLIST%5FTENANTADMIN%5FAGGREGATED%5FSITECO%2F24%5F%2E000",
+            "FileRef.urlencodeasurl": "/Lists/DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECO/24_.000",
+            "FileRef.urlencoding": "/Lists/DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECO/24_.000",
+            "ItemChildCount": "0",
+            "FolderChildCount": "0",
+            "SMTotalSize": "490",
+            "Title": "America",
+            "SiteUrl": "https://contoso.sharepoint.com/sites/america",
+            "HubSiteId": "{B2C94CA1-0957-4BDD-B549-B7D365EDC10F}",
+            "TimeDeleted": "",
+            "State": "",
+            "State.": ""
+          }],
+          RowLimit: 100
+        });
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    auth.site = new Site();
+    auth.site.connected = true;
+    auth.site.url = 'https://contoso.sharepoint.com';
+    cmdInstance.action = command.action();
+    cmdInstance.action({ options: { debug: false, includeAssociatedSites: true, output: 'json' } }, () => {
+      try {
+        assert(cmdInstanceLogSpy.calledWith([
+          {
+            "Description": null,
+            "ID": "389d0d83-40bb-40ad-b92a-534b7cb37d0b",
+            "LogoUrl": "http://contoso.com/__siteIcon__.jpg",
+            "SiteId": "389d0d83-40bb-40ad-b92a-534b7cb37d0b",
+            "SiteUrl": "https://contoso.sharepoint.com/sites/Sales",
+            "Targets": null,
+            "TenantInstanceId": "00000000-0000-0000-0000-000000000000",
+            "Title": "Sales",
+            "AssociatedSites": [
+              {
+                "Title": "North",
+                "SiteUrl": "https://contoso.sharepoint.com/sites/north"
+              }
+              , {
+                "Title": "South",
+                "SiteUrl": "https://contoso.sharepoint.com/sites/south"
+              }
+            ]
+          },
+          {
+            "Description": null,
+            "ID": "b2c94ca1-0957-4bdd-b549-b7d365edc10f",
+            "LogoUrl": "http://contoso.com/__siteIcon__.jpg",
+            "SiteId": "b2c94ca1-0957-4bdd-b549-b7d365edc10f",
+            "SiteUrl": "https://contoso.sharepoint.com/sites/travelprograms",
+            "Targets": null,
+            "TenantInstanceId": "00000000-0000-0000-0000-000000000000",
+            "Title": "Travel Programs",
+            "AssociatedSites": [
+              {
+                "Title": "Europe",
+                "SiteUrl": "https://contoso.sharepoint.com/sites/europe"
+              },
+              {
+                "Title": "Asia",
+                "SiteUrl": "https://contoso.sharepoint.com/sites/asia"
+              },
+              {
+                "Title": "America",
+                "SiteUrl": "https://contoso.sharepoint.com/sites/america"
+              }
+            ]
           }
         ]));
         done();

--- a/src/o365/spo/commands/hubsite/hubsite-list.spec.ts
+++ b/src/o365/spo/commands/hubsite/hubsite-list.spec.ts
@@ -315,7 +315,7 @@ describe(commands.HUBSITE_LIST, () => {
       if (opts.url.indexOf(`/_api/web/lists/GetByTitle('DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECOLLECTIONS')/RenderListDataAsStream`) > -1
         && JSON.stringify(opts.body) === JSON.stringify({
           parameters: {
-            ViewXml: "<View><Query><Where><And><And><IsNull><FieldRef Name=\"TimeDeleted\"/></IsNull><Neq><FieldRef Name=\"State\"/><Value Type='Integer'>0</Value></Neq></And><Neq><FieldRef Name=\"HubSiteId\"/><Value Type='Text'>{00000000-0000-0000-0000-000000000000}</Value></Neq></And></Where><OrderBy><FieldRef Name='Title' Ascending='true' /></OrderBy></Query><ViewFields><FieldRef Name=\"Title\"/><FieldRef Name=\"SiteUrl\"/><FieldRef Name=\"SiteId\"/><FieldRef Name=\"HubSiteId\"/></ViewFields><RowLimit Paged=\"TRUE\">100</RowLimit></View>",
+            ViewXml: "<View><Query><Where><And><And><IsNull><FieldRef Name=\"TimeDeleted\"/></IsNull><Neq><FieldRef Name=\"State\"/><Value Type='Integer'>0</Value></Neq></And><Neq><FieldRef Name=\"HubSiteId\"/><Value Type='Text'>{00000000-0000-0000-0000-000000000000}</Value></Neq></And></Where><OrderBy><FieldRef Name='Title' Ascending='true' /></OrderBy></Query><ViewFields><FieldRef Name=\"Title\"/><FieldRef Name=\"SiteUrl\"/><FieldRef Name=\"SiteId\"/><FieldRef Name=\"HubSiteId\"/></ViewFields><RowLimit Paged=\"TRUE\">30</RowLimit></View>",
             DatesInUtc: true
           }
         })
@@ -482,7 +482,7 @@ describe(commands.HUBSITE_LIST, () => {
       if (opts.url.indexOf(`/_api/web/lists/GetByTitle('DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECOLLECTIONS')/RenderListDataAsStream`) > -1
         && JSON.stringify(opts.body) === JSON.stringify({
           parameters: {
-            ViewXml: "<View><Query><Where><And><And><IsNull><FieldRef Name=\"TimeDeleted\"/></IsNull><Neq><FieldRef Name=\"State\"/><Value Type='Integer'>0</Value></Neq></And><Neq><FieldRef Name=\"HubSiteId\"/><Value Type='Text'>{00000000-0000-0000-0000-000000000000}</Value></Neq></And></Where><OrderBy><FieldRef Name='Title' Ascending='true' /></OrderBy></Query><ViewFields><FieldRef Name=\"Title\"/><FieldRef Name=\"SiteUrl\"/><FieldRef Name=\"SiteId\"/><FieldRef Name=\"HubSiteId\"/></ViewFields><RowLimit Paged=\"TRUE\">100</RowLimit></View>",
+            ViewXml: "<View><Query><Where><And><And><IsNull><FieldRef Name=\"TimeDeleted\"/></IsNull><Neq><FieldRef Name=\"State\"/><Value Type='Integer'>0</Value></Neq></And><Neq><FieldRef Name=\"HubSiteId\"/><Value Type='Text'>{00000000-0000-0000-0000-000000000000}</Value></Neq></And></Where><OrderBy><FieldRef Name='Title' Ascending='true' /></OrderBy></Query><ViewFields><FieldRef Name=\"Title\"/><FieldRef Name=\"SiteUrl\"/><FieldRef Name=\"SiteId\"/><FieldRef Name=\"HubSiteId\"/></ViewFields><RowLimit Paged=\"TRUE\">30</RowLimit></View>",
             DatesInUtc: true
           }
         })
@@ -644,6 +644,265 @@ describe(commands.HUBSITE_LIST, () => {
             ]
           }
         ]));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('corrrectly retrieves the associated sites in batches', (done) => {
+    // Cast the command class instance to any so we can set the private
+    // property 'batchSize' to a small number for easier testing
+    const newBatchSize = 3;
+    (command as any).batchSize = newBatchSize;
+    let firstPagedRequest: boolean = false;
+    let secondPagedRequest: boolean = false;
+    let thirdPagedRequest: boolean = false;
+    sinon.stub(request, 'get').resolves({
+      value: [
+        {
+          "Description": null,
+          "ID": "389d0d83-40bb-40ad-b92a-534b7cb37d0b",
+          "LogoUrl": "http://contoso.com/__siteIcon__.jpg",
+          "SiteId": "389d0d83-40bb-40ad-b92a-534b7cb37d0b",
+          "SiteUrl": "https://contoso.sharepoint.com/sites/Sales",
+          "Targets": null,
+          "TenantInstanceId": "00000000-0000-0000-0000-000000000000",
+          "Title": "Sales"
+        },
+        {
+          "Description": null,
+          "ID": "b2c94ca1-0957-4bdd-b549-b7d365edc10f",
+          "LogoUrl": "http://contoso.com/__siteIcon__.jpg",
+          "SiteId": "b2c94ca1-0957-4bdd-b549-b7d365edc10f",
+          "SiteUrl": "https://contoso.sharepoint.com/sites/travelprograms",
+          "Targets": null,
+          "TenantInstanceId": "00000000-0000-0000-0000-000000000000",
+          "Title": "Travel Programs"
+        }
+      ]
+    });
+    sinon.stub(request, 'post').callsFake((opts) => {
+      if (opts.url.indexOf(`/_api/web/lists/GetByTitle('DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECOLLECTIONS')/RenderListDataAsStream`) > -1
+        && opts.body.parameters.ViewXml.indexOf('<RowLimit Paged="TRUE">' + newBatchSize + '</RowLimit>') > -1) {
+        if (opts.url.indexOf('?Paged=TRUE') == -1) {
+          firstPagedRequest = true;
+          return Promise.resolve({
+            FilterLink : "?",
+            FirstRow: 1,
+            FolderPermissions: "0x7fffffffffffffff",
+            ForceNoHierarchy: 1,
+            HierarchyHasIndention: null,
+            LastRow: 3,
+            NextHref: "?Paged=TRUE&p_Title=Another%20Hub%20Sub%202&p_ID=32&PageFirstRow=4&View=00000000-0000-0000-0000-00000000000",
+            Row: [{"ID":"30","PermMask":"0x7fffffffffffffff","FSObjType":"0","ContentTypeId":"0x0100F14AFE642BCF6347882B6B8ABA3E15E3","FileRef":"/Lists/DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECO/30_.000","FileRef.urlencode":"%2FLists%2FDO%5FNOT%5FDELETE%5FSPLIST%5FTENANTADMIN%5FAGGREGATED%5FSITECO%2F30%5F%2E000","FileRef.urlencodeasurl":"/Lists/DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECO/30_.000","FileRef.urlencoding":"/Lists/DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECO/30_.000","ItemChildCount":"0","FolderChildCount":"0","SMTotalSize":"554","Title":"Another Hub Root","SiteUrl":"https://bloemium.sharepoint.com/sites/AnotherHubRoot","SiteId":"{E9E2090B-1F51-47EA-8466-75D5A244217E}","HubSiteId":"{E9E2090B-1F51-47EA-8466-75D5A244217E}","TimeDeleted":"","State":"","State.":""},{"ID":"31","PermMask":"0x7fffffffffffffff","FSObjType":"0","ContentTypeId":"0x0100F14AFE642BCF6347882B6B8ABA3E15E3","FileRef":"/Lists/DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECO/31_.000","FileRef.urlencode":"%2FLists%2FDO%5FNOT%5FDELETE%5FSPLIST%5FTENANTADMIN%5FAGGREGATED%5FSITECO%2F31%5F%2E000","FileRef.urlencodeasurl":"/Lists/DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECO/31_.000","FileRef.urlencoding":"/Lists/DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECO/31_.000","ItemChildCount":"0","FolderChildCount":"0","SMTotalSize":"556","Title":"Another Hub Sub 1","SiteUrl":"https://bloemium.sharepoint.com/sites/AnotherHubSub1","SiteId":"{3A569D44-D3CD-45AB-9AB8-87675D18AF63}","HubSiteId":"{E9E2090B-1F51-47EA-8466-75D5A244217E}","TimeDeleted":"","State":"","State.":""},{"ID":"32","PermMask":"0x7fffffffffffffff","FSObjType":"0","ContentTypeId":"0x0100F14AFE642BCF6347882B6B8ABA3E15E3","FileRef":"/Lists/DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECO/32_.000","FileRef.urlencode":"%2FLists%2FDO%5FNOT%5FDELETE%5FSPLIST%5FTENANTADMIN%5FAGGREGATED%5FSITECO%2F32%5F%2E000","FileRef.urlencodeasurl":"/Lists/DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECO/32_.000","FileRef.urlencoding":"/Lists/DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECO/32_.000","ItemChildCount":"0","FolderChildCount":"0","SMTotalSize":"556","Title":"Another Hub Sub 2","SiteUrl":"https://bloemium.sharepoint.com/sites/AnotherHubSub2","SiteId":"{794FE8EC-458F-444B-A799-E179AB786784}","HubSiteId":"{E9E2090B-1F51-47EA-8466-75D5A244217E}","TimeDeleted":"","State":"","State.":""}],
+            RowLimit: 3
+          });
+        }
+        if (opts.url.indexOf('?Paged=TRUE&p_Title=Another%20Hub%20Sub%202&p_ID=32&PageFirstRow=4&View=00000000-0000-0000-0000-00000000000') > -1) {
+          secondPagedRequest = true
+          return Promise.resolve({
+            FilterLink : "?",
+            FirstRow: 4,
+            FolderPermissions: "0x7fffffffffffffff",
+            ForceNoHierarchy: 1,
+            HierarchyHasIndention: null,
+            LastRow: 6,
+            NextHref: "?Paged=TRUE&p_Title=Hub%20sub%204&p_ID=29&PageFirstRow=7&View=00000000-0000-0000-0000-00000000000",
+            PrevHref: "?&&p_Title=Hub%20sub%201&&PageFirstRow=1&View=00000000-0000-0000-0000-000000000000",
+            Row: [{"ID":"25","PermMask":"0x7fffffffffffffff","FSObjType":"0","ContentTypeId":"0x0100F14AFE642BCF6347882B6B8ABA3E15E3","FileRef":"/Lists/DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECO/25_.000","FileRef.urlencode":"%2FLists%2FDO%5FNOT%5FDELETE%5FSPLIST%5FTENANTADMIN%5FAGGREGATED%5FSITECO%2F25%5F%2E000","FileRef.urlencodeasurl":"/Lists/DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECO/25_.000","FileRef.urlencoding":"/Lists/DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECO/25_.000","ItemChildCount":"0","FolderChildCount":"0","SMTotalSize":"518","Title":"Hub sub 1","SiteUrl":"https://bloemium.sharepoint.com/sites/Hubsub1","SiteId":"{83C2E5B0-DC64-4040-AB1F-A6A9A8169E46}","HubSiteId":"{77F50C57-C40A-4666-83F5-D325567512BE}","TimeDeleted":"","State":"","State.":""},{"ID":"28","PermMask":"0x7fffffffffffffff","FSObjType":"0","ContentTypeId":"0x0100F14AFE642BCF6347882B6B8ABA3E15E3","FileRef":"/Lists/DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECO/28_.000","FileRef.urlencode":"%2FLists%2FDO%5FNOT%5FDELETE%5FSPLIST%5FTENANTADMIN%5FAGGREGATED%5FSITECO%2F28%5F%2E000","FileRef.urlencodeasurl":"/Lists/DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECO/28_.000","FileRef.urlencoding":"/Lists/DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECO/28_.000","ItemChildCount":"0","FolderChildCount":"0","SMTotalSize":"550","Title":"Hub sub 3","SiteUrl":"https://bloemium.sharepoint.com/sites/Hubsub3","SiteId":"{5509F9AC-ECF8-488A-B960-BEDF4D8FB321}","HubSiteId":"{77F50C57-C40A-4666-83F5-D325567512BE}","TimeDeleted":"","State":"","State.":""},{"ID":"29","PermMask":"0x7fffffffffffffff","FSObjType":"0","ContentTypeId":"0x0100F14AFE642BCF6347882B6B8ABA3E15E3","FileRef":"/Lists/DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECO/29_.000","FileRef.urlencode":"%2FLists%2FDO%5FNOT%5FDELETE%5FSPLIST%5FTENANTADMIN%5FAGGREGATED%5FSITECO%2F29%5F%2E000","FileRef.urlencodeasurl":"/Lists/DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECO/29_.000","FileRef.urlencoding":"/Lists/DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECO/29_.000","ItemChildCount":"0","FolderChildCount":"0","SMTotalSize":"518","Title":"Hub sub 4","SiteUrl":"https://bloemium.sharepoint.com/sites/Hubsub4","SiteId":"{8AC9E1ED-29B8-4342-AF30-11F597731F8A}","HubSiteId":"{77F50C57-C40A-4666-83F5-D325567512BE}","TimeDeleted":"","State":"","State.":""}],
+            RowLimit: 3
+          });
+        } 
+        if (opts.url.indexOf('?Paged=TRUE&p_Title=Hub%20sub%204&p_ID=29&PageFirstRow=7&View=00000000-0000-0000-0000-00000000000') > -1) {
+          thirdPagedRequest = true;
+          return Promise.resolve({
+            FilterLink : "?",
+            FirstRow: 7,
+            FolderPermissions: "0x7fffffffffffffff",
+            ForceNoHierarchy: 1,
+            HierarchyHasIndention: null,
+            LastRow: 8,
+            PrevHref: "?Paged=TRUE&PagedPrev=TRUE&p_Title=Hub%20sub%20x&p_ID=27&PageFirstRow=4&View=00000000-0000-0000-0000-000000000000",
+            Row: [{"ID":"27","PermMask":"0x7fffffffffffffff","FSObjType":"0","ContentTypeId":"0x0100F14AFE642BCF6347882B6B8ABA3E15E3","FileRef":"/Lists/DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECO/27_.000","FileRef.urlencode":"%2FLists%2FDO%5FNOT%5FDELETE%5FSPLIST%5FTENANTADMIN%5FAGGREGATED%5FSITECO%2F27%5F%2E000","FileRef.urlencodeasurl":"/Lists/DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECO/27_.000","FileRef.urlencoding":"/Lists/DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECO/27_.000","ItemChildCount":"0","FolderChildCount":"0","SMTotalSize":"550","Title":"Hub sub x","SiteUrl":"https://bloemium.sharepoint.com/sites/Hubsubx","SiteId":"{DC0D0D79-1B0D-45A7-A8EE-7B97679B79DE}","HubSiteId":"{77F50C57-C40A-4666-83F5-D325567512BE}","TimeDeleted":"","State":"","State.":""},{"ID":"24","PermMask":"0x7fffffffffffffff","FSObjType":"0","ContentTypeId":"0x0100F14AFE642BCF6347882B6B8ABA3E15E3","FileRef":"/Lists/DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECO/24_.000","FileRef.urlencode":"%2FLists%2FDO%5FNOT%5FDELETE%5FSPLIST%5FTENANTADMIN%5FAGGREGATED%5FSITECO%2F24%5F%2E000","FileRef.urlencodeasurl":"/Lists/DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECO/24_.000","FileRef.urlencoding":"/Lists/DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECO/24_.000","ItemChildCount":"0","FolderChildCount":"0","SMTotalSize":"514","Title":"Root Hub","SiteUrl":"https://bloemium.sharepoint.com/sites/RootHub","SiteId":"{77F50C57-C40A-4666-83F5-D325567512BE}","HubSiteId":"{77F50C57-C40A-4666-83F5-D325567512BE}","TimeDeleted":"","State":"","State.":""}],
+            RowLimit: 3
+          });
+        }
+        return Promise.reject('Invalid request');
+      }
+      return Promise.reject('Invalid request');
+    });
+    auth.site = new Site();
+    auth.site.connected = true;
+    auth.site.url = 'https://contoso.sharepoint.com';
+    cmdInstance.action = command.action();
+    cmdInstance.action({ options: { debug: false, includeAssociatedSites: true, output: 'json' } }, () => {
+      try {
+        assert.equal((firstPagedRequest && secondPagedRequest && thirdPagedRequest), true);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('corrrectly retrieves the associated sites in batches (debug)', (done) => {
+    // Cast the command class instance to any so we can set the private
+    // property 'batchSize' to a small number for easier testing
+    const newBatchSize = 3;
+    (command as any).batchSize = newBatchSize;
+    let firstPagedRequest: boolean = false;
+    let secondPagedRequest: boolean = false;
+    let thirdPagedRequest: boolean = false;
+    sinon.stub(request, 'get').resolves({
+      value: [
+        {
+          "Description": null,
+          "ID": "389d0d83-40bb-40ad-b92a-534b7cb37d0b",
+          "LogoUrl": "http://contoso.com/__siteIcon__.jpg",
+          "SiteId": "389d0d83-40bb-40ad-b92a-534b7cb37d0b",
+          "SiteUrl": "https://contoso.sharepoint.com/sites/Sales",
+          "Targets": null,
+          "TenantInstanceId": "00000000-0000-0000-0000-000000000000",
+          "Title": "Sales"
+        },
+        {
+          "Description": null,
+          "ID": "b2c94ca1-0957-4bdd-b549-b7d365edc10f",
+          "LogoUrl": "http://contoso.com/__siteIcon__.jpg",
+          "SiteId": "b2c94ca1-0957-4bdd-b549-b7d365edc10f",
+          "SiteUrl": "https://contoso.sharepoint.com/sites/travelprograms",
+          "Targets": null,
+          "TenantInstanceId": "00000000-0000-0000-0000-000000000000",
+          "Title": "Travel Programs"
+        }
+      ]
+    });
+    sinon.stub(request, 'post').callsFake((opts) => {
+      if (opts.url.indexOf(`/_api/web/lists/GetByTitle('DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECOLLECTIONS')/RenderListDataAsStream`) > -1
+        && opts.body.parameters.ViewXml.indexOf('<RowLimit Paged="TRUE">' + newBatchSize + '</RowLimit>') > -1) {
+        if (opts.url.indexOf('?Paged=TRUE') == -1) {
+          firstPagedRequest = true;
+          return Promise.resolve({
+            FilterLink : "?",
+            FirstRow: 1,
+            FolderPermissions: "0x7fffffffffffffff",
+            ForceNoHierarchy: 1,
+            HierarchyHasIndention: null,
+            LastRow: 3,
+            NextHref: "?Paged=TRUE&p_Title=Another%20Hub%20Sub%202&p_ID=32&PageFirstRow=4&View=00000000-0000-0000-0000-00000000000",
+            Row: [{"ID":"30","PermMask":"0x7fffffffffffffff","FSObjType":"0","ContentTypeId":"0x0100F14AFE642BCF6347882B6B8ABA3E15E3","FileRef":"/Lists/DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECO/30_.000","FileRef.urlencode":"%2FLists%2FDO%5FNOT%5FDELETE%5FSPLIST%5FTENANTADMIN%5FAGGREGATED%5FSITECO%2F30%5F%2E000","FileRef.urlencodeasurl":"/Lists/DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECO/30_.000","FileRef.urlencoding":"/Lists/DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECO/30_.000","ItemChildCount":"0","FolderChildCount":"0","SMTotalSize":"554","Title":"Another Hub Root","SiteUrl":"https://bloemium.sharepoint.com/sites/AnotherHubRoot","SiteId":"{E9E2090B-1F51-47EA-8466-75D5A244217E}","HubSiteId":"{E9E2090B-1F51-47EA-8466-75D5A244217E}","TimeDeleted":"","State":"","State.":""},{"ID":"31","PermMask":"0x7fffffffffffffff","FSObjType":"0","ContentTypeId":"0x0100F14AFE642BCF6347882B6B8ABA3E15E3","FileRef":"/Lists/DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECO/31_.000","FileRef.urlencode":"%2FLists%2FDO%5FNOT%5FDELETE%5FSPLIST%5FTENANTADMIN%5FAGGREGATED%5FSITECO%2F31%5F%2E000","FileRef.urlencodeasurl":"/Lists/DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECO/31_.000","FileRef.urlencoding":"/Lists/DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECO/31_.000","ItemChildCount":"0","FolderChildCount":"0","SMTotalSize":"556","Title":"Another Hub Sub 1","SiteUrl":"https://bloemium.sharepoint.com/sites/AnotherHubSub1","SiteId":"{3A569D44-D3CD-45AB-9AB8-87675D18AF63}","HubSiteId":"{E9E2090B-1F51-47EA-8466-75D5A244217E}","TimeDeleted":"","State":"","State.":""},{"ID":"32","PermMask":"0x7fffffffffffffff","FSObjType":"0","ContentTypeId":"0x0100F14AFE642BCF6347882B6B8ABA3E15E3","FileRef":"/Lists/DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECO/32_.000","FileRef.urlencode":"%2FLists%2FDO%5FNOT%5FDELETE%5FSPLIST%5FTENANTADMIN%5FAGGREGATED%5FSITECO%2F32%5F%2E000","FileRef.urlencodeasurl":"/Lists/DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECO/32_.000","FileRef.urlencoding":"/Lists/DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECO/32_.000","ItemChildCount":"0","FolderChildCount":"0","SMTotalSize":"556","Title":"Another Hub Sub 2","SiteUrl":"https://bloemium.sharepoint.com/sites/AnotherHubSub2","SiteId":"{794FE8EC-458F-444B-A799-E179AB786784}","HubSiteId":"{E9E2090B-1F51-47EA-8466-75D5A244217E}","TimeDeleted":"","State":"","State.":""}],
+            RowLimit: 3
+          });
+        }
+        if (opts.url.indexOf('?Paged=TRUE&p_Title=Another%20Hub%20Sub%202&p_ID=32&PageFirstRow=4&View=00000000-0000-0000-0000-00000000000') > -1) {
+          secondPagedRequest = true
+          return Promise.resolve({
+            FilterLink : "?",
+            FirstRow: 4,
+            FolderPermissions: "0x7fffffffffffffff",
+            ForceNoHierarchy: 1,
+            HierarchyHasIndention: null,
+            LastRow: 6,
+            NextHref: "?Paged=TRUE&p_Title=Hub%20sub%204&p_ID=29&PageFirstRow=7&View=00000000-0000-0000-0000-00000000000",
+            PrevHref: "?&&p_Title=Hub%20sub%201&&PageFirstRow=1&View=00000000-0000-0000-0000-000000000000",
+            Row: [{"ID":"25","PermMask":"0x7fffffffffffffff","FSObjType":"0","ContentTypeId":"0x0100F14AFE642BCF6347882B6B8ABA3E15E3","FileRef":"/Lists/DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECO/25_.000","FileRef.urlencode":"%2FLists%2FDO%5FNOT%5FDELETE%5FSPLIST%5FTENANTADMIN%5FAGGREGATED%5FSITECO%2F25%5F%2E000","FileRef.urlencodeasurl":"/Lists/DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECO/25_.000","FileRef.urlencoding":"/Lists/DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECO/25_.000","ItemChildCount":"0","FolderChildCount":"0","SMTotalSize":"518","Title":"Hub sub 1","SiteUrl":"https://bloemium.sharepoint.com/sites/Hubsub1","SiteId":"{83C2E5B0-DC64-4040-AB1F-A6A9A8169E46}","HubSiteId":"{77F50C57-C40A-4666-83F5-D325567512BE}","TimeDeleted":"","State":"","State.":""},{"ID":"28","PermMask":"0x7fffffffffffffff","FSObjType":"0","ContentTypeId":"0x0100F14AFE642BCF6347882B6B8ABA3E15E3","FileRef":"/Lists/DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECO/28_.000","FileRef.urlencode":"%2FLists%2FDO%5FNOT%5FDELETE%5FSPLIST%5FTENANTADMIN%5FAGGREGATED%5FSITECO%2F28%5F%2E000","FileRef.urlencodeasurl":"/Lists/DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECO/28_.000","FileRef.urlencoding":"/Lists/DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECO/28_.000","ItemChildCount":"0","FolderChildCount":"0","SMTotalSize":"550","Title":"Hub sub 3","SiteUrl":"https://bloemium.sharepoint.com/sites/Hubsub3","SiteId":"{5509F9AC-ECF8-488A-B960-BEDF4D8FB321}","HubSiteId":"{77F50C57-C40A-4666-83F5-D325567512BE}","TimeDeleted":"","State":"","State.":""},{"ID":"29","PermMask":"0x7fffffffffffffff","FSObjType":"0","ContentTypeId":"0x0100F14AFE642BCF6347882B6B8ABA3E15E3","FileRef":"/Lists/DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECO/29_.000","FileRef.urlencode":"%2FLists%2FDO%5FNOT%5FDELETE%5FSPLIST%5FTENANTADMIN%5FAGGREGATED%5FSITECO%2F29%5F%2E000","FileRef.urlencodeasurl":"/Lists/DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECO/29_.000","FileRef.urlencoding":"/Lists/DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECO/29_.000","ItemChildCount":"0","FolderChildCount":"0","SMTotalSize":"518","Title":"Hub sub 4","SiteUrl":"https://bloemium.sharepoint.com/sites/Hubsub4","SiteId":"{8AC9E1ED-29B8-4342-AF30-11F597731F8A}","HubSiteId":"{77F50C57-C40A-4666-83F5-D325567512BE}","TimeDeleted":"","State":"","State.":""}],
+            RowLimit: 3
+          });
+        } 
+        if (opts.url.indexOf('?Paged=TRUE&p_Title=Hub%20sub%204&p_ID=29&PageFirstRow=7&View=00000000-0000-0000-0000-00000000000') > -1) {
+          thirdPagedRequest = true;
+          return Promise.resolve({
+            FilterLink : "?",
+            FirstRow: 7,
+            FolderPermissions: "0x7fffffffffffffff",
+            ForceNoHierarchy: 1,
+            HierarchyHasIndention: null,
+            LastRow: 8,
+            PrevHref: "?Paged=TRUE&PagedPrev=TRUE&p_Title=Hub%20sub%20x&p_ID=27&PageFirstRow=4&View=00000000-0000-0000-0000-000000000000",
+            Row: [{"ID":"27","PermMask":"0x7fffffffffffffff","FSObjType":"0","ContentTypeId":"0x0100F14AFE642BCF6347882B6B8ABA3E15E3","FileRef":"/Lists/DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECO/27_.000","FileRef.urlencode":"%2FLists%2FDO%5FNOT%5FDELETE%5FSPLIST%5FTENANTADMIN%5FAGGREGATED%5FSITECO%2F27%5F%2E000","FileRef.urlencodeasurl":"/Lists/DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECO/27_.000","FileRef.urlencoding":"/Lists/DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECO/27_.000","ItemChildCount":"0","FolderChildCount":"0","SMTotalSize":"550","Title":"Hub sub x","SiteUrl":"https://bloemium.sharepoint.com/sites/Hubsubx","SiteId":"{DC0D0D79-1B0D-45A7-A8EE-7B97679B79DE}","HubSiteId":"{77F50C57-C40A-4666-83F5-D325567512BE}","TimeDeleted":"","State":"","State.":""},{"ID":"24","PermMask":"0x7fffffffffffffff","FSObjType":"0","ContentTypeId":"0x0100F14AFE642BCF6347882B6B8ABA3E15E3","FileRef":"/Lists/DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECO/24_.000","FileRef.urlencode":"%2FLists%2FDO%5FNOT%5FDELETE%5FSPLIST%5FTENANTADMIN%5FAGGREGATED%5FSITECO%2F24%5F%2E000","FileRef.urlencodeasurl":"/Lists/DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECO/24_.000","FileRef.urlencoding":"/Lists/DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECO/24_.000","ItemChildCount":"0","FolderChildCount":"0","SMTotalSize":"514","Title":"Root Hub","SiteUrl":"https://bloemium.sharepoint.com/sites/RootHub","SiteId":"{77F50C57-C40A-4666-83F5-D325567512BE}","HubSiteId":"{77F50C57-C40A-4666-83F5-D325567512BE}","TimeDeleted":"","State":"","State.":""}],
+            RowLimit: 3
+          });
+        }
+        return Promise.reject('Invalid request');
+      }
+      return Promise.reject('Invalid request');
+    });
+    auth.site = new Site();
+    auth.site.connected = true;
+    auth.site.url = 'https://contoso.sharepoint.com';
+    cmdInstance.action = command.action();
+    cmdInstance.action({ options: { debug: true, includeAssociatedSites: true, output: 'json' } }, () => {
+      try {
+        assert.equal((firstPagedRequest && secondPagedRequest && thirdPagedRequest), true);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('corrrectly handles empty result while retrieving associated sites in batches', (done) => {
+    // Cast the command class instance to any so we can set the private
+    // property 'batchSize' to a small number for easier testing
+    const newBatchSize = 3;
+    (command as any).batchSize = newBatchSize;
+    let firstPagedRequest: boolean = false;
+    sinon.stub(request, 'get').resolves({
+      value: [
+        {
+          "Description": null,
+          "ID": "389d0d83-40bb-40ad-b92a-534b7cb37d0b",
+          "LogoUrl": "http://contoso.com/__siteIcon__.jpg",
+          "SiteId": "389d0d83-40bb-40ad-b92a-534b7cb37d0b",
+          "SiteUrl": "https://contoso.sharepoint.com/sites/Sales",
+          "Targets": null,
+          "TenantInstanceId": "00000000-0000-0000-0000-000000000000",
+          "Title": "Sales"
+        },
+        {
+          "Description": null,
+          "ID": "b2c94ca1-0957-4bdd-b549-b7d365edc10f",
+          "LogoUrl": "http://contoso.com/__siteIcon__.jpg",
+          "SiteId": "b2c94ca1-0957-4bdd-b549-b7d365edc10f",
+          "SiteUrl": "https://contoso.sharepoint.com/sites/travelprograms",
+          "Targets": null,
+          "TenantInstanceId": "00000000-0000-0000-0000-000000000000",
+          "Title": "Travel Programs"
+        }
+      ]
+    });
+    sinon.stub(request, 'post').callsFake((opts) => {
+      if (opts.url.indexOf(`/_api/web/lists/GetByTitle('DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECOLLECTIONS')/RenderListDataAsStream`) > -1
+        && opts.body.parameters.ViewXml.indexOf('<RowLimit Paged="TRUE">' + newBatchSize + '</RowLimit>') > -1) {
+        if (opts.url.indexOf('?Paged=TRUE') == -1) {
+          firstPagedRequest = true;
+          return Promise.resolve({
+            FilterLink : "?",
+            FirstRow: 1,
+            FolderPermissions: "0x7fffffffffffffff",
+            ForceNoHierarchy: 1,
+            HierarchyHasIndention: null,
+            LastRow: 0,
+            Row: [],
+            RowLimit: 3
+          });
+        }
+        return Promise.reject('Invalid request');
+      }
+      return Promise.reject('Invalid request');
+    });
+    auth.site = new Site();
+    auth.site.connected = true;
+    auth.site.url = 'https://contoso.sharepoint.com';
+    cmdInstance.action = command.action();
+    cmdInstance.action({ options: { debug: true, includeAssociatedSites: true, output: 'json' } }, () => {
+      try {
+        assert.equal(firstPagedRequest, true);
         done();
       }
       catch (e) {

--- a/src/o365/spo/commands/hubsite/hubsite-list.spec.ts
+++ b/src/o365/spo/commands/hubsite/hubsite-list.spec.ts
@@ -286,7 +286,7 @@ describe(commands.HUBSITE_LIST, () => {
     });
   });
 
-  it('lists hub sites including their associated sites', (done) => {
+  it('does not list associated sites allong the hub sites, if the includeAssociatedSites option is provided, if the output is TEXT', (done) => {
     sinon.stub(request, 'get').resolves({
       value: [
         {
@@ -433,13 +433,11 @@ describe(commands.HUBSITE_LIST, () => {
       try {
         assert(cmdInstanceLogSpy.calledWith([
           {
-            "AssociatedSites": ["North", "South"],
             "ID": "389d0d83-40bb-40ad-b92a-534b7cb37d0b",
             "SiteUrl": "https://contoso.sharepoint.com/sites/Sales",
             "Title": "Sales"
           },
           {
-            "AssociatedSites": ["Europe", "Asia", "America"],
             "ID": "b2c94ca1-0957-4bdd-b549-b7d365edc10f",
             "SiteUrl": "https://contoso.sharepoint.com/sites/travelprograms",
             "Title": "Travel Programs"

--- a/src/o365/spo/commands/hubsite/hubsite-list.ts
+++ b/src/o365/spo/commands/hubsite/hubsite-list.ts
@@ -20,6 +20,8 @@ interface Options extends GlobalOptions {
 }
 
 class SpoHubSiteListCommand extends SpoCommand {
+  private batchSize: number = 30;
+
   public get name(): string {
     return `${commands.HUBSITE_LIST}`;
   }
@@ -34,7 +36,7 @@ class SpoHubSiteListCommand extends SpoCommand {
     return telemetryProps;
   }
 
-  public commandAction(cmd: CommandInstance, args: CommandArgs, cb: () => void, listQueryBatchSize: number = 30): void {
+  public commandAction(cmd: CommandInstance, args: CommandArgs, cb: () => void): void {
     let hubSites: HubSite[];
 
     auth
@@ -61,7 +63,7 @@ class SpoHubSiteListCommand extends SpoCommand {
 
         return request.get(requestOptions);
       })
-      .then((res: { value: HubSite[] }): Promise<any[]> => {
+      .then((res: { value: HubSite[] }): Promise<any[]|void>=> {
         if (this.debug) {
           cmd.log('Response:');
           cmd.log(res);
@@ -71,7 +73,7 @@ class SpoHubSiteListCommand extends SpoCommand {
         hubSites = res.value;
 
         if (args.options.includeAssociatedSites !== true) {
-          return Promise.resolve([]);
+          return Promise.resolve();
         } else {
           if (this.debug) {
             cmd.log('Retrieving associated sites...');
@@ -88,7 +90,7 @@ class SpoHubSiteListCommand extends SpoCommand {
           json: true,
           body: {
             parameters: {
-              ViewXml: "<View><Query><Where><And><And><IsNull><FieldRef Name=\"TimeDeleted\"/></IsNull><Neq><FieldRef Name=\"State\"/><Value Type='Integer'>0</Value></Neq></And><Neq><FieldRef Name=\"HubSiteId\"/><Value Type='Text'>{00000000-0000-0000-0000-000000000000}</Value></Neq></And></Where><OrderBy><FieldRef Name='Title' Ascending='true' /></OrderBy></Query><ViewFields><FieldRef Name=\"Title\"/><FieldRef Name=\"SiteUrl\"/><FieldRef Name=\"SiteId\"/><FieldRef Name=\"HubSiteId\"/></ViewFields><RowLimit Paged=\"TRUE\">" + listQueryBatchSize + "</RowLimit></View>",
+              ViewXml: "<View><Query><Where><And><And><IsNull><FieldRef Name=\"TimeDeleted\"/></IsNull><Neq><FieldRef Name=\"State\"/><Value Type='Integer'>0</Value></Neq></And><Neq><FieldRef Name=\"HubSiteId\"/><Value Type='Text'>{00000000-0000-0000-0000-000000000000}</Value></Neq></And></Where><OrderBy><FieldRef Name='Title' Ascending='true' /></OrderBy></Query><ViewFields><FieldRef Name=\"Title\"/><FieldRef Name=\"SiteUrl\"/><FieldRef Name=\"SiteId\"/><FieldRef Name=\"HubSiteId\"/></ViewFields><RowLimit Paged=\"TRUE\">" + this.batchSize + "</RowLimit></View>",
               DatesInUtc: true
             }
           }
@@ -101,21 +103,22 @@ class SpoHubSiteListCommand extends SpoCommand {
         }
 
         if (this.debug || this.verbose) {
-          cmd.log(`Will retrieve associated sites (including the hub sites) in batches of ${listQueryBatchSize}`);
+          cmd.log(`Will retrieve associated sites (including the hub sites) in batches of ${this.batchSize}`);
         }
-        const getSites = async (reqOptions: any, nonPagedUrl: string, sites: any[]): Promise<any> => {
-          try {
+        const getSites = async (reqOptions: any, nonPagedUrl: string, sites: any[] = [], batchNumber: number = 0): Promise<any> => {
             const res: QueryListResult = await request.post(requestOptions);
-            const retreivedSites = sites.concat(res.Row);
+            batchNumber++;
+            const retreivedSites = res.Row.length > 0 ? sites.concat(res.Row) : sites;
             if (this.debug || this.verbose) {
-              cmd.log(`Retrieved ${res.Row.length} sites`);
+              cmd.log(res);
+              cmd.log(`Retrieved ${res.Row.length} sites in batch ${batchNumber}`);
             }
             if (!!res.NextHref) {
               reqOptions.url = nonPagedUrl + res.NextHref;
               if (this.debug) {
                 cmd.log(`Url for next batch of sites: ${reqOptions.url}`);
               }
-              return getSites(reqOptions, nonPagedUrl, retreivedSites);
+              return getSites(reqOptions, nonPagedUrl, retreivedSites, batchNumber);
             }
             else {
               if (this.debug || this.verbose) {
@@ -123,15 +126,11 @@ class SpoHubSiteListCommand extends SpoCommand {
               }
               return retreivedSites;
             }
-          }
-          catch (error) {
-            Promise.reject(new Error(error));
-          }
         }
 
-        return getSites(requestOptions, requestOptions.url, []);
+        return getSites(requestOptions, requestOptions.url);
       })
-      .then((res: any[]): void => {
+      .then((res: any[]|void): void => {
         if (this.debug) {
           cmd.log('Response:');
           cmd.log(res);

--- a/src/o365/spo/commands/hubsite/hubsite-list.ts
+++ b/src/o365/spo/commands/hubsite/hubsite-list.ts
@@ -30,6 +30,11 @@ class SpoHubSiteListCommand extends SpoCommand {
     return 'Lists hub sites in the current tenant';
   }
 
+  constructor() {
+    super()/* istanbul ignore next */;
+    this.batchSize = 30;
+  }
+
   public getTelemetryProperties(args: CommandArgs): any {
     const telemetryProps: any = super.getTelemetryProperties(args);
     telemetryProps.classifications = args.options.includeAssociatedSites === true;
@@ -72,7 +77,7 @@ class SpoHubSiteListCommand extends SpoCommand {
 
         hubSites = res.value;
 
-        if (args.options.includeAssociatedSites !== true) {
+        if (args.options.includeAssociatedSites !== true || args.options.output !== 'json') {
           return Promise.resolve();
         } else {
           if (this.debug) {
@@ -158,16 +163,6 @@ class SpoHubSiteListCommand extends SpoCommand {
         if (args.options.output === 'json') {
           cmd.log(hubSites);
         }
-        else if (args.options.includeAssociatedSites === true) {
-          cmd.log(hubSites.map(h => {
-            return {
-              ID: h.ID,
-              SiteUrl: h.SiteUrl,
-              Title: h.Title,
-              AssociatedSites: h.AssociatedSites.map(a => a.Title)
-            };
-          }));
-        }
         else {
           cmd.log(hubSites.map(h => {
             return {
@@ -190,7 +185,7 @@ class SpoHubSiteListCommand extends SpoCommand {
     const options: CommandOption[] = [
       {
         option: '-i, --includeAssociatedSites',
-        description: `Include the associated sites in the result`
+        description: `Include the associated sites in the result (only in JSON output)`
       }
     ];
 
@@ -224,8 +219,8 @@ class SpoHubSiteListCommand extends SpoCommand {
     List hub sites in the current tenant
       ${chalk.grey(config.delimiter)} ${this.name}
 
-    List hub sites, including their associated sites, in the current tenant
-      ${chalk.grey(config.delimiter)} ${this.name} --includeAssociatedSites
+    List hub sites, including their associated sites, in the current tenant. Associated site info is only shown in JSON output.
+      ${chalk.grey(config.delimiter)} ${this.name} --includeAssociatedSites --output json
 
   More information:
 

--- a/src/o365/spo/commands/hubsite/hubsite-list.ts
+++ b/src/o365/spo/commands/hubsite/hubsite-list.ts
@@ -2,6 +2,7 @@ import auth from '../../SpoAuth';
 import config from '../../../../config';
 import * as request from 'request-promise-native';
 import commands from '../../commands';
+import { CommandOption } from '../../../../Command';
 import SpoCommand from '../../SpoCommand';
 import Utils from '../../../../Utils';
 import GlobalOptions from '../../../../GlobalOptions';
@@ -10,7 +11,11 @@ import { HubSite } from './HubSite';
 const vorpal: Vorpal = require('../../../../vorpal-init');
 
 interface CommandArgs {
-  options: GlobalOptions;
+  options: Options;
+}
+
+interface Options extends GlobalOptions {
+  includeAssociatedSites?: boolean;
 }
 
 class SpoHubSiteListCommand extends SpoCommand {
@@ -20,6 +25,12 @@ class SpoHubSiteListCommand extends SpoCommand {
 
   public get description(): string {
     return 'Lists hub sites in the current tenant';
+  }
+
+  public getTelemetryProperties(args: CommandArgs): any {
+    const telemetryProps: any = super.getTelemetryProperties(args);
+    telemetryProps.classifications = args.options.includeAssociatedSites === true; 
+    return telemetryProps;
   }
 
   public commandAction(cmd: CommandInstance, args: CommandArgs, cb: () => void): void {
@@ -75,6 +86,18 @@ class SpoHubSiteListCommand extends SpoCommand {
       }, (err: any): void => this.handleRejectedODataJsonPromise(err, cmd, cb));
   }
 
+  public options(): CommandOption[] {
+    const options: CommandOption[] = [
+      {
+        option: '-i, --includeAssociatedSites',
+        description: `Include the associated sites in the result`
+      }
+    ];
+
+    const parentOptions: CommandOption[] = super.options();
+    return options.concat(parentOptions);
+  }
+
   public commandHelp(args: {}, log: (help: string) => void): void {
     const chalk = vorpal.chalk;
     log(vorpal.find(this.name).helpInformation());
@@ -100,6 +123,9 @@ class SpoHubSiteListCommand extends SpoCommand {
   
     List hub sites in the current tenant
       ${chalk.grey(config.delimiter)} ${this.name}
+
+    List hub sites, including their associated sites, in the current tenant
+      ${chalk.grey(config.delimiter)} ${this.name} --includeAssociatedSites
 
   More information:
 


### PR DESCRIPTION
Added a new option `includeAssociatedSites` to `spo hubsite list` command, which will list the sites associated to the hub sites in the result, as described in #709 