### PR TITLE
Enhancement #887

### DIFF
--- a/src/o365/spfx/commands/project/project-upgrade.spec.ts
+++ b/src/o365/spfx/commands/project/project-upgrade.spec.ts
@@ -39,6 +39,7 @@ describe(commands.PROJECT_UPGRADE, () => {
     telemetry = null;
     (command as any).allFindings = [];
     (command as any).packageManager = 'npm';
+    (command as any).shell = 'bash';
     packagesDevExact = [];
     packagesDepExact = [];
     packagesDepUn = [];
@@ -1889,6 +1890,31 @@ describe(commands.PROJECT_UPGRADE, () => {
 
   it('passes validation when yarn package manager specified', () => {
     const actual = (command.validate() as CommandValidate)({ options: { packageManager: 'yarn' } });
+    assert.equal(actual, true);
+  });
+
+  it('passes validation when shell not specified', () => {
+    const actual = (command.validate() as CommandValidate)({ options: { } });
+    assert.equal(actual, true);
+  });
+
+  it('fails validation when unsupported shell specified', () => {
+    const actual = (command.validate() as CommandValidate)({ options: { packageManager: 'abc' } });
+    assert.notEqual(actual, true);
+  });
+
+  it('passes validation when bash shell specified', () => {
+    const actual = (command.validate() as CommandValidate)({ options: { shell: 'bash' } });
+    assert.equal(actual, true);
+  });
+
+  it('passes validation when powershell shell specified', () => {
+    const actual = (command.validate() as CommandValidate)({ options: { shell: 'powershell' } });
+    assert.equal(actual, true);
+  });
+
+  it('passes validation when cmd shell specified', () => {
+    const actual = (command.validate() as CommandValidate)({ options: { shell: 'cmd' } });
     assert.equal(actual, true);
   });
 

--- a/src/o365/spfx/commands/project/project-upgrade.ts
+++ b/src/o365/spfx/commands/project/project-upgrade.ts
@@ -23,12 +23,14 @@ interface CommandArgs {
 interface Options extends GlobalOptions {
   packageManager?: string;
   toVersion?: string;
+  shell?: string;
 }
 
 class SpfxProjectUpgradeCommand extends Command {
   private projectVersion: string | undefined;
   private toVersion: string = '';
   private packageManager: string = 'npm';
+  private shell: string = 'bash';
   private projectRootPath: string | null = null;
   private allFindings: Finding[] = [];
   private supportedVersions: string[] = [
@@ -95,6 +97,7 @@ class SpfxProjectUpgradeCommand extends Command {
     const telemetryProps: any = super.getTelemetryProperties(args);
     telemetryProps.toVersion = args.options.toVersion || this.supportedVersions[this.supportedVersions.length - 1];
     telemetryProps.packageManager = args.options.packageManager || 'npm';
+    telemetryProps.shell = args.options.shell || 'bash';
     return telemetryProps;
   }
 
@@ -107,6 +110,7 @@ class SpfxProjectUpgradeCommand extends Command {
 
     this.toVersion = args.options.toVersion ? args.options.toVersion : this.supportedVersions[this.supportedVersions.length - 1];
     this.packageManager = args.options.packageManager || 'npm';
+    this.shell = args.options.shell || 'bash';
 
     if (this.supportedVersions.indexOf(this.toVersion) < 0) {
       cb(new CommandError(`Office 365 CLI doesn't support upgrading SharePoint Framework projects to version ${this.toVersion}. Supported versions are ${this.supportedVersions.join(', ')}`, SpfxProjectUpgradeCommand.ERROR_UNSUPPORTED_TO_VERSION));
@@ -235,6 +239,8 @@ class SpfxProjectUpgradeCommand extends Command {
       default:
         cmd.log(this.getTextReport(findingsToReport));
     }
+
+    cmd.log(this.shell);
 
     cb();
   }
@@ -648,6 +654,11 @@ ${f.resolution}
         option: '--packageManager [packageManager]',
         description: 'The package manager you use. Supported managers npm|pnpm|yarn. Default npm',
         autocomplete: ['npm', 'pnpm', 'yarn']
+      },
+      {
+        option: '--shell [shell]',
+        description: 'The shell you use. Supported shells bash|powershell|cmd. Default bash',
+        autocomplete: ['bash', 'powershell', 'cmd']
       }
     ];
 
@@ -666,6 +677,11 @@ ${f.resolution}
       if (args.options.packageManager) {
         if (['npm', 'pnpm', 'yarn'].indexOf(args.options.packageManager) < 0) {
           return `${args.options.packageManager} is not a supported package manager. Supported package managers are npm, pnpm and yarn`;
+        }
+      }
+      if (args.options.shell) {
+        if (['bash', 'powershell', 'cmd'].indexOf(args.options.shell) < 0) {
+          return `${args.options.shell} is not a supported shell. Supported package managers are bash, powershell and cmd`;
         }
       }
 

--- a/src/o365/spfx/commands/project/project-upgrade.ts
+++ b/src/o365/spfx/commands/project/project-upgrade.ts
@@ -78,6 +78,21 @@ class SpfxProjectUpgradeCommand extends Command {
     }
   }
 
+  private static copyCommands = {
+    bash: {
+      copyCommand: 'cp',
+      copyDestinationParam: ' '
+    },
+    powershell: {
+      copyCommand: 'Copy-Item',
+      copyDestinationParam: ' -Destination '
+    },
+    cmd: {
+      copyCommand: 'xcopy',
+      copyDestinationParam: ' '
+    }
+  }
+
   public static ERROR_NO_PROJECT_ROOT_FOLDER: number = 1;
   public static ERROR_UNSUPPORTED_TO_VERSION: number = 2;
   public static ERROR_NO_VERSION: number = 3;
@@ -225,6 +240,12 @@ class SpfxProjectUpgradeCommand extends Command {
       }
       if (f.resolution.startsWith('install')) {
         f.resolution = f.resolution.replace('install', this.getPackageManagerCommand('install'));
+        return;
+      }
+      //copy support for multiple shells
+      if (f.resolution.startsWith('copy')) {
+        f.resolution = f.resolution.replace('copy', this.getCopyCommand('copyCommand'));
+        f.resolution = f.resolution.replace('DestinationParam', this.getCopyCommand('copyDestinationParam'));
         return;
       }
     });
@@ -600,6 +621,10 @@ ${f.resolution}
     return (SpfxProjectUpgradeCommand.packageCommands as any)[this.packageManager][command];
   }
 
+  private getCopyCommand(command: string): string {
+    return (SpfxProjectUpgradeCommand.copyCommands as any)[this.shell][command];
+  }
+
   private getProjectRoot(folderPath: string): string | null {
     const packageJsonPath: string = path.resolve(folderPath, 'package.json');
     if (fs.existsSync(packageJsonPath)) {
@@ -736,7 +761,8 @@ ${f.resolution}
     Get instructions to upgrade the current SharePoint Framework project to the
     latest SharePoint Framework version supported by the Office 365 CLI
       ${chalk.grey(config.delimiter)} ${this.name}
-`);
+    `
+    );
   }
 }
 

--- a/src/o365/spfx/commands/project/project-upgrade/rules/FN018003_TEAMS_tab20x20_png.ts
+++ b/src/o365/spfx/commands/project/project-upgrade/rules/FN018003_TEAMS_tab20x20_png.ts
@@ -58,7 +58,7 @@ export class FN018003_TEAMS_tab20x20_png extends Rule {
       if (!fs.existsSync(iconPath)) {
         occurrences.push({
           file: path.relative(project.path, iconPath),
-          resolution: `cp ${path.join(__dirname, '..', 'assets', 'tab20x20.png')} ${iconPath}`
+          resolution: `copy ${path.join(__dirname, '..', 'assets', 'tab20x20.png')}DestinationParam${iconPath}`
         });
       }
     });

--- a/src/o365/spfx/commands/project/project-upgrade/rules/FN018004_TEAMS_tab96x96_png.ts
+++ b/src/o365/spfx/commands/project/project-upgrade/rules/FN018004_TEAMS_tab96x96_png.ts
@@ -58,7 +58,7 @@ export class FN018004_TEAMS_tab96x96_png extends Rule {
       if (!fs.existsSync(iconPath)) {
         occurrences.push({
           file: path.relative(project.path, iconPath),
-          resolution: `cp ${path.join(__dirname, '..', 'assets', 'tab96x96.png')} ${iconPath}`
+          resolution: `copy ${path.join(__dirname, '..', 'assets', 'tab96x96.png')}DestinationParam${iconPath}`
         });
       }
     });


### PR DESCRIPTION
Added support for multiple shells for command spfx project upgrade as outlined by @waldekmastykarz in #887 

Command now supports three shell options: bash|powershell|cmd with bash being the default.
Copy commands are cp|Copy-Item|xcopy respectively, tests added for shell validation.

Code was generally aligned to the work done for npm|pnpm|yarn.