### PR TITLE
implemented PeriodBasedReport base class

### DIFF
--- a/src/o365/base/PeriodBasedReport.spec.ts
+++ b/src/o365/base/PeriodBasedReport.spec.ts
@@ -1,0 +1,334 @@
+import * as sinon from 'sinon';
+import appInsights from '../../appInsights';
+import auth from '../../Auth';
+import * as assert from 'assert';
+import Utils from '../../Utils';
+import request from '../../request';
+import * as fs from 'fs';
+import PeriodBasedReport from './PeriodBasedReport';
+import { CommandValidate, CommandError } from '../../Command';
+
+class MockCommand extends PeriodBasedReport {
+  public get name(): string {
+    return 'mock';
+  }
+
+  public get description(): string {
+    return 'Mock command';
+  }
+
+  public get usageEndPoint(): string {
+    return 'MockEndPoint';
+  }
+
+  public commandHelp(args: any, log: (message: string) => void): void {
+  }
+}
+
+describe('PeriodBasedReport', () => {
+  const mockCommand = new MockCommand();
+  let vorpal: Vorpal;
+  let log: string[];
+  let cmdInstance: any;
+  let cmdInstanceLogSpy: sinon.SinonSpy;
+  let writeFileSyncFake = () => { };
+
+  before(() => {
+    sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
+    sinon.stub(appInsights, 'trackEvent').callsFake(() => { });
+    auth.service.connected = true;
+  });
+
+  beforeEach(() => {
+    vorpal = require('../../vorpal-init');
+    log = [];
+    cmdInstance = {
+      commandWrapper: {
+        command: mockCommand.name
+      },
+      action: mockCommand.action(),
+      log: (msg: string) => {
+        log.push(msg);
+      }
+    };
+    cmdInstanceLogSpy = sinon.spy(cmdInstance, 'log');
+    (mockCommand as any).items = [];
+  });
+
+  afterEach(() => {
+    Utils.restore([
+      vorpal.find,
+      request.get,
+      fs.writeFileSync
+    ]);
+  });
+
+  after(() => {
+    Utils.restore([
+      appInsights.trackEvent,
+      auth.restoreAuth
+    ]);
+    auth.service.connected = false;
+  });
+
+  it('has correct name', () => {
+    assert.equal(mockCommand.name.startsWith('mock'), true);
+  });
+
+  it('has a description', () => {
+    assert.notEqual(mockCommand.description, null);
+  });
+
+  it('fails validation if period option is not passed', () => {
+    const actual = (mockCommand.validate() as CommandValidate)({ options: {} });
+    assert.notEqual(actual, true);
+  });
+
+  it('fails validation on invalid period', () => {
+    const actual = (mockCommand.validate() as CommandValidate)({ options: { period: 'abc' } });
+    assert.notEqual(actual, true);
+  });
+
+  it('passes validation on valid \'D7\' period', () => {
+    const actual = (mockCommand.validate() as CommandValidate)({
+      options: {
+        period: 'D7'
+      }
+    });
+    assert.equal(actual, true);
+  });
+
+  it('passes validation on valid \'D30\' period', () => {
+    const actual = (mockCommand.validate() as CommandValidate)({
+      options: {
+        period: 'D30'
+      }
+    });
+    assert.equal(actual, true);
+  });
+
+  it('passes validation on valid \'D90\' period', () => {
+    const actual = (mockCommand.validate() as CommandValidate)({
+      options: {
+        period: 'D90'
+      }
+    });
+    assert.equal(actual, true);
+  });
+
+  it('passes validation on valid \'180\' period', () => {
+    const actual = (mockCommand.validate() as CommandValidate)({
+      options: {
+        period: 'D90'
+      }
+    });
+    assert.equal(actual, true);
+  });
+
+  it('fails validation if specified outputFile directory path doesn\'t exist', () => {
+    sinon.stub(fs, 'existsSync').callsFake(() => false);
+    const actual = (mockCommand.validate() as CommandValidate)({
+      options: {
+        period: 'D7',
+        outputFile: '/path/not/found.zip'
+      }
+    });
+    Utils.restore(fs.existsSync);
+    assert.notEqual(actual, true);
+  });
+
+  it('gets the number of Microsoft Teams unique users by device type for the given period', (done) => {
+    const requestStub: sinon.SinonStub = sinon.stub(request, 'get').callsFake((opts) => {
+      /*if (opts.url === `https://graph.microsoft.com/v1.0/reports/MockEndPoint(period='D7')`) {*/
+        return Promise.resolve(`
+        Report Refresh Date,Web,Windows Phone,Android Phone,iOS,Mac,Windows,Report Period
+        2019-08-28,0,0,0,0,0,0,7
+        `);
+      /*}*/
+
+      return Promise.reject('Invalid request');
+    });
+
+    cmdInstance.action({ options: { debug: false, period: 'D7' } }, () => {
+      try {
+        assert.equal(requestStub.lastCall.args[0].url, "https://graph.microsoft.com/v1.0/reports/MockEndPoint(period='D7')");
+        assert.equal(requestStub.lastCall.args[0].headers["accept"], 'application/json;odata.metadata=none');
+        assert.equal(requestStub.lastCall.args[0].json, true);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('gets the number of Microsoft Teams unique users by device type for the given period and export report data in txt format', (done) => {
+    const requestStub: sinon.SinonStub = sinon.stub(request, 'get').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/reports/MockEndPoint(period='D7')`) {
+        return Promise.resolve(`
+        Report Refresh Date,Web,Windows Phone,Android Phone,iOS,Mac,Windows,Report Period
+        2019-08-28,0,0,0,0,0,0,7
+        `);
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    const fileStub: sinon.SinonStub = sinon.stub(fs, 'writeFileSync').callsFake(writeFileSyncFake);
+
+    cmdInstance.action({ options: { debug: false, period: 'D7', outputFile: '/Users/josephvelliah/Desktop/deviceusagedistributionusercounts.txt' } }, () => {
+      try {
+        assert.equal(requestStub.lastCall.args[0].url, "https://graph.microsoft.com/v1.0/reports/MockEndPoint(period='D7')");
+        assert.equal(requestStub.lastCall.args[0].headers["accept"], 'application/json;odata.metadata=none');
+        assert.equal(requestStub.lastCall.args[0].json, true);
+        assert.equal(fileStub.called, true);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('gets the number of Microsoft Teams unique users by device type for the given period when output is json', (done) => {
+    const requestStub: sinon.SinonStub = sinon.stub(request, 'get').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/reports/MockEndPoint(period='D7')`) {
+        return Promise.resolve(`Report Refresh Date,Web,Windows Phone,Android Phone,iOS,Mac,Windows,Report Period
+        2019-08-28,0,0,0,0,0,0,7
+        `);
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    const fileStub: sinon.SinonStub = sinon.stub(fs, 'writeFileSync').callsFake(writeFileSyncFake);
+
+    cmdInstance.action({ options: { debug: false, period: 'D7', output: 'json' } }, () => {
+      try {
+        assert.equal(requestStub.lastCall.args[0].url, "https://graph.microsoft.com/v1.0/reports/MockEndPoint(period='D7')");
+        assert.equal(requestStub.lastCall.args[0].headers["accept"], 'application/json;odata.metadata=none');
+        assert.equal(requestStub.lastCall.args[0].json, true);
+        assert.equal(fileStub.notCalled, true);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('gets the number of Microsoft Teams unique users by device type for the given period and export report data in txt format with output', (done) => {
+    const requestStub: sinon.SinonStub = sinon.stub(request, 'get').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/reports/MockEndPoint(period='D7')`) {
+        return Promise.resolve(`
+        Report Refresh Date,Web,Windows Phone,Android Phone,iOS,Mac,Windows,Report Period
+        2019-08-28,0,0,0,0,0,0,7
+        `);
+      }
+
+      return Promise.reject('Invalid request');
+    });
+    const fileStub: sinon.SinonStub = sinon.stub(fs, 'writeFileSync').callsFake(writeFileSyncFake);
+
+    cmdInstance.action({ options: { debug: false, period: 'D7', outputFile: '/Users/josephvelliah/Desktop/deviceusagedistributionusercounts.txt', output: 'text' } }, () => {
+      try {
+        assert.equal(requestStub.lastCall.args[0].url, "https://graph.microsoft.com/v1.0/reports/MockEndPoint(period='D7')");
+        assert.equal(requestStub.lastCall.args[0].headers["accept"], 'application/json;odata.metadata=none');
+        assert.equal(requestStub.lastCall.args[0].json, true);
+        assert.equal(fileStub.called, true);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('gets the number of Microsoft Teams unique users by device type for the given period and export report data in json format', (done) => {
+    const requestStub: sinon.SinonStub = sinon.stub(request, 'get').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/reports/MockEndPoint(period='D7')`) {
+        return Promise.resolve(`
+        Report Refresh Date,Web,Windows Phone,Android Phone,iOS,Mac,Windows,Report Period
+        2019-08-28,0,0,0,0,0,0,7
+        `);
+      }
+
+      return Promise.reject('Invalid request');
+    });
+    const fileStub: sinon.SinonStub = sinon.stub(fs, 'writeFileSync').callsFake(writeFileSyncFake);
+
+    cmdInstance.action({ options: { debug: false, period: 'D7', outputFile: '/Users/josephvelliah/Desktop/deviceusagedistributionusercounts.json' } }, () => {
+      try {
+        assert.equal(requestStub.lastCall.args[0].url, "https://graph.microsoft.com/v1.0/reports/MockEndPoint(period='D7')");
+        assert.equal(requestStub.lastCall.args[0].headers["accept"], 'application/json;odata.metadata=none');
+        assert.equal(requestStub.lastCall.args[0].json, true);
+        assert.equal(fileStub.called, true);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('gets the number of Microsoft Teams unique users by device type for the given period and export report data in json format with output', (done) => {
+    const requestStub: sinon.SinonStub = sinon.stub(request, 'get').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/reports/MockEndPoint(period='D7')`) {
+        return Promise.resolve(`Report Refresh Date,Web,Windows Phone,Android Phone,iOS,Mac,Windows,Report Period\n2019-08-28,0,0,0,0,0,0,7`);
+      }
+
+      return Promise.reject('Invalid request');
+    });
+    const fileStub: sinon.SinonStub = sinon.stub(fs, 'writeFileSync').callsFake(writeFileSyncFake);
+
+    cmdInstance.action({ options: { debug: true, period: 'D7', outputFile: '/Users/josephvelliah/Desktop/deviceusagedistributionusercounts.json', output: 'json' } }, () => {
+      try {
+        assert.equal(requestStub.lastCall.args[0].url, "https://graph.microsoft.com/v1.0/reports/MockEndPoint(period='D7')");
+        assert.equal(requestStub.lastCall.args[0].headers["accept"], 'application/json;odata.metadata=none');
+        assert.equal(requestStub.lastCall.args[0].json, true);
+        assert.equal(fileStub.called, true);
+        assert(cmdInstanceLogSpy.calledWith(`File saved to path '/Users/josephvelliah/Desktop/deviceusagedistributionusercounts.json'`));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('correctly handles random API error', (done) => {
+    sinon.stub(request, 'get').callsFake((opts) => Promise.reject('An error has occurred'));
+
+    cmdInstance.action({ options: { debug: false, period: 'D7' } }, (err?: any) => {
+      try {
+        assert.equal(JSON.stringify(err), JSON.stringify(new CommandError('An error has occurred')));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('supports specifying outputFile', () => {
+    const options = mockCommand.options();
+    let containsOption = false;
+    options.forEach((o: any) => {
+      if (o.option.indexOf('--outputFile') > -1) {
+        containsOption = true;
+      }
+    });
+    assert(containsOption);
+  });
+
+  it('supports debug mode', () => {
+    const options = mockCommand.options();
+    let containsOption = false;
+    options.forEach((o: any) => {
+      if (o.option === '--debug') {
+        containsOption = true;
+      }
+    });
+    assert(containsOption);
+  });
+});

--- a/src/o365/base/PeriodBasedReport.spec.ts
+++ b/src/o365/base/PeriodBasedReport.spec.ts
@@ -137,14 +137,14 @@ describe('PeriodBasedReport', () => {
     assert.notEqual(actual, true);
   });
 
-  it('gets the number of Microsoft Teams unique users by device type for the given period', (done) => {
+  it('get unique device type in teams and export it in a period', (done) => {
     const requestStub: sinon.SinonStub = sinon.stub(request, 'get').callsFake((opts) => {
-      /*if (opts.url === `https://graph.microsoft.com/v1.0/reports/MockEndPoint(period='D7')`) {*/
+      if (opts.url === `https://graph.microsoft.com/v1.0/reports/MockEndPoint(period='D7')`) {
         return Promise.resolve(`
         Report Refresh Date,Web,Windows Phone,Android Phone,iOS,Mac,Windows,Report Period
         2019-08-28,0,0,0,0,0,0,7
         `);
-      /*}*/
+      }
 
       return Promise.reject('Invalid request');
     });
@@ -162,7 +162,7 @@ describe('PeriodBasedReport', () => {
     });
   });
 
-  it('gets the number of Microsoft Teams unique users by device type for the given period and export report data in txt format', (done) => {
+  it('produce export using period format and Teams unique device type output in txt', (done) => {
     const requestStub: sinon.SinonStub = sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/reports/MockEndPoint(period='D7')`) {
         return Promise.resolve(`
@@ -190,7 +190,7 @@ describe('PeriodBasedReport', () => {
     });
   });
 
-  it('gets the number of Microsoft Teams unique users by device type for the given period when output is json', (done) => {
+  it('produce export using period format and Teams unique device type output in json', (done) => {
     const requestStub: sinon.SinonStub = sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/reports/MockEndPoint(period='D7')`) {
         return Promise.resolve(`Report Refresh Date,Web,Windows Phone,Android Phone,iOS,Mac,Windows,Report Period
@@ -217,7 +217,7 @@ describe('PeriodBasedReport', () => {
     });
   });
 
-  it('gets the number of Microsoft Teams unique users by device type for the given period and export report data in txt format with output', (done) => {
+  it('produce export using period format and Teams unique users output in txt', (done) => {
     const requestStub: sinon.SinonStub = sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/reports/MockEndPoint(period='D7')`) {
         return Promise.resolve(`
@@ -244,7 +244,7 @@ describe('PeriodBasedReport', () => {
     });
   });
 
-  it('gets the number of Microsoft Teams unique users by device type for the given period and export report data in json format', (done) => {
+  it('produce export using period format and Teams unique users output in json', (done) => {
     const requestStub: sinon.SinonStub = sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/reports/MockEndPoint(period='D7')`) {
         return Promise.resolve(`
@@ -271,7 +271,7 @@ describe('PeriodBasedReport', () => {
     });
   });
 
-  it('gets the number of Microsoft Teams unique users by device type for the given period and export report data in json format with output', (done) => {
+  it('produce export using period format and Teams output in json', (done) => {
     const requestStub: sinon.SinonStub = sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/v1.0/reports/MockEndPoint(period='D7')`) {
         return Promise.resolve(`Report Refresh Date,Web,Windows Phone,Android Phone,iOS,Mac,Windows,Report Period\n2019-08-28,0,0,0,0,0,0,7`);

--- a/src/o365/base/PeriodBasedReport.ts
+++ b/src/o365/base/PeriodBasedReport.ts
@@ -1,0 +1,125 @@
+import GlobalOptions from '../../GlobalOptions';
+import {
+  CommandOption, CommandValidate
+} from '../../Command';
+import GraphCommand from "./GraphCommand";
+import request from '../../request';
+import * as path from 'path';
+import * as fs from 'fs';
+
+interface CommandArgs {
+  options: Options;
+}
+
+interface Options extends GlobalOptions {
+  period: string;
+  outputFile?: string;
+}
+
+export default abstract class PeriodBasedReport extends GraphCommand {
+  public getTelemetryProperties(args: CommandArgs): any {
+    const telemetryProps: any = super.getTelemetryProperties(args);
+    telemetryProps.period = args.options.period;
+    telemetryProps.outputFile = typeof args.options.outputFile !== 'undefined';
+    return telemetryProps;
+  }
+
+  public abstract get usageEndPoint(): string;
+
+  public commandAction(cmd: CommandInstance, args: CommandArgs, cb: () => void): void {
+    const endpoint: string = `${this.resource}/v1.0/reports/${this.usageEndPoint}(period='${encodeURIComponent(args.options.period)}')`;
+
+    const requestOptions: any = {
+      url: endpoint,
+      headers: {
+        accept: 'application/json;odata.metadata=none'
+      },
+      json: true
+    };
+
+    request
+      .get(requestOptions)
+      .then((res: any): void => {
+        let content: string = '';
+        let cleanResponse = this.removeEmptyLines(res);
+
+        if (args.options.output && args.options.output.toLowerCase() === 'json') {
+          const reportdata: any = this.getReport(cleanResponse);
+          content = JSON.stringify(reportdata);
+        }
+        else {
+          content = cleanResponse;
+        }
+
+        if (!args.options.outputFile) {
+          cmd.log(content);
+        }
+        else {
+          fs.writeFileSync(args.options.outputFile, content, 'utf8');
+          if (this.verbose) {
+            cmd.log(`File saved to path '${args.options.outputFile}'`);
+          }
+        }
+
+        cb();
+      }, (err: any): void => this.handleRejectedODataJsonPromise(err, cmd, cb));
+  }
+
+  private removeEmptyLines(input: string): string {
+    const rows: string[] = input.split('\n');
+    const cleanRows = rows.filter(Boolean);
+    return cleanRows.join('\n');
+  }
+
+  private getReport(res: string): any {
+    const rows: string[] = res.split('\n');
+    const jsonObj: any = [];
+    const headers: string[] = rows[0].split(',');
+
+    for (let i = 1; i < rows.length; i++) {
+      const data: string[] = rows[i].split(',');
+      let obj: any = {};
+      for (let j = 0; j < data.length; j++) {
+        obj[headers[j].trim()] = data[j].trim();
+      }
+      jsonObj.push(obj);
+    }
+
+    return jsonObj;
+  }
+
+  public options(): CommandOption[] {
+    const options: CommandOption[] = [
+      {
+        option: '-p, --period <period>',
+        description: 'The length of time over which the report is aggregated. Supported values D7|D30|D90|D180',
+        autocomplete: ['D7', 'D30', 'D90', 'D180']
+      },
+      {
+        option: '-f, --outputFile [outputFile]',
+        description: 'Path to the file where the Microsoft Teams unique users by device type report should be stored in'
+      }
+    ];
+
+    const parentOptions: CommandOption[] = super.options();
+    return options.concat(parentOptions);
+  }
+
+  public validate(): CommandValidate {
+    return (args: CommandArgs): boolean | string => {
+      if (!args.options.period) {
+        return 'Required parameter period missing';
+      }
+
+      if (['D7', 'D30', 'D90', 'D180'].indexOf(args.options.period) < 0) {
+        return `${args.options.period} is not a valid period type. The supported values are D7|D30|D90|D180`;
+      }
+
+      if (args.options.outputFile && !fs.existsSync(path.dirname(args.options.outputFile))) {
+        return `The specified path ${path.dirname(args.options.outputFile)} doesn't exist`;
+      }
+
+      return true;
+    };
+  }
+}

--- a/src/o365/base/PeriodBasedReport.ts
+++ b/src/o365/base/PeriodBasedReport.ts
@@ -97,7 +97,7 @@ export default abstract class PeriodBasedReport extends GraphCommand {
       },
       {
         option: '-f, --outputFile [outputFile]',
-        description: 'Path to the file where the Microsoft Teams unique users by device type report should be stored in'
+        description: 'Path to the file where the report should be stored in'
       }
     ];
 

--- a/src/o365/teams/commands/report/teams-report-deviceusagedistributionusercounts.spec.ts
+++ b/src/o365/teams/commands/report/teams-report-deviceusagedistributionusercounts.spec.ts
@@ -1,5 +1,5 @@
 import commands from '../../commands';
-import Command, { CommandOption, CommandError, CommandValidate } from '../../../../Command';
+import Command from '../../../../Command';
 import * as sinon from 'sinon';
 import appInsights from '../../../../appInsights';
 import auth from '../../../../Auth';
@@ -7,14 +7,11 @@ const command: Command = require('./teams-report-deviceusagedistributionusercoun
 import * as assert from 'assert';
 import Utils from '../../../../Utils';
 import request from '../../../../request';
-import * as fs from 'fs';
 
 describe(commands.TEAMS_REPORT_DEVICEUSAGEDISTRIBUTIONUSERCOUNTS, () => {
   let vorpal: Vorpal;
   let log: string[];
   let cmdInstance: any;
-  let cmdInstanceLogSpy: sinon.SinonSpy;
-  let writeFileSyncFake = () => { };
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
@@ -34,15 +31,13 @@ describe(commands.TEAMS_REPORT_DEVICEUSAGEDISTRIBUTIONUSERCOUNTS, () => {
         log.push(msg);
       }
     };
-    cmdInstanceLogSpy = sinon.spy(cmdInstance, 'log');
     (command as any).items = [];
   });
 
   afterEach(() => {
     Utils.restore([
       vorpal.find,
-      request.get,
-      fs.writeFileSync
+      request.get
     ]);
   });
 
@@ -60,64 +55,6 @@ describe(commands.TEAMS_REPORT_DEVICEUSAGEDISTRIBUTIONUSERCOUNTS, () => {
 
   it('has a description', () => {
     assert.notEqual(command.description, null);
-  });
-
-  it('fails validation if period option is not passed', () => {
-    const actual = (command.validate() as CommandValidate)({ options: {} });
-    assert.notEqual(actual, true);
-  });
-
-  it('fails validation on invalid period', () => {
-    const actual = (command.validate() as CommandValidate)({ options: { period: 'abc' } });
-    assert.notEqual(actual, true);
-  });
-
-  it('passes validation on valid \'D7\' period', () => {
-    const actual = (command.validate() as CommandValidate)({
-      options: {
-        period: 'D7'
-      }
-    });
-    assert.equal(actual, true);
-  });
-
-  it('passes validation on valid \'D30\' period', () => {
-    const actual = (command.validate() as CommandValidate)({
-      options: {
-        period: 'D30'
-      }
-    });
-    assert.equal(actual, true);
-  });
-
-  it('passes validation on valid \'D90\' period', () => {
-    const actual = (command.validate() as CommandValidate)({
-      options: {
-        period: 'D90'
-      }
-    });
-    assert.equal(actual, true);
-  });
-
-  it('passes validation on valid \'180\' period', () => {
-    const actual = (command.validate() as CommandValidate)({
-      options: {
-        period: 'D90'
-      }
-    });
-    assert.equal(actual, true);
-  });
-
-  it('fails validation if specified outputFile directory path doesn\'t exist', () => {
-    sinon.stub(fs, 'existsSync').callsFake(() => false);
-    const actual = (command.validate() as CommandValidate)({
-      options: {
-        period: 'D7',
-        outputFile: '/path/not/found.zip'
-      }
-    });
-    Utils.restore(fs.existsSync);
-    assert.notEqual(actual, true);
   });
 
   it('gets the number of Microsoft Teams unique users by device type for the given period', (done) => {
@@ -145,176 +82,6 @@ describe(commands.TEAMS_REPORT_DEVICEUSAGEDISTRIBUTIONUSERCOUNTS, () => {
     });
   });
 
-  it('gets the number of Microsoft Teams unique users by device type for the given period and export report data in txt format', (done) => {
-    const requestStub: sinon.SinonStub = sinon.stub(request, 'get').callsFake((opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/reports/getTeamsDeviceUsageDistributionUserCounts(period='D7')`) {
-        return Promise.resolve(`
-        Report Refresh Date,Web,Windows Phone,Android Phone,iOS,Mac,Windows,Report Period
-        2019-08-28,0,0,0,0,0,0,7
-        `);
-      }
-
-      return Promise.reject('Invalid request');
-    });
-
-    const fileStub: sinon.SinonStub = sinon.stub(fs, 'writeFileSync').callsFake(writeFileSyncFake);
-
-    cmdInstance.action({ options: { debug: false, period: 'D7', outputFile: '/Users/josephvelliah/Desktop/deviceusagedistributionusercounts.txt' } }, () => {
-      try {
-        assert.equal(requestStub.lastCall.args[0].url, "https://graph.microsoft.com/v1.0/reports/getTeamsDeviceUsageDistributionUserCounts(period='D7')");
-        assert.equal(requestStub.lastCall.args[0].headers["accept"], 'application/json;odata.metadata=none');
-        assert.equal(requestStub.lastCall.args[0].json, true);
-        assert.equal(fileStub.called, true);
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
-  });
-
-  it('gets the number of Microsoft Teams unique users by device type for the given period when output is json', (done) => {
-    const requestStub: sinon.SinonStub = sinon.stub(request, 'get').callsFake((opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/reports/getTeamsDeviceUsageDistributionUserCounts(period='D7')`) {
-        return Promise.resolve(`Report Refresh Date,Web,Windows Phone,Android Phone,iOS,Mac,Windows,Report Period
-        2019-08-28,0,0,0,0,0,0,7
-        `);
-      }
-
-      return Promise.reject('Invalid request');
-    });
-
-    const fileStub: sinon.SinonStub = sinon.stub(fs, 'writeFileSync').callsFake(writeFileSyncFake);
-
-    cmdInstance.action({ options: { debug: false, period: 'D7', output: 'json' } }, () => {
-      try {
-        assert.equal(requestStub.lastCall.args[0].url, "https://graph.microsoft.com/v1.0/reports/getTeamsDeviceUsageDistributionUserCounts(period='D7')");
-        assert.equal(requestStub.lastCall.args[0].headers["accept"], 'application/json;odata.metadata=none');
-        assert.equal(requestStub.lastCall.args[0].json, true);
-        assert.equal(fileStub.notCalled, true);
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
-  });
-
-  it('gets the number of Microsoft Teams unique users by device type for the given period and export report data in txt format with output', (done) => {
-    const requestStub: sinon.SinonStub = sinon.stub(request, 'get').callsFake((opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/reports/getTeamsDeviceUsageDistributionUserCounts(period='D7')`) {
-        return Promise.resolve(`
-        Report Refresh Date,Web,Windows Phone,Android Phone,iOS,Mac,Windows,Report Period
-        2019-08-28,0,0,0,0,0,0,7
-        `);
-      }
-
-      return Promise.reject('Invalid request');
-    });
-    const fileStub: sinon.SinonStub = sinon.stub(fs, 'writeFileSync').callsFake(writeFileSyncFake);
-
-    cmdInstance.action({ options: { debug: false, period: 'D7', outputFile: '/Users/josephvelliah/Desktop/deviceusagedistributionusercounts.txt', output: 'text' } }, () => {
-      try {
-        assert.equal(requestStub.lastCall.args[0].url, "https://graph.microsoft.com/v1.0/reports/getTeamsDeviceUsageDistributionUserCounts(period='D7')");
-        assert.equal(requestStub.lastCall.args[0].headers["accept"], 'application/json;odata.metadata=none');
-        assert.equal(requestStub.lastCall.args[0].json, true);
-        assert.equal(fileStub.called, true);
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
-  });
-
-  it('gets the number of Microsoft Teams unique users by device type for the given period and export report data in json format', (done) => {
-    const requestStub: sinon.SinonStub = sinon.stub(request, 'get').callsFake((opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/reports/getTeamsDeviceUsageDistributionUserCounts(period='D7')`) {
-        return Promise.resolve(`
-        Report Refresh Date,Web,Windows Phone,Android Phone,iOS,Mac,Windows,Report Period
-        2019-08-28,0,0,0,0,0,0,7
-        `);
-      }
-
-      return Promise.reject('Invalid request');
-    });
-    const fileStub: sinon.SinonStub = sinon.stub(fs, 'writeFileSync').callsFake(writeFileSyncFake);
-
-    cmdInstance.action({ options: { debug: false, period: 'D7', outputFile: '/Users/josephvelliah/Desktop/deviceusagedistributionusercounts.json' } }, () => {
-      try {
-        assert.equal(requestStub.lastCall.args[0].url, "https://graph.microsoft.com/v1.0/reports/getTeamsDeviceUsageDistributionUserCounts(period='D7')");
-        assert.equal(requestStub.lastCall.args[0].headers["accept"], 'application/json;odata.metadata=none');
-        assert.equal(requestStub.lastCall.args[0].json, true);
-        assert.equal(fileStub.called, true);
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
-  });
-
-  it('gets the number of Microsoft Teams unique users by device type for the given period and export report data in json format with output', (done) => {
-    const requestStub: sinon.SinonStub = sinon.stub(request, 'get').callsFake((opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/reports/getTeamsDeviceUsageDistributionUserCounts(period='D7')`) {
-        return Promise.resolve(`Report Refresh Date,Web,Windows Phone,Android Phone,iOS,Mac,Windows,Report Period\n2019-08-28,0,0,0,0,0,0,7`);
-      }
-
-      return Promise.reject('Invalid request');
-    });
-    const fileStub: sinon.SinonStub = sinon.stub(fs, 'writeFileSync').callsFake(writeFileSyncFake);
-
-    cmdInstance.action({ options: { debug: true, period: 'D7', outputFile: '/Users/josephvelliah/Desktop/deviceusagedistributionusercounts.json', output: 'json' } }, () => {
-      try {
-        assert.equal(requestStub.lastCall.args[0].url, "https://graph.microsoft.com/v1.0/reports/getTeamsDeviceUsageDistributionUserCounts(period='D7')");
-        assert.equal(requestStub.lastCall.args[0].headers["accept"], 'application/json;odata.metadata=none');
-        assert.equal(requestStub.lastCall.args[0].json, true);
-        assert.equal(fileStub.called, true);
-        assert(cmdInstanceLogSpy.calledWith(`File saved to path '/Users/josephvelliah/Desktop/deviceusagedistributionusercounts.json'`));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
-  });
-
-  it('correctly handles random API error', (done) => {
-    sinon.stub(request, 'get').callsFake((opts) => Promise.reject('An error has occurred'));
-
-    cmdInstance.action({ options: { debug: false, period: 'D7' } }, (err?: any) => {
-      try {
-        assert.equal(JSON.stringify(err), JSON.stringify(new CommandError('An error has occurred')));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
-  });
-
-  it('supports specifying outputFile', () => {
-    const options = (command.options() as CommandOption[]);
-    let containsOption = false;
-    options.forEach(o => {
-      if (o.option.indexOf('--outputFile') > -1) {
-        containsOption = true;
-      }
-    });
-    assert(containsOption);
-  });
-
-  it('supports debug mode', () => {
-    const options = (command.options() as CommandOption[]);
-    let containsOption = false;
-    options.forEach(o => {
-      if (o.option === '--debug') {
-        containsOption = true;
-      }
-    });
-    assert(containsOption);
-  });
-
   it('has help referring to the right command', () => {
     const cmd: any = {
       log: (msg: string) => { },
@@ -325,27 +92,5 @@ describe(commands.TEAMS_REPORT_DEVICEUSAGEDISTRIBUTIONUSERCOUNTS, () => {
     cmd.help = command.help();
     cmd.help({}, () => { });
     assert(find.calledWith(commands.TEAMS_REPORT_DEVICEUSAGEDISTRIBUTIONUSERCOUNTS));
-  });
-
-  it('has help with examples', () => {
-    const _log: string[] = [];
-    const cmd: any = {
-      log: (msg: string) => {
-        _log.push(msg);
-      },
-      prompt: () => { },
-      helpInformation: () => { }
-    };
-    sinon.stub(vorpal, 'find').callsFake(() => cmd);
-    cmd.help = command.help();
-    cmd.help({}, () => { });
-    let containsExamples: boolean = false;
-    _log.forEach(l => {
-      if (l && l.indexOf('Examples:') > -1) {
-        containsExamples = true;
-      }
-    });
-    Utils.restore(vorpal.find);
-    assert(containsExamples);
   });
 });

--- a/src/o365/teams/commands/report/teams-report-deviceusagedistributionusercounts.ts
+++ b/src/o365/teams/commands/report/teams-report-deviceusagedistributionusercounts.ts
@@ -1,135 +1,19 @@
 import commands from '../../commands';
-import GlobalOptions from '../../../../GlobalOptions';
-import {
-  CommandOption, CommandValidate
-} from '../../../../Command';
-import GraphCommand from "../../../base/GraphCommand";
-import request from '../../../../request';
-import * as path from 'path';
-import * as fs from 'fs';
+import PeriodBasedReport from '../../../base/PeriodBasedReport';
 
 const vorpal: Vorpal = require('../../../../vorpal-init');
 
-interface CommandArgs {
-  options: Options;
-}
-
-interface Options extends GlobalOptions {
-  period: string;
-  outputFile?: string;
-}
-
-class TeamsReportDeviceUsageDistributionUserCountsCommand extends GraphCommand {
+class TeamsReportDeviceUsageDistributionUserCountsCommand extends PeriodBasedReport {
   public get name(): string {
     return `${commands.TEAMS_REPORT_DEVICEUSAGEDISTRIBUTIONUSERCOUNTS}`;
   }
 
+  public get usageEndPoint(): string {
+    return 'getTeamsDeviceUsageDistributionUserCounts';
+  }
+
   public get description(): string {
     return 'Get the number of Microsoft Teams unique users by device type';
-  }
-
-  public getTelemetryProperties(args: CommandArgs): any {
-    const telemetryProps: any = super.getTelemetryProperties(args);
-    telemetryProps.period = args.options.period;
-    telemetryProps.outputFile = typeof args.options.outputFile !== 'undefined';
-    return telemetryProps;
-  }
-
-  public commandAction(cmd: CommandInstance, args: CommandArgs, cb: () => void): void {
-    const endpoint: string = `${this.resource}/v1.0/reports/getTeamsDeviceUsageDistributionUserCounts(period='${encodeURIComponent(args.options.period)}')`;
-
-    const requestOptions: any = {
-      url: endpoint,
-      headers: {
-        accept: 'application/json;odata.metadata=none'
-      },
-      json: true
-    };
-
-    request
-      .get(requestOptions)
-      .then((res: any): void => {
-        let content: string = '';
-        let cleanResponse = this.removeEmptyLines(res);
-
-        if (args.options.output && args.options.output.toLowerCase() === 'json') {
-          const reportdata: any = this.getReport(cleanResponse);
-          content = JSON.stringify(reportdata);
-        }
-        else {
-          content = cleanResponse;
-        }
-
-        if (!args.options.outputFile) {
-          cmd.log(content);
-        }
-        else {
-          fs.writeFileSync(args.options.outputFile, content, 'utf8');
-          if (this.verbose) {
-            cmd.log(`File saved to path '${args.options.outputFile}'`);
-          }
-        }
-
-        cb();
-      }, (err: any): void => this.handleRejectedODataJsonPromise(err, cmd, cb));
-  }
-
-  private removeEmptyLines(input: string): string {
-    const rows: string[] = input.split('\n');
-    const cleanRows = rows.filter(Boolean);
-    return cleanRows.join('\n');
-  }
-
-  private getReport(res: string): any {
-    const rows: string[] = res.split('\n');
-    const jsonObj: any = [];
-    const headers: string[] = rows[0].split(',');
-
-    for (let i = 1; i < rows.length; i++) {
-      const data: string[] = rows[i].split(',');
-      let obj: any = {};
-      for (let j = 0; j < data.length; j++) {
-        obj[headers[j].trim()] = data[j].trim();
-      }
-      jsonObj.push(obj);
-    }
-
-    return jsonObj;
-  }
-
-  public options(): CommandOption[] {
-    const options: CommandOption[] = [
-      {
-        option: '-p, --period <period>',
-        description: 'The length of time over which the report is aggregated. Supported values D7|D30|D90|D180',
-        autocomplete: ['D7', 'D30', 'D90', 'D180']
-      },
-      {
-        option: '-f, --outputFile [outputFile]',
-        description: 'Path to the file where the Microsoft Teams unique users by device type report should be stored in'
-      }
-    ];
-
-    const parentOptions: CommandOption[] = super.options();
-    return options.concat(parentOptions);
-  }
-
-  public validate(): CommandValidate {
-    return (args: CommandArgs): boolean | string => {
-      if (!args.options.period) {
-        return 'Required parameter period missing';
-      }
-
-      if (['D7', 'D30', 'D90', 'D180'].indexOf(args.options.period) < 0) {
-        return `${args.options.period} is not a valid period type. The supported values are D7|D30|D90|D180`;
-      }
-
-      if (args.options.outputFile && !fs.existsSync(path.dirname(args.options.outputFile))) {
-        return `The specified path ${path.dirname(args.options.outputFile)} doesn't exist`;
-      }
-
-      return true;
-    };
   }
 
   public commandHelp(args: {}, log: (help: string) => void): void {


### PR DESCRIPTION
Implements the PeriodBasedReport base class defined in #1174. 

This pull also includes the inheritance of this base class in deviceusagedistributionusercounts.ts. It is a reduction of repetitive code. You just need to add the additional endpoint with *usageEndPoint* and you are all set.

Credits go to @sprider, who developed the first version of the command.

After this pull, I am planning to follow with #1175. Afterward, we can start creating issues for each usage endpoint and create the necessary commands for all services.