### PR TITLE
Fix #1031 - allow validation to work if search scope passed is a number

### DIFF
--- a/src/o365/spo/commands/web/web-set.spec.ts
+++ b/src/o365/spo/commands/web/web-set.spec.ts
@@ -629,6 +629,11 @@ describe(commands.WEB_SET, () => {
     assert.equal(actual, true);
   });
 
+  it('fails validation if search scope passed is a number', () => {
+    const actual = (command.validate() as CommandValidate)({ options: { webUrl: 'https://contoso.sharepoint.com/sites/team-a', searchScope: 2 } });
+    assert.notEqual(actual, true);
+  });
+
   it('sets search scope to default scope', (done) => {
     sinon.stub(request, 'patch').callsFake((opts) => {
       if (JSON.stringify(opts.body) === JSON.stringify({

--- a/src/o365/spo/commands/web/web-set.ts
+++ b/src/o365/spo/commands/web/web-set.ts
@@ -209,7 +209,7 @@ class SpoWebSetCommand extends SpoCommand {
       }
 
       if (typeof args.options.searchScope !== 'undefined') {
-        const searchScope = args.options.searchScope.toLowerCase();
+        const searchScope = args.options.searchScope.toString().toLowerCase();
         if (SpoWebSetCommand.searchScopeOptions.indexOf(searchScope) < 0) {
           return `${args.options.searchScope} is not a valid value for searchScope. Allowed values are DefaultScope|Tenant|Hub|Site`;
         }


### PR DESCRIPTION
Add a toString to searchOptions so toLowerCase will work for numeric inputs 