### PR TITLE
Update remarks to handle trailing slash

### DIFF
--- a/docs/manual/docs/cmd/spo/storageentity/storageentity-set.md
+++ b/docs/manual/docs/cmd/spo/storageentity/storageentity-set.md
@@ -27,7 +27,9 @@ Option|Description
 
 ## Remarks
 
-Tenant properties are stored in the app catalog site associated with that tenant. To set a property, you have to specify the absolute URL of the app catalog site. If you specify the URL of a site different than the app catalog, you will get an access denied error.
+Tenant properties are stored in the app catalog site associated with that tenant. To set a property, you have to specify the absolute URL of the app catalog site without a trailing slash. 
+- If you specify the URL of a site different than the app catalog, you will get an access denied error.
+- If you specify the URL with trailing slash you get the error 'The managed path sites/apps is not a managed path in this tenant.'
 
 ## Examples
 


### PR DESCRIPTION
otherwise, the following error will be raised:

> Error: The managed path sites/apps is not a managed path in this tenant.

Related issue: #1153 