### PR TITLE
Add extra checks in handling rejected oData promise

### DIFF
--- a/src/Command.spec.ts
+++ b/src/Command.spec.ts
@@ -668,4 +668,35 @@ describe('Command', () => {
       }
     });
   });
+
+  it('correctly handles forbidden error (code) from the promise', (done) => {
+    const errorMessage = "forbidden-message";
+    const errorCode = "Access Denied";
+    const cmd = new MockCommand3();
+    (cmd as any).handleRejectedODataPromise({ error: { error: { message: errorMessage,code: errorCode} }}, undefined, (msg: any): void => {
+      try {
+        console.log(msg);
+        assert.equal(JSON.stringify(msg), JSON.stringify(new CommandError(errorCode+" - "+errorMessage)));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('correctly handles forbidden error (without code) from the promise', (done) => {
+    const errorMessage = "forbidden-message";
+    const cmd = new MockCommand3();
+    (cmd as any).handleRejectedODataPromise({ error: { error: { message: errorMessage} }}, undefined, (msg: any): void => {
+      try {
+        console.log(msg);
+        assert.equal(JSON.stringify(msg), JSON.stringify(new CommandError(errorMessage)));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
 });

--- a/src/Command.spec.ts
+++ b/src/Command.spec.ts
@@ -669,7 +669,7 @@ describe('Command', () => {
     });
   });
 
-  it('correctly handles forbidden error (code) from the promise', (done) => {
+  it('correctly handles graph response (code) from the promise', (done) => {
     const errorMessage = "forbidden-message";
     const errorCode = "Access Denied";
     const cmd = new MockCommand3();
@@ -685,7 +685,7 @@ describe('Command', () => {
     });
   });
 
-  it('correctly handles forbidden error (without code) from the promise', (done) => {
+  it('correctly handles graph response error (without code) from the promise', (done) => {
     const errorMessage = "forbidden-message";
     const cmd = new MockCommand3();
     (cmd as any).handleRejectedODataPromise({ error: { error: { message: errorMessage} }}, undefined, (msg: any): void => {

--- a/src/Command.ts
+++ b/src/Command.ts
@@ -32,6 +32,17 @@ export interface CommandTypes {
   boolean?: string[];
 }
 
+export interface GraphResponseError {
+  error: {
+    code: string;
+    message: string;
+    innerError: {
+      "request-id": string;
+      date: string;
+    }
+  }
+}
+
 export class CommandError {
   constructor(public message: string, public code?: number) {
   }
@@ -241,17 +252,18 @@ export default abstract class Command {
         callback(new CommandError(err['odata.error'].message.value));
       }
       catch {
-        if(res.error.error && res.error.error.message) {
-          if(res.error.error.code) {
-            callback(new CommandError(res.error.error.code+" - "+res.error.error.message));
+        try {
+          const graphResponseError:GraphResponseError = res.error;
+          if(graphResponseError.error.code) {
+            callback(new CommandError(graphResponseError.error.code+" - "+graphResponseError.error.message));
           } else {
-            callback(new CommandError(res.error.error.message));
+            callback(new CommandError(graphResponseError.error.message));
           }
         }
-        else {
+        catch {
           callback(new CommandError(res.error));
         }
-      }
+      } 
     }
     else {
       if (rawResponse instanceof Error) {

--- a/src/Command.ts
+++ b/src/Command.ts
@@ -2,6 +2,7 @@ import appInsights from './appInsights';
 import GlobalOptions from './GlobalOptions';
 import request from './request';
 import auth from './Auth';
+import { GraphResponseError } from './o365/base/GraphCommand';
 
 const vorpal: Vorpal = require('./vorpal-init');
 
@@ -30,17 +31,6 @@ export interface CommandCancel {
 export interface CommandTypes {
   string?: string[];
   boolean?: string[];
-}
-
-export interface GraphResponseError {
-  error: {
-    code: string;
-    message: string;
-    innerError: {
-      "request-id": string;
-      date: string;
-    }
-  }
 }
 
 export class CommandError {

--- a/src/Command.ts
+++ b/src/Command.ts
@@ -241,7 +241,16 @@ export default abstract class Command {
         callback(new CommandError(err['odata.error'].message.value));
       }
       catch {
-        callback(new CommandError(res.error));
+        if(res.error.error && res.error.error.message) {
+          if(res.error.error.code) {
+            callback(new CommandError(res.error.error.code+" - "+res.error.error.message));
+          } else {
+            callback(new CommandError(res.error.error.message));
+          }
+        }
+        else {
+          callback(new CommandError(res.error));
+        }
       }
     }
     else {

--- a/src/o365/base/GraphCommand.ts
+++ b/src/o365/base/GraphCommand.ts
@@ -1,5 +1,16 @@
 import Command from '../../Command';
 
+export interface GraphResponseError {
+  error: {
+    code: string;
+    message: string;
+    innerError: {
+      "request-id": string;
+      date: string;
+    }
+  }
+}
+
 export default abstract class GraphCommand extends Command {
   protected get resource(): string {
     return 'https://graph.microsoft.com';


### PR DESCRIPTION
Fixes #1096 

The issue was within 'handleRejectedODataPromise'.
It presumed a certain structure for the rawError message which wasn't met.
(res.error was passed as a string when it was actually an object...)
I added some extra checks so the error message returned, better indicates the error that occurred.
The case from #1088 now results in following response:
![image](https://user-images.githubusercontent.com/9864443/64489132-b5736a00-d24f-11e9-9c85-33905af295f2.png)

So now a proper error is thrown based on the web response. However, running with --debug is still required to troubleshoot the actual issue...