### PR TITLE
Added command to archive a Microsoft Team

### DIFF
--- a/docs/manual/docs/cmd/graph/teams/teams-archive.md
+++ b/docs/manual/docs/cmd/graph/teams/teams-archive.md
@@ -1,0 +1,47 @@
+# graph teams archive
+
+Archive the specified team. When a team is archived, users can no longer send or like messages on any channel in the team, edit the team's name, description, or other settings, or in general make most changes to the team. Membership changes to the team continue to be allowed.
+
+## Usage
+
+```sh
+graph teams archive [options]
+```
+
+## Options
+
+Option|Description
+------|-----------
+`--help`|output usage information
+`-i, --teamId [teamId]`|The ID of the team for which to list installed apps
+`--shouldSetSpoSiteReadOnlyForMembers [shouldSetSpoSiteReadOnlyForMembers]`|Set to `true` to set permissions for team members to read-only on the Sharepoint Online site associated with the team
+`-o, --output [output]`|Output type. `json|text`. Default `text`
+`--verbose`|Runs command with verbose logging
+`--debug`|Runs command with debug logging
+
+!!! important
+    Before using this command, log in to the Microsoft Graph, using the [graph login](../login.md) command.
+
+## Remarks
+
+To archive a Microsoft Team, you have to first log in to the Microsoft Graph using the [graph login](../login.md) command, eg. `graph login`.
+
+To archive a Microsoft Team, specify that team's ID using the `teamId` option.
+
+Set `shouldSetSpoSiteReadOnlyForMembers` option to `true` to set permissions for team members to read-only on the Sharepoint Online site associated with the team.
+
+You can only archive a Team as a global administrator.
+
+## Examples
+
+Archive the specified Microsoft Teams team
+
+```sh
+graph teams archive --teamId 6f6fd3f7-9ba5-4488-bbe6-a789004d0d55
+```
+
+Archive the specified Microsoft Teams team and set permissions for team members to read-only on the Sharepoint Online site associated with the team
+
+```sh
+graph teams archive --teamId 6f6fd3f7-9ba5-4488-bbe6-a789004d0d55 --shouldSetSpoSiteReadOnlyForMembers true
+```

--- a/docs/manual/docs/cmd/graph/teams/teams-archive.md
+++ b/docs/manual/docs/cmd/graph/teams/teams-archive.md
@@ -30,7 +30,7 @@ To archive a Microsoft Team, specify that team's ID using the `teamId` option.
 
 Set `shouldSetSpoSiteReadOnlyForMembers` option to `true` to set permissions for team members to read-only on the Sharepoint Online site associated with the team.
 
-You can only archive a Team as a global administrator.
+This API supports admin permissions. Global admins and Microsoft Teams service admins can access teams that they are not a member of.
 
 ## Examples
 

--- a/docs/manual/mkdocs.yml
+++ b/docs/manual/mkdocs.yml
@@ -245,6 +245,7 @@ nav:
         - teams list: 'cmd/graph/teams/teams-list.md'
         - teams app install: 'cmd/graph/teams/teams-app-install.md'
         - teams app list: 'cmd/graph/teams/teams-app-list.md'
+        - teams archive: 'cmd/graph/teams/teams-archive.md'
         - teams app publish: 'cmd/graph/teams/teams-app-publish.md'
         - teams app remove: 'cmd/graph/teams/teams-app-remove.md'
         - teams app update: 'cmd/graph/teams/teams-app-update.md'

--- a/src/o365/graph/commands.ts
+++ b/src/o365/graph/commands.ts
@@ -25,6 +25,7 @@ export default {
   STATUS: `${prefix} status`,
   TEAMS_APP_INSTALL: `${prefix} teams app install`,
   TEAMS_APP_LIST: `${prefix} teams app list`,
+  TEAMS_ARCHIVE: `${prefix} teams archive`,
   TEAMS_APP_PUBLISH: `${prefix} teams app publish`,
   TEAMS_APP_REMOVE: `${prefix} teams app remove`,
   TEAMS_APP_UPDATE: `${prefix} teams app update`,

--- a/src/o365/graph/commands/teams/teams-archive.spec.ts
+++ b/src/o365/graph/commands/teams/teams-archive.spec.ts
@@ -1,0 +1,252 @@
+import commands from '../../commands';
+import Command, { CommandOption, CommandError, CommandValidate } from '../../../../Command';
+import * as sinon from 'sinon';
+import appInsights from '../../../../appInsights';
+import auth from '../../GraphAuth';
+const command: Command = require('./teams-archive');
+import * as assert from 'assert';
+import * as request from 'request-promise-native';
+import Utils from '../../../../Utils';
+import { Service } from '../../../../Auth';
+
+describe(commands.TEAMS_ARCHIVE, () => {
+  let vorpal: Vorpal;
+  let log: string[];
+  let cmdInstance: any;
+  let cmdInstanceLogSpy: sinon.SinonSpy;
+  let trackEvent: any;
+  let telemetry: any;
+
+  before(() => {
+    sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
+    sinon.stub(auth, 'ensureAccessToken').callsFake(() => { return Promise.resolve('ABC'); });
+    trackEvent = sinon.stub(appInsights, 'trackEvent').callsFake((t) => {
+      telemetry = t;
+    });
+  });
+
+  beforeEach(() => {
+    vorpal = require('../../../../vorpal-init');
+    log = [];
+    cmdInstance = {
+      log: (msg: string) => {
+        log.push(msg);
+      }
+    };
+    cmdInstanceLogSpy = sinon.spy(cmdInstance, 'log');
+    auth.service = new Service();
+    telemetry = null;
+    (command as any).items = [];
+  });
+
+  afterEach(() => {
+    Utils.restore([
+      vorpal.find,
+      request.post
+    ]);
+  });
+
+  after(() => {
+    Utils.restore([
+      appInsights.trackEvent,
+      auth.ensureAccessToken,
+      auth.restoreAuth
+    ]);
+  });
+
+  it('has correct name', () => {
+    assert.equal(command.name.startsWith(commands.TEAMS_ARCHIVE), true);
+  });
+
+  it('has a description', () => {
+    assert.notEqual(command.description, null);
+  });
+
+  it('calls telemetry', (done) => {
+    cmdInstance.action = command.action();
+    cmdInstance.action({ options: {} }, () => {
+      try {
+        assert(trackEvent.called);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('logs correct telemetry event', (done) => {
+    cmdInstance.action = command.action();
+    cmdInstance.action({ options: {} }, () => {
+      try {
+        assert.equal(telemetry.name, commands.TEAMS_ARCHIVE);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('aborts when not logged in to Microsoft Graph', (done) => {
+    auth.service = new Service();
+    auth.service.connected = false;
+    cmdInstance.action = command.action();
+    cmdInstance.action({ options: { debug: true } }, (err?: any) => {
+      try {
+        assert.equal(JSON.stringify(err), JSON.stringify(new CommandError('Log in to the Microsoft Graph first')));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('fails validation if the teamId is not a valid guid.', () => {
+    const actual = (command.validate() as CommandValidate)({
+      options: {
+        teamId: 'invalid'
+      }
+    });
+    assert.notEqual(actual, true);
+  });
+
+
+  it('fails validation if the teamId is not provided.', () => {
+    const actual = (command.validate() as CommandValidate)({
+      options: {
+      }
+    });
+    assert.notEqual(actual, true);
+  });
+
+  it('passes validation when the input is correct', () => {
+    const actual = (command.validate() as CommandValidate)({
+      options: {
+        teamId: '15d7a78e-fd77-4599-97a5-dbb6372846c5'
+      }
+    });
+    assert.equal(actual, true);
+  });
+
+  it('archives a Microsoft Team', (done) => {
+    sinon.stub(request, 'post').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/teams/f5dba91d-6494-4d5e-89a7-ad832f6946d6/archive`) {
+        return Promise.resolve();
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    auth.service = new Service();
+    auth.service.connected = true;
+    auth.service.resource = 'https://graph.microsoft.com';
+    cmdInstance.action = command.action();
+    cmdInstance.action({
+      options: {
+        teamId: 'f5dba91d-6494-4d5e-89a7-ad832f6946d6'
+      }
+    }, () => {
+      try {
+        assert(cmdInstanceLogSpy.notCalled);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('archives a Microsoft Team (debug)', (done) => {
+    sinon.stub(request, 'post').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/teams/f5dba91d-6494-4d5e-89a7-ad832f6946d6/archive`) {
+        return Promise.resolve();
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    auth.service = new Service();
+    auth.service.connected = true;
+    auth.service.resource = 'https://graph.microsoft.com';
+    cmdInstance.action = command.action();
+    cmdInstance.action({
+      options: {
+        teamId: 'f5dba91d-6494-4d5e-89a7-ad832f6946d6',
+        debug: true
+      }
+    }, () => {
+      try {
+        assert(cmdInstanceLogSpy.called);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('supports debug mode', () => {
+    const options = (command.options() as CommandOption[]);
+    let containsOption = false;
+    options.forEach(o => {
+      if (o.option === '--debug') {
+        containsOption = true;
+      }
+    });
+    assert(containsOption);
+  });
+
+  it('has help referring to the right command', () => {
+    const cmd: any = {
+      log: (msg: string) => { },
+      prompt: () => { },
+      helpInformation: () => { }
+    };
+    const find = sinon.stub(vorpal, 'find').callsFake(() => cmd);
+    cmd.help = command.help();
+    cmd.help({}, () => { });
+    assert(find.calledWith(commands.TEAMS_ARCHIVE));
+  });
+
+  it('has help with examples', () => {
+    const _log: string[] = [];
+    const cmd: any = {
+      log: (msg: string) => {
+        _log.push(msg);
+      },
+      prompt: () => { },
+      helpInformation: () => { }
+    };
+    sinon.stub(vorpal, 'find').callsFake(() => cmd);
+    cmd.help = command.help();
+    cmd.help({}, () => { });
+    let containsExamples: boolean = false;
+    _log.forEach(l => {
+      if (l && l.indexOf('Examples:') > -1) {
+        containsExamples = true;
+      }
+    });
+    Utils.restore(vorpal.find);
+    assert(containsExamples);
+  });
+
+  it('correctly handles lack of valid access token', (done) => {
+    Utils.restore(auth.ensureAccessToken);
+    sinon.stub(auth, 'ensureAccessToken').callsFake(() => { return Promise.reject(new Error('Error getting access token')); });
+    auth.service = new Service();
+    auth.service.connected = true;
+    auth.service.resource = 'https://graph.microsoft.com';
+    cmdInstance.action = command.action();
+    cmdInstance.action({ options: { debug: true } }, (err?: any) => {
+      try {
+        assert.equal(JSON.stringify(err), JSON.stringify(new CommandError('Error getting access token')));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+});

--- a/src/o365/graph/commands/teams/teams-archive.ts
+++ b/src/o365/graph/commands/teams/teams-archive.ts
@@ -1,0 +1,116 @@
+import * as request from 'request-promise-native';
+import auth from '../../GraphAuth';
+import Utils from '../../../../Utils';
+import config from '../../../../config';
+import commands from '../../commands';
+import GlobalOptions from '../../../../GlobalOptions';
+import { CommandOption, CommandValidate } from '../../../../Command';
+import GraphCommand from '../../GraphCommand';
+
+const vorpal: Vorpal = require('../../../../vorpal-init');
+
+interface CommandArgs {
+  options: Options;
+}
+
+interface Options extends GlobalOptions {
+  teamId: string;
+  shouldSetSpoSiteReadOnlyForMembers?: false;
+}
+
+class GraphTeamsArchiveCommand extends GraphCommand {
+  public get name(): string {
+    return `${commands.TEAMS_ARCHIVE}`;
+  }
+
+  public get description(): string {
+    return 'Archive the specified Microsoft Team';
+  }
+
+  public commandAction(cmd: CommandInstance, args: CommandArgs, cb: () => void): void {
+    const endpoint: string = `${auth.service.resource}/v1.0`
+
+    auth
+      .ensureAccessToken(auth.service.resource, cmd, this.debug)
+      .then((): request.RequestPromise => {
+        const requestOptions: any = {
+          url: `${endpoint}/teams/${args.options.teamId}/archive`,
+          headers: Utils.getRequestHeaders({
+            authorization: `Bearer ${auth.service.accessToken}`,
+            'content-type': 'application/json;odata=nometadata',
+            'accept': 'application/json;odata.metadata=none'
+          }),
+          json: true,
+          body: {
+            'shouldSetSpoSiteReadOnlyForMembers': `${args.options.shouldSetSpoSiteReadOnlyForMembers ? args.options.shouldSetSpoSiteReadOnlyForMembers : false}`
+          }
+        };
+
+        if (this.debug) {
+          cmd.log('Executing web request...');
+          cmd.log(requestOptions);
+          cmd.log('');
+        }
+
+        return request.post(requestOptions);
+      })
+      .then((res: any): void => {
+        if (this.verbose) {
+          cmd.log(vorpal.chalk.green('DONE'));
+        }
+
+        cb();
+      }, (res: any): void => this.handleRejectedODataJsonPromise(res, cmd, cb));
+  }
+
+  public options(): CommandOption[] {
+    const options: CommandOption[] = [
+      {
+        option: '--teamId <teamId>',
+        description: 'The ID of the Microsoft Teams team to archive'
+      },
+      {
+        option: '--shouldSetSpoSiteReadOnlyForMembers <true or false>',
+        description: 'This optional parameter defines whether to set permissions for team members to read-only on the Sharepoint Online site associated with the team. Setting it to false or omitting the body altogether will result in this step being skipped.'
+      }
+    ];
+
+    const parentOptions: CommandOption[] = super.options();
+    return options.concat(parentOptions);
+  }
+
+  public validate(): CommandValidate {
+    return (args: CommandArgs): boolean | string => {
+      if (!args.options.teamId) {
+        return 'Required parameter teamId missing';
+      }
+
+      if (!Utils.isValidGuid(args.options.teamId)) {
+        return `${args.options.teamId} is not a valid GUID`;
+      }
+
+      return true;
+    };
+  }
+
+  public commandHelp(args: {}, log: (help: string) => void): void {
+    const chalk = vorpal.chalk;
+    log(vorpal.find(this.name).helpInformation());
+    log(
+      `  ${chalk.yellow('Important:')} before using this command, log in to the Microsoft Graph
+    using the ${chalk.blue(commands.LOGIN)} command.
+        
+  Remarks:
+    To archive a Microsoft Team, you have to first log in to
+    the Microsoft Graph using the ${chalk.blue(commands.LOGIN)} command,
+    eg. ${chalk.grey(`${config.delimiter} ${commands.LOGIN}`)}.
+    The ${chalk.grey(`teamId`)} has to be a valid GUID.
+    The ${chalk.grey(`shouldSetSpoSiteReadOnlyForMembers`)} has to be true or false.
+  Examples:
+    Archive a Microsoft Team
+      ${chalk.grey(config.delimiter)} ${this.name} --teamId f5dba91d-6494-4d5e-89a7-ad832f6946d6 --shouldSetSpoSiteReadOnlyForMembers false
+`);
+  }
+}
+
+module.exports = new GraphTeamsArchiveCommand();

--- a/src/o365/graph/commands/teams/teams-archive.ts
+++ b/src/o365/graph/commands/teams/teams-archive.ts
@@ -42,7 +42,7 @@ class GraphTeamsArchiveCommand extends GraphCommand {
           }),
           json: true,
           body: {
-            'shouldSetSpoSiteReadOnlyForMembers': `${args.options.shouldSetSpoSiteReadOnlyForMembers ? args.options.shouldSetSpoSiteReadOnlyForMembers : false}`
+            'shouldSetSpoSiteReadOnlyForMembers': args.options.shouldSetSpoSiteReadOnlyForMembers || false
           }
         };
 


### PR DESCRIPTION
Added the command to archive the specified team. When a team is archived, users can no longer send or like messages on any channel in the team, edit the team's name, description, or other settings, or in general make most changes to the team. Membership changes to the team continue to be allowed.

command: graph teams archive -i|--teamId 6f6fd3f7-9ba5-4488-bbe6-a789004d0d55 --shouldSetSpoSiteReadOnlyForMembers true
teamId: The ID of the team to archive
shouldSetSpoSiteReadOnlyForMembers: sets permissions for team members to read-only on the Sharepoint Online site associated with the team