### PR TITLE
New Command : Get the daily total number of groups and how many of them were active based on email conversations, Yammer posts, and SharePoint file activities.

### DIFF
--- a/docs/manual/docs/cmd/aad/o365group/o365group-report-activitygroupcounts.md
+++ b/docs/manual/docs/cmd/aad/o365group/o365group-report-activitygroupcounts.md
@@ -1,0 +1,39 @@
+# aad o365group report activitygroupcounts
+
+Get the daily total number of groups and how many of them were active based on email conversations, Yammer posts, and SharePoint file activities.
+
+## Usage
+
+```sh
+aad o365group report activitygroupcounts [options]
+```
+
+## Options
+
+Option|Description
+------|-----------
+`--help`|output usage information
+`-p, --period <period>`|The length of time over which the report is aggregated. Supported values `D7|D30|D90|D180`
+`-f, --outputFile [outputFile]`|Path to the file where the Office 365 Groups activities report should be stored in
+`-o, --output [output]`|Output type. `text|json`. Default `text`
+`--verbose`|Runs command with verbose logging
+`--debug`|Runs command with debug logging
+
+## Examples
+
+Get the daily total number of groups and how many of them were active based on activities for the last week
+
+```sh
+aad o365group report activitygroupcounts --period D7
+```
+
+Get the daily total number of groups and how many of them were active based on activities for the last week and exports the report data in the specified path in text format
+
+```sh
+aad o365group report activitygroupcounts --period D7 --output text --outputFile './o365groupactivitygroupcounts.txt'
+```
+
+Get the daily total number of groups and how many of them were active based on activities for the last week and exports the report data in the specified path in json format
+
+```sh
+aad o365group report activitygroupcounts --period D7 --output json --outputFile './o365groupactivitygroupcounts.json'

--- a/docs/manual/mkdocs.yml
+++ b/docs/manual/mkdocs.yml
@@ -31,6 +31,7 @@ nav:
         - o365group set: 'cmd/aad/o365group/o365group-set.md'
         - o365group teamify: 'cmd/aad/o365group/o365group-teamify.md'
         - o365group report activitydetail: 'cmd/aad/o365group/o365group-report-activitydetail.md'
+        - o365group report activitygroupcounts: 'cmd/aad/o365group/o365group-report-activitygroupcounts.md'
         - o365group user add: 'cmd/aad/o365group/o365group-user-add.md'
         - o365group user list: 'cmd/aad/o365group/o365group-user-list.md'
         - o365group user remove: 'cmd/aad/o365group/o365group-user-remove.md'

--- a/src/o365/aad/commands.ts
+++ b/src/o365/aad/commands.ts
@@ -16,6 +16,7 @@ export default {
   O365GROUP_REMOVE: `${prefix} o365group remove`,
   O365GROUP_RENEW: `${prefix} o365group renew`,
   O365GROUP_REPORT_ACTIVITYDETAIL: `${prefix} o365group report activitydetail`,
+  O365GROUP_REPORT_ACTIVITYGROUPCOUNTS: `${prefix} o365group report activitygroupcounts`,
   O365GROUP_RESTORE: `${prefix} o365group restore`,
   O365GROUP_USER_ADD: `${prefix} o365group user add`,
   O365GROUP_USER_LIST: `${prefix} o365group user list`,

--- a/src/o365/aad/commands/o365group/o365group-report-activitygroupcounts.spec.ts
+++ b/src/o365/aad/commands/o365group/o365group-report-activitygroupcounts.spec.ts
@@ -1,0 +1,357 @@
+import commands from '../../commands';
+import Command, { CommandOption, CommandError, CommandValidate } from '../../../../Command';
+import * as sinon from 'sinon';
+import appInsights from '../../../../appInsights';
+import auth from '../../../../Auth';
+const command: Command = require('./o365group-report-activitygroupcounts');
+import * as assert from 'assert';
+import Utils from '../../../../Utils';
+import request from '../../../../request';
+import * as fs from 'fs';
+
+describe(commands.O365GROUP_REPORT_ACTIVITYGROUPCOUNTS, () => {
+  let vorpal: Vorpal;
+  let log: string[];
+  let cmdInstance: any;
+  let cmdInstanceLogSpy: sinon.SinonSpy;
+  let writeFileSyncFake = () => { };
+
+  before(() => {
+    sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
+    sinon.stub(appInsights, 'trackEvent').callsFake(() => { });
+    auth.service.connected = true;
+  });
+
+  beforeEach(() => {
+    vorpal = require('../../../../vorpal-init');
+    log = [];
+    cmdInstance = {
+      commandWrapper: {
+        command: command.name
+      },
+      action: command.action(),
+      log: (msg: string) => {
+        log.push(msg);
+      }
+    };
+    cmdInstanceLogSpy = sinon.spy(cmdInstance, 'log');
+    (command as any).items = [];
+  });
+
+  afterEach(() => {
+    Utils.restore([
+      vorpal.find,
+      request.get,
+      fs.writeFileSync
+    ]);
+  });
+
+  after(() => {
+    Utils.restore([
+      appInsights.trackEvent,
+      auth.restoreAuth
+    ]);
+    auth.service.connected = false;
+  });
+
+  it('has correct name', () => {
+    assert.equal(command.name.startsWith(commands.O365GROUP_REPORT_ACTIVITYGROUPCOUNTS), true);
+  });
+
+  it('has a description', () => {
+    assert.notEqual(command.description, null);
+  });
+
+  it('fails validation if period option is not passed', () => {
+    const actual = (command.validate() as CommandValidate)({ options: {} });
+    assert.notEqual(actual, true);
+  });
+
+  it('fails validation on invalid period', () => {
+    const actual = (command.validate() as CommandValidate)({ options: { period: 'abc' } });
+    assert.notEqual(actual, true);
+  });
+
+  it('passes validation on valid \'D7\' period', () => {
+    const actual = (command.validate() as CommandValidate)({
+      options: {
+        period: 'D7'
+      }
+    });
+    assert.equal(actual, true);
+  });
+
+  it('passes validation on valid \'D30\' period', () => {
+    const actual = (command.validate() as CommandValidate)({
+      options: {
+        period: 'D30'
+      }
+    });
+    assert.equal(actual, true);
+  });
+
+  it('passes validation on valid \'D90\' period', () => {
+    const actual = (command.validate() as CommandValidate)({
+      options: {
+        period: 'D90'
+      }
+    });
+    assert.equal(actual, true);
+  });
+
+  it('passes validation on valid \'180\' period', () => {
+    const actual = (command.validate() as CommandValidate)({
+      options: {
+        period: 'D90'
+      }
+    });
+    assert.equal(actual, true);
+  });
+
+  it('fails validation if specified outputFile directory path doesn\'t exist', () => {
+    sinon.stub(fs, 'existsSync').callsFake(() => false);
+    const actual = (command.validate() as CommandValidate)({
+      options: {
+        period: 'D7',
+        outputFile: '/path/not/found.zip'
+      }
+    });
+    Utils.restore(fs.existsSync);
+    assert.notEqual(actual, true);
+  });
+  
+  it('gets the daily total number of groups and how many of them were active based on activities for the given period', (done) => {
+    const requestStub: sinon.SinonStub = sinon.stub(request, 'get').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/reports/getOffice365GroupsActivityGroupCounts(period='D7')`) {
+        return Promise.resolve(`
+        Report Refresh Date,Total,Active,Report Date,Report Period
+        2019-10-14,217,0,2019-10-14,7
+        2019-10-14,217,0,2019-10-13,7
+        `);
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    cmdInstance.action({ options: { debug: false, period: 'D7' } }, () => {
+      try {
+        assert.equal(requestStub.lastCall.args[0].url, "https://graph.microsoft.com/v1.0/reports/getOffice365GroupsActivityGroupCounts(period='D7')");
+        assert.equal(requestStub.lastCall.args[0].headers["accept"], 'application/json;odata.metadata=none');
+        assert.equal(requestStub.lastCall.args[0].json, true);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('gets the daily total number of groups and how many of them were active based on activities for the given period and export report data in txt format', (done) => {
+    const requestStub: sinon.SinonStub = sinon.stub(request, 'get').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/reports/getOffice365GroupsActivityGroupCounts(period='D7')`) {
+        return Promise.resolve(`
+        Report Refresh Date,Total,Active,Report Date,Report Period
+        2019-10-14,217,0,2019-10-14,7
+        2019-10-14,217,0,2019-10-13,7
+        `);
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    const fileStub: sinon.SinonStub = sinon.stub(fs, 'writeFileSync').callsFake(writeFileSyncFake);
+
+    cmdInstance.action({ options: { debug: false, period: 'D7', outputFile: './o365groupactivitygroupcounts.txt' } }, () => {
+      try {
+        assert.equal(requestStub.lastCall.args[0].url, "https://graph.microsoft.com/v1.0/reports/getOffice365GroupsActivityGroupCounts(period='D7')");
+        assert.equal(requestStub.lastCall.args[0].headers["accept"], 'application/json;odata.metadata=none');
+        assert.equal(requestStub.lastCall.args[0].json, true);
+        assert.equal(fileStub.called, true);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('gets the daily total number of groups and how many of them were active based on activities for the given period when output is json', (done) => {
+    const requestStub: sinon.SinonStub = sinon.stub(request, 'get').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/reports/getOffice365GroupsActivityGroupCounts(period='D7')`) {
+        return Promise.resolve(`
+        Report Refresh Date,Total,Active,Report Date,Report Period
+        2019-10-14,217,0,2019-10-14,7
+        2019-10-14,217,0,2019-10-13,7
+        `);
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    const fileStub: sinon.SinonStub = sinon.stub(fs, 'writeFileSync').callsFake(writeFileSyncFake);
+
+    cmdInstance.action({ options: { debug: false, period: 'D7', output: 'json' } }, () => {
+      try {
+        assert.equal(requestStub.lastCall.args[0].url, "https://graph.microsoft.com/v1.0/reports/getOffice365GroupsActivityGroupCounts(period='D7')");
+        assert.equal(requestStub.lastCall.args[0].headers["accept"], 'application/json;odata.metadata=none');
+        assert.equal(requestStub.lastCall.args[0].json, true);
+        assert.equal(fileStub.notCalled, true);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('gets the daily total number of groups and how many of them were active based on activities for the given period and export report data in txt format with output', (done) => {
+    const requestStub: sinon.SinonStub = sinon.stub(request, 'get').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/reports/getOffice365GroupsActivityGroupCounts(period='D7')`) {
+        return Promise.resolve(`
+        Report Refresh Date,Total,Active,Report Date,Report Period
+        2019-10-14,217,0,2019-10-14,7
+        2019-10-14,217,0,2019-10-13,7
+        `);
+      }
+
+      return Promise.reject('Invalid request');
+    });
+    const fileStub: sinon.SinonStub = sinon.stub(fs, 'writeFileSync').callsFake(writeFileSyncFake);
+
+    cmdInstance.action({ options: { debug: false, period: 'D7', outputFile: './o365groupactivitygroupcounts.txt', output: 'text' } }, () => {
+      try {
+        assert.equal(requestStub.lastCall.args[0].url, "https://graph.microsoft.com/v1.0/reports/getOffice365GroupsActivityGroupCounts(period='D7')");
+        assert.equal(requestStub.lastCall.args[0].headers["accept"], 'application/json;odata.metadata=none');
+        assert.equal(requestStub.lastCall.args[0].json, true);
+        assert.equal(fileStub.called, true);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('gets the daily total number of groups and how many of them were active based on activities for the given period and export report data in json format', (done) => {
+    const requestStub: sinon.SinonStub = sinon.stub(request, 'get').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/reports/getOffice365GroupsActivityGroupCounts(period='D7')`) {
+        return Promise.resolve(`
+        Report Refresh Date,Total,Active,Report Date,Report Period
+        2019-10-14,217,0,2019-10-14,7
+        2019-10-14,217,0,2019-10-13,7
+        `);
+      }
+
+      return Promise.reject('Invalid request');
+    });
+    const fileStub: sinon.SinonStub = sinon.stub(fs, 'writeFileSync').callsFake(writeFileSyncFake);
+
+    cmdInstance.action({ options: { debug: false, period: 'D7', outputFile: './o365groupactivitygroupcounts.json' } }, () => {
+      try {
+        assert.equal(requestStub.lastCall.args[0].url, "https://graph.microsoft.com/v1.0/reports/getOffice365GroupsActivityGroupCounts(period='D7')");
+        assert.equal(requestStub.lastCall.args[0].headers["accept"], 'application/json;odata.metadata=none');
+        assert.equal(requestStub.lastCall.args[0].json, true);
+        assert.equal(fileStub.called, true);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('gets the daily total number of groups and how many of them were active based on activities for the given period and export report data in json format with output', (done) => {
+    const requestStub: sinon.SinonStub = sinon.stub(request, 'get').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/reports/getOffice365GroupsActivityGroupCounts(period='D7')`) {
+        return Promise.resolve(`Report Refresh Date,Total,Active,Report Date,Report Period\n2019-10-14,217,0,2019-10-14,7`);
+      }
+
+      return Promise.reject('Invalid request');
+    });
+    const fileStub: sinon.SinonStub = sinon.stub(fs, 'writeFileSync').callsFake(writeFileSyncFake);
+
+    cmdInstance.action({ options: { debug: true, period: 'D7', outputFile: './o365groupactivitygroupcounts.json', output: 'json' } }, () => {
+      try {
+        assert.equal(requestStub.lastCall.args[0].url, "https://graph.microsoft.com/v1.0/reports/getOffice365GroupsActivityGroupCounts(period='D7')");
+        assert.equal(requestStub.lastCall.args[0].headers["accept"], 'application/json;odata.metadata=none');
+        assert.equal(requestStub.lastCall.args[0].json, true);
+        assert.equal(fileStub.called, true);
+        assert(cmdInstanceLogSpy.calledWith(`File saved to path './o365groupactivitygroupcounts.json'`));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('correctly handles random API error', (done) => {
+    sinon.stub(request, 'get').callsFake((opts) => Promise.reject('An error has occurred'));
+
+    cmdInstance.action({ options: { debug: false, period: 'D7' } }, (err?: any) => {
+      try {
+        assert.equal(JSON.stringify(err), JSON.stringify(new CommandError('An error has occurred')));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('supports specifying outputFile', () => {
+    const options = (command.options() as CommandOption[]);
+    let containsOption = false;
+    options.forEach(o => {
+      if (o.option.indexOf('--outputFile') > -1) {
+        containsOption = true;
+      }
+    });
+    assert(containsOption);
+  });
+
+  it('supports debug mode', () => {
+    const options = (command.options() as CommandOption[]);
+    let containsOption = false;
+    options.forEach(o => {
+      if (o.option === '--debug') {
+        containsOption = true;
+      }
+    });
+    assert(containsOption);
+  });
+
+  it('has help referring to the right command', () => {
+    const cmd: any = {
+      log: (msg: string) => { },
+      prompt: () => { },
+      helpInformation: () => { }
+    };
+    const find = sinon.stub(vorpal, 'find').callsFake(() => cmd);
+    cmd.help = command.help();
+    cmd.help({}, () => { });
+    assert(find.calledWith(commands.O365GROUP_REPORT_ACTIVITYGROUPCOUNTS));
+  });
+
+  it('has help with examples', () => {
+    const _log: string[] = [];
+    const cmd: any = {
+      log: (msg: string) => {
+        _log.push(msg);
+      },
+      prompt: () => { },
+      helpInformation: () => { }
+    };
+    sinon.stub(vorpal, 'find').callsFake(() => cmd);
+    cmd.help = command.help();
+    cmd.help({}, () => { });
+    let containsExamples: boolean = false;
+    _log.forEach(l => {
+      if (l && l.indexOf('Examples:') > -1) {
+        containsExamples = true;
+      }
+    });
+    Utils.restore(vorpal.find);
+    assert(containsExamples);
+  });
+});

--- a/src/o365/aad/commands/o365group/o365group-report-activitygroupcounts.ts
+++ b/src/o365/aad/commands/o365group/o365group-report-activitygroupcounts.ts
@@ -1,0 +1,154 @@
+import commands from '../../commands';
+import GlobalOptions from '../../../../GlobalOptions';
+import {
+  CommandOption, CommandValidate
+} from '../../../../Command';
+import GraphCommand from "../../../base/GraphCommand";
+import request from '../../../../request';
+import * as path from 'path';
+import * as fs from 'fs';
+
+const vorpal: Vorpal = require('../../../../vorpal-init');
+
+interface CommandArgs {
+  options: Options;
+}
+
+interface Options extends GlobalOptions {
+  period: string;
+  outputFile?: string;
+}
+
+class O365GroupReportActivityGroupCountsCommand extends GraphCommand {
+  public get name(): string {
+    return `${commands.O365GROUP_REPORT_ACTIVITYGROUPCOUNTS}`;
+  }
+
+  public get description(): string {
+    return 'Get the daily total number of groups and how many of them were active based on email conversations, Yammer posts, and SharePoint file activities';
+  }
+
+  public getTelemetryProperties(args: CommandArgs): any {
+    const telemetryProps: any = super.getTelemetryProperties(args);
+    telemetryProps.period = args.options.period;
+    telemetryProps.outputFile = typeof args.options.outputFile !== 'undefined';
+    return telemetryProps;
+  }
+
+  public commandAction(cmd: CommandInstance, args: CommandArgs, cb: () => void): void {
+    const endpoint: string = `${this.resource}/v1.0/reports/getOffice365GroupsActivityGroupCounts(period='${encodeURIComponent(args.options.period)}')`;
+
+    const requestOptions: any = {
+      url: endpoint,
+      headers: {
+        accept: 'application/json;odata.metadata=none'
+      },
+      json: true
+    };
+
+    request
+      .get(requestOptions)
+      .then((res: any): void => {
+        let content: string = '';
+        const cleanResponse = this.removeEmptyLines(res);
+
+        if (args.options.output && args.options.output.toLowerCase() === 'json') {
+          const reportdata: any = this.getReport(cleanResponse);
+          content = JSON.stringify(reportdata);
+        }
+        else {
+          content = cleanResponse;
+        }
+
+        if (!args.options.outputFile) {
+          cmd.log(content);
+        }
+        else {
+          fs.writeFileSync(args.options.outputFile, content, 'utf8');
+          if (this.verbose) {
+            cmd.log(`File saved to path '${args.options.outputFile}'`);
+          }
+        }
+
+        cb();
+      }, (err: any): void => this.handleRejectedODataJsonPromise(err, cmd, cb));
+  }
+
+  private removeEmptyLines(input: string): string {
+    const rows: string[] = input.split('\n');
+    const cleanRows = rows.filter(Boolean);
+    return cleanRows.join('\n');
+  }
+
+  private getReport(res: string): any {
+    const rows: string[] = res.split('\n');
+    const jsonObj: any = [];
+    const headers: string[] = rows[0].split(',');
+
+    for (let i = 1; i < rows.length; i++) {
+      const data: string[] = rows[i].split(',');
+      let obj: any = {};
+      for (let j = 0; j < data.length; j++) {
+        obj[headers[j].trim()] = data[j].trim();
+      }
+      jsonObj.push(obj);
+    }
+
+    return jsonObj;
+  }
+
+  public options(): CommandOption[] {
+    const options: CommandOption[] = [
+      {
+        option: '-p, --period <period>',
+        description: 'The length of time over which the report is aggregated. Supported values D7|D30|D90|D180',
+        autocomplete: ['D7', 'D30', 'D90', 'D180']
+      },
+      {
+        option: '-f, --outputFile [outputFile]',
+        description: 'Path to the file where the Office 365 Groups activities report should be stored in'
+      }
+    ];
+
+    const parentOptions: CommandOption[] = super.options();
+    return options.concat(parentOptions);
+  }
+
+  public validate(): CommandValidate {
+    return (args: CommandArgs): boolean | string => {
+      if (!args.options.period) {
+        return 'Required parameter period missing';
+      }
+
+      if (['D7', 'D30', 'D90', 'D180'].indexOf(args.options.period) < 0) {
+        return `${args.options.period} is not a valid period type. The supported values are D7|D30|D90|D180`;
+      }
+
+      if (args.options.outputFile && !fs.existsSync(path.dirname(args.options.outputFile))) {
+        return `The specified path ${path.dirname(args.options.outputFile)} doesn't exist`;
+      }
+
+      return true;
+    };
+  }
+
+  public commandHelp(args: {}, log: (help: string) => void): void {
+    log(vorpal.find(this.name).helpInformation());
+    log(
+      `  Examples:
+
+    Get the daily total number of groups and how many of them were active based on activities for the last week
+      ${commands.O365GROUP_REPORT_ACTIVITYGROUPCOUNTS} --period D7
+
+    Get the daily total number of groups and how many of them were active based on activities for the last week
+    and exports the report data in the specified path in text format
+      ${commands.O365GROUP_REPORT_ACTIVITYGROUPCOUNTS} --period D7 --output text --outputFile './o365groupactivitygroupcounts.txt'
+
+    Get the daily total number of groups and how many of them were active based on activities for the last week
+    and exports the report data in the specified path in json format
+      ${commands.O365GROUP_REPORT_ACTIVITYGROUPCOUNTS} --period D7 --output json --outputFile './o365groupactivitygroupcounts.json'
+`);
+  }
+}
+
+module.exports = new O365GroupReportActivityGroupCountsCommand();


### PR DESCRIPTION
Hi @waldekmastykarz,
Could you please review this(issue #1160) new command and provide feedback/merge?
Thanks.