### PR TITLE
Update ~/.bashrc for command completion on Mac

### DIFF
--- a/docs/manual/docs/concepts/completion.md
+++ b/docs/manual/docs/concepts/completion.md
@@ -37,6 +37,8 @@ Command completion is based on a static file. After updating the Office 365 CLI,
 
 If you're using Zsh, Bash or Fish as your shell, you can benefit of Office 365 CLI command completion as well, when typing commands directly in the shell. The completion is based on the [Omelette](https://www.npmjs.com/package/omelette) package.
 
+For Mac Terminal, you'll need to add `source /usr/local/etc/profile.d/bash_completion.sh` to `~/.bashrc`
+
 #### Enable sh completion
 
 To enable completion:


### PR DESCRIPTION
Added an extra step for Mac Terminal to update ~/.bashrc so that command completion for o365 CLI works on Mac inline with #1050 