### PR TITLE
Added command to restore an archived Microsoft Teams team

### DIFF
--- a/docs/manual/docs/cmd/graph/teams/teams-unarchive.md
+++ b/docs/manual/docs/cmd/graph/teams/teams-unarchive.md
@@ -1,0 +1,38 @@
+# graph teams archive
+
+Restore an archived Microsoft Teams team
+
+## Usage
+
+```sh
+graph teams unarchive [options]
+```
+
+## Options
+
+Option|Description
+------|-----------
+`--help`|output usage information
+`-i, --teamId [teamId]`|The ID of the Microsoft Teams team to unarchive
+`-o, --output [output]`|Output type. `json|text`. Default `text`
+`--verbose`|Runs command with verbose logging
+`--debug`|Runs command with debug logging
+
+!!! important
+    Before using this command, log in to the Microsoft Graph, using the [graph login](../login.md) command.
+
+## Remarks
+
+To restore an archived Microsoft Teams team, you have to first log in to the Microsoft Graph using the [graph login](../login.md) command, eg. `graph login`.
+
+This API supports admin permissions. Global admins and Microsoft Teams service admins can access teams that they are not a member of.
+
+This restores users' ability to send messages and edit the team, abiding by tenant and team settings.
+
+## Examples
+
+Restore an archived Microsoft Teams team
+
+```sh
+graph teams unarchive --teamId 6f6fd3f7-9ba5-4488-bbe6-a789004d0d55
+```

--- a/docs/manual/mkdocs.yml
+++ b/docs/manual/mkdocs.yml
@@ -260,6 +260,7 @@ nav:
         - teams message list: 'cmd/graph/teams/teams-message-list.md'
         - teams membersettings list: 'cmd/graph/teams/teams-membersettings-list.md'
         - teams messagingsettings list: 'cmd/graph/teams/teams-messagingsettings-list.md'
+        - teams unarchive: 'cmd/graph/teams/teams-unarchive.md' 
         - teams user add: 'cmd/graph/teams/teams-user-add.md'
         - teams user list: 'cmd/graph/teams/teams-user-list.md'
         - teams user remove: 'cmd/graph/teams/teams-user-remove.md'

--- a/src/o365/graph/commands.ts
+++ b/src/o365/graph/commands.ts
@@ -41,6 +41,7 @@ export default {
   TEAMS_MESSAGE_GET: `${prefix} teams message get`,
   TEAMS_MESSAGE_LIST: `${prefix} teams message list`,
   TEAMS_MESSAGINGSETTINGS_LIST: `${prefix} teams messagingsettings list`,
+  TEAMS_UNARCHIVE: `${prefix} teams unarchive`, 
   TEAMS_USER_ADD: `${prefix} teams user add`,
   TEAMS_USER_LIST: `${prefix} teams user list`,
   TEAMS_USER_REMOVE: `${prefix} teams user remove`,

--- a/src/o365/graph/commands/teams/teams-unarchive.spec.ts
+++ b/src/o365/graph/commands/teams/teams-unarchive.spec.ts
@@ -1,0 +1,290 @@
+import commands from '../../commands';
+import Command, { CommandOption, CommandError, CommandValidate } from '../../../../Command';
+import * as sinon from 'sinon';
+import appInsights from '../../../../appInsights';
+import auth from '../../GraphAuth';
+const command: Command = require('./teams-unarchive');
+import * as assert from 'assert';
+import * as request from 'request-promise-native';
+import Utils from '../../../../Utils';
+import { Service } from '../../../../Auth';
+
+describe(commands.TEAMS_UNARCHIVE, () => {
+  let vorpal: Vorpal;
+  let log: string[];
+  let cmdInstance: any;
+  let cmdInstanceLogSpy: sinon.SinonSpy;
+  let trackEvent: any;
+  let telemetry: any;
+
+  before(() => {
+    sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
+    sinon.stub(auth, 'ensureAccessToken').callsFake(() => { return Promise.resolve('ABC'); });
+    trackEvent = sinon.stub(appInsights, 'trackEvent').callsFake((t) => {
+      telemetry = t;
+    });
+  });
+
+  beforeEach(() => {
+    vorpal = require('../../../../vorpal-init');
+    log = [];
+    cmdInstance = {
+      log: (msg: string) => {
+        log.push(msg);
+      }
+    };
+    cmdInstanceLogSpy = sinon.spy(cmdInstance, 'log');
+    auth.service = new Service();
+    telemetry = null;
+    (command as any).items = [];
+  });
+
+  afterEach(() => {
+    Utils.restore([
+      vorpal.find,
+      request.post
+    ]);
+  });
+
+  after(() => {
+    Utils.restore([
+      appInsights.trackEvent,
+      auth.ensureAccessToken,
+      auth.restoreAuth
+    ]);
+  });
+
+  it('has correct name', () => {
+    assert.equal(command.name.startsWith(commands.TEAMS_UNARCHIVE), true);
+  });
+
+  it('has a description', () => {
+    assert.notEqual(command.description, null);
+  });
+
+  it('calls telemetry', (done) => {
+    cmdInstance.action = command.action();
+    cmdInstance.action({ options: {} }, () => {
+      try {
+        assert(trackEvent.called);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('logs correct telemetry event', (done) => {
+    cmdInstance.action = command.action();
+    cmdInstance.action({ options: {} }, () => {
+      try {
+        assert.equal(telemetry.name, commands.TEAMS_UNARCHIVE);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('aborts when not logged in to Microsoft Graph', (done) => {
+    auth.service = new Service();
+    auth.service.connected = false;
+    cmdInstance.action = command.action();
+    cmdInstance.action({ options: { debug: true } }, (err?: any) => {
+      try {
+        assert.equal(JSON.stringify(err), JSON.stringify(new CommandError('Log in to the Microsoft Graph first')));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('fails validation if the teamId is not a valid guid.', () => {
+    const actual = (command.validate() as CommandValidate)({
+      options: {
+        teamId: 'invalid'
+      }
+    });
+    assert.notEqual(actual, true);
+  });
+
+
+  it('fails validation if the teamId is not provided.', () => {
+    const actual = (command.validate() as CommandValidate)({
+      options: {
+      }
+    });
+    assert.notEqual(actual, true);
+  });
+
+  it('passes validation when the input is correct', () => {
+    const actual = (command.validate() as CommandValidate)({
+      options: {
+        teamId: '15d7a78e-fd77-4599-97a5-dbb6372846c5'
+      }
+    });
+    assert.equal(actual, true);
+  });
+
+  it('restores an archived Microsoft Team', (done) => {
+    sinon.stub(request, 'post').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/teams/f5dba91d-6494-4d5e-89a7-ad832f6946d6/unarchive`) {
+        return Promise.resolve();
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    auth.service = new Service();
+    auth.service.connected = true;
+    auth.service.resource = 'https://graph.microsoft.com';
+    cmdInstance.action = command.action();
+    cmdInstance.action({
+      options: {
+        teamId: 'f5dba91d-6494-4d5e-89a7-ad832f6946d6'
+      }
+    }, () => {
+      try {
+        assert(cmdInstanceLogSpy.notCalled);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('should correctly handle graph error response', (done) => {
+    sinon.stub(request, 'post').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/teams/f5dba91d-6494-4d5e-89a7-ad832f6946d6/unarchive`) {
+        return Promise.reject(
+          {
+              "error": {
+                  "code": "ItemNotFound",
+                  "message": "No team found with Group Id f5dba91d-6494-4d5e-89a7-ad832f6946d6",
+                  "innerError": {
+                      "request-id": "ad0c0a4f-a4fc-4567-8ae1-1150db48b620",
+                      "date": "2019-04-05T15:51:43"
+                  }
+              }
+          });
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    auth.service = new Service();
+    auth.service.connected = true;
+    auth.service.resource = 'https://graph.microsoft.com';
+    cmdInstance.action = command.action();
+    cmdInstance.action({
+      options: {
+        teamId: 'f5dba91d-6494-4d5e-89a7-ad832f6946d6'
+      }
+    }, (err?: any) => {
+      try {
+        assert.equal(err.message, 'No team found with Group Id f5dba91d-6494-4d5e-89a7-ad832f6946d6');
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('restores an archived Microsoft Team (debug)', (done) => {
+    sinon.stub(request, 'post').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/teams/f5dba91d-6494-4d5e-89a7-ad832f6946d6/unarchive`) {
+        return Promise.resolve();
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    auth.service = new Service();
+    auth.service.connected = true;
+    auth.service.resource = 'https://graph.microsoft.com';
+    cmdInstance.action = command.action();
+    cmdInstance.action({
+      options: {
+        teamId: 'f5dba91d-6494-4d5e-89a7-ad832f6946d6',
+        debug: true
+      }
+    }, () => {
+      try {
+        assert(cmdInstanceLogSpy.called);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('supports debug mode', () => {
+    const options = (command.options() as CommandOption[]);
+    let containsOption = false;
+    options.forEach(o => {
+      if (o.option === '--debug') {
+        containsOption = true;
+      }
+    });
+    assert(containsOption);
+  });
+
+  it('has help referring to the right command', () => {
+    const cmd: any = {
+      log: (msg: string) => { },
+      prompt: () => { },
+      helpInformation: () => { }
+    };
+    const find = sinon.stub(vorpal, 'find').callsFake(() => cmd);
+    cmd.help = command.help();
+    cmd.help({}, () => { });
+    assert(find.calledWith(commands.TEAMS_UNARCHIVE));
+  });
+
+  it('has help with examples', () => {
+    const _log: string[] = [];
+    const cmd: any = {
+      log: (msg: string) => {
+        _log.push(msg);
+      },
+      prompt: () => { },
+      helpInformation: () => { }
+    };
+    sinon.stub(vorpal, 'find').callsFake(() => cmd);
+    cmd.help = command.help();
+    cmd.help({}, () => { });
+    let containsExamples: boolean = false;
+    _log.forEach(l => {
+      if (l && l.indexOf('Examples:') > -1) {
+        containsExamples = true;
+      }
+    });
+    Utils.restore(vorpal.find);
+    assert(containsExamples);
+  });
+
+  it('correctly handles lack of valid access token', (done) => {
+    Utils.restore(auth.ensureAccessToken);
+    sinon.stub(auth, 'ensureAccessToken').callsFake(() => { return Promise.reject(new Error('Error getting access token')); });
+    auth.service = new Service();
+    auth.service.connected = true;
+    auth.service.resource = 'https://graph.microsoft.com';
+    cmdInstance.action = command.action();
+    cmdInstance.action({ options: { debug: true } }, (err?: any) => {
+      try {
+        assert.equal(JSON.stringify(err), JSON.stringify(new CommandError('Error getting access token')));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+});

--- a/src/o365/graph/commands/teams/teams-unarchive.ts
+++ b/src/o365/graph/commands/teams/teams-unarchive.ts
@@ -1,0 +1,112 @@
+import * as request from 'request-promise-native';
+import auth from '../../GraphAuth';
+import Utils from '../../../../Utils';
+import config from '../../../../config';
+import commands from '../../commands';
+import GlobalOptions from '../../../../GlobalOptions';
+import { CommandOption, CommandValidate } from '../../../../Command';
+import GraphCommand from '../../GraphCommand';
+
+const vorpal: Vorpal = require('../../../../vorpal-init');
+
+interface CommandArgs {
+  options: Options;
+}
+
+interface Options extends GlobalOptions {
+  teamId: string;
+}
+
+class GraphTeamsUnArchiveCommand extends GraphCommand {
+  public get name(): string {
+    return `${commands.TEAMS_UNARCHIVE}`;
+  }
+
+  public get description(): string {
+    return 'Restore an archived Microsoft Teams team';
+  }
+
+  public commandAction(cmd: CommandInstance, args: CommandArgs, cb: () => void): void {
+    const endpoint: string = `${auth.service.resource}/v1.0`;
+
+    auth
+      .ensureAccessToken(auth.service.resource, cmd, this.debug)
+      .then((): request.RequestPromise => {
+
+        const requestOptions: any = {
+          url: `${endpoint}/teams/${encodeURIComponent(args.options.teamId)}/unarchive`,
+          headers: Utils.getRequestHeaders({
+            authorization: `Bearer ${auth.service.accessToken}`,
+            'content-type': 'application/json;odata=nometadata',
+            'accept': 'application/json;odata.metadata=none'
+          }),
+          json: true
+        };
+
+        if (this.debug) {
+          cmd.log('Executing web request...');
+          cmd.log(requestOptions);
+          cmd.log('');
+        }
+
+        return request.post(requestOptions);
+      })
+      .then((): void => {
+        if (this.verbose) {
+          cmd.log(vorpal.chalk.green('DONE'));
+        }
+
+        cb();
+      }, (res: any): void => this.handleRejectedODataJsonPromise(res, cmd, cb));
+  }
+
+  public options(): CommandOption[] {
+    const options: CommandOption[] = [
+      {
+        option: '-i, --teamId <teamId>',
+        description: 'The ID of the Microsoft Teams team to restore'
+      }
+    ];
+
+    const parentOptions: CommandOption[] = super.options();
+    return options.concat(parentOptions);
+  }
+
+  public validate(): CommandValidate {
+    return (args: CommandArgs): boolean | string => {
+      if (!args.options.teamId) {
+        return 'Required parameter teamId missing';
+      }
+
+      if (!Utils.isValidGuid(args.options.teamId)) {
+        return `${args.options.teamId} is not a valid GUID`;
+      }
+
+      return true;
+    };
+  }
+
+  public commandHelp(args: {}, log: (help: string) => void): void {
+    const chalk = vorpal.chalk;
+    log(vorpal.find(this.name).helpInformation());
+    log(
+      `${chalk.yellow('Important:')} Before using this command, log in to the Microsoft Graph, using the ${chalk.blue(commands.LOGIN)} command.
+          
+  Remarks:
+          
+    To restore an archived Microsoft Teams team, you have to first log in to the Microsoft Graph using the
+    ${chalk.blue(commands.LOGIN)} command, eg. ${chalk.grey(`${config.delimiter} ${commands.LOGIN}`)}.
+
+    This API supports admin permissions. Global admins and Microsoft Teams service admins can access teams that they are not a member of.
+
+    This restores users' ability to send messages and edit the team, abiding by tenant and team settings.
+
+  Examples:
+    
+      Restore an archived Microsoft Teams team
+      ${chalk.grey(config.delimiter)} ${commands.TEAMS_UNARCHIVE} --teamId 6f6fd3f7-9ba5-4488-bbe6-a789004d0d55
+    `);
+  }
+}
+
+module.exports = new GraphTeamsUnArchiveCommand();


### PR DESCRIPTION
Added the command to restore an archived Microsoft Teams team. This restores users' ability to send messages and edit the team, abiding by tenant and team settings.

command: graph teams unarchive --teamId 6f6fd3f7-9ba5-4488-bbe6-a789004d0d55
teamId: The ID of the Microsoft Teams team to unarchive