### PR TITLE
Extending 'spo page add' with promoteAs Template solving issue #977

### DIFF
--- a/docs/manual/docs/cmd/spo/page/page-add.md
+++ b/docs/manual/docs/cmd/spo/page/page-add.md
@@ -68,6 +68,12 @@ Create new page and set it as the site's home page
 spo page add --name new-page.aspx --webUrl https://contoso.sharepoint.com/sites/a-team --layoutType Home --promoteAs HomePage
 ```
 
+Create new article page and promote it as a template
+
+```sh
+spo page add --name page.aspx --webUrl https://contoso.sharepoint.com/sites/a-team --promoteAs Template
+```
+
 Create new article page and enable comments on the page
 
 ```sh


### PR DESCRIPTION
New PR for Issue #977, updated based on comments in PR #995.

This PR is kind of similar to #992. The only big difference is that when adding a page, another HTTP request is made to disable/enable comments on the template as well. This is to ensure that the template has the same settings as the page added (which I personally would expect).