### PR TITLE
Implement baseclass for date and period based reports

### DIFF
--- a/src/o365/base/DateAndPeriodBasedReport.spec.ts
+++ b/src/o365/base/DateAndPeriodBasedReport.spec.ts
@@ -1,0 +1,375 @@
+import * as sinon from 'sinon';
+import appInsights from '../../appInsights';
+import auth from '../../Auth';
+import * as assert from 'assert';
+import Utils from '../../Utils';
+import request from '../../request';
+import * as fs from 'fs';
+import { CommandValidate, CommandError } from '../../Command';
+import DateAndPeriodBasedReport from './DateAndPeriodBasedReport';
+
+class MockCommand extends DateAndPeriodBasedReport {
+  public get name(): string {
+    return 'mock';
+  }
+
+  public get description(): string {
+    return 'Mock command';
+  }
+
+  public get usageEndPoint(): string {
+    return 'MockEndPoint';
+  }
+
+  public commandHelp(args: any, log: (message: string) => void): void {
+  }
+}
+
+describe('PeriodBasedReport', () => {
+  const mockCommand = new MockCommand();
+  let vorpal: Vorpal;
+  let log: string[];
+  let cmdInstance: any;
+  let cmdInstanceLogSpy: sinon.SinonSpy;
+  let writeFileSyncFake = () => { };
+
+  before(() => {
+    sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
+    sinon.stub(appInsights, 'trackEvent').callsFake(() => { });
+    auth.service.connected = true;
+  });
+
+  beforeEach(() => {
+    vorpal = require('../../vorpal-init');
+    log = [];
+    cmdInstance = {
+      commandWrapper: {
+        command: mockCommand.name
+      },
+      action: mockCommand.action(),
+      log: (msg: string) => {
+        log.push(msg);
+      }
+    };
+    cmdInstanceLogSpy = sinon.spy(cmdInstance, 'log');
+    (mockCommand as any).items = [];
+  });
+
+  afterEach(() => {
+    Utils.restore([
+      vorpal.find,
+      request.get,
+      fs.writeFileSync
+    ]);
+  });
+
+  after(() => {
+    Utils.restore([
+      appInsights.trackEvent,
+      auth.restoreAuth
+    ]);
+    auth.service.connected = false;
+  });
+
+  it('has correct name', () => {
+    assert.equal(mockCommand.name.startsWith('mock'), true);
+  });
+
+  it('has a description', () => {
+    assert.notEqual(mockCommand.description, null);
+  });
+
+  it('fails validation if period option is not passed', () => {
+    const actual = (mockCommand.validate() as CommandValidate)({ options: {} });
+    assert.notEqual(actual, true);
+  });
+
+  it('fails validation on invalid period', () => {
+    const actual = (mockCommand.validate() as CommandValidate)({ options: { period: 'abc' } });
+    assert.notEqual(actual, true);
+  });
+
+  it('passes validation on valid \'D7\' period', () => {
+    const actual = (mockCommand.validate() as CommandValidate)({
+      options: {
+        period: 'D7'
+      }
+    });
+    assert.equal(actual, true);
+  });
+
+  it('passes validation on valid \'D30\' period', () => {
+    const actual = (mockCommand.validate() as CommandValidate)({
+      options: {
+        period: 'D30'
+      }
+    });
+    assert.equal(actual, true);
+  });
+
+  it('passes validation on valid \'D90\' period', () => {
+    const actual = (mockCommand.validate() as CommandValidate)({
+      options: {
+        period: 'D90'
+      }
+    });
+    assert.equal(actual, true);
+  });
+
+  it('passes validation on valid \'180\' period', () => {
+    const actual = (mockCommand.validate() as CommandValidate)({
+      options: {
+        period: 'D90'
+      }
+    });
+    assert.equal(actual, true);
+  });
+
+  it('fails validation if both period and date options set', () => {
+    const actual = (mockCommand.validate() as CommandValidate)({ options: { period: 'D7', date: '2019-07-13' } });
+    assert.notEqual(actual, true);
+  });
+
+  it('fails validation if specified outputFile directory path doesn\'t exist', () => {
+    sinon.stub(fs, 'existsSync').callsFake(() => false);
+    const actual = (mockCommand.validate() as CommandValidate)({
+      options: {
+        period: 'D7',
+        outputFile: '/path/not/found.zip'
+      }
+    });
+    Utils.restore(fs.existsSync);
+    assert.notEqual(actual, true);
+  });
+
+  it('get unique device type in teams and export it in a period', (done) => {
+    const requestStub: sinon.SinonStub = sinon.stub(request, 'get').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/reports/MockEndPoint(period='D7')`) {
+        return Promise.resolve(`
+        Report Refresh Date,Web,Windows Phone,Android Phone,iOS,Mac,Windows,Report Period
+        2019-08-28,0,0,0,0,0,0,7
+        `);
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    cmdInstance.action({ options: { debug: false, period: 'D7' } }, () => {
+      try {
+        assert.equal(requestStub.lastCall.args[0].url, "https://graph.microsoft.com/v1.0/reports/MockEndPoint(period='D7')");
+        assert.equal(requestStub.lastCall.args[0].headers["accept"], 'application/json;odata.metadata=none');
+        assert.equal(requestStub.lastCall.args[0].json, true);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('produce export using period format and Teams unique device type output in txt', (done) => {
+    const requestStub: sinon.SinonStub = sinon.stub(request, 'get').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/reports/MockEndPoint(period='D7')`) {
+        return Promise.resolve(`
+        Report Refresh Date,Web,Windows Phone,Android Phone,iOS,Mac,Windows,Report Period
+        2019-08-28,0,0,0,0,0,0,7
+        `);
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    const fileStub: sinon.SinonStub = sinon.stub(fs, 'writeFileSync').callsFake(writeFileSyncFake);
+
+    cmdInstance.action({ options: { debug: false, period: 'D7', outputFile: '/Users/josephvelliah/Desktop/deviceusagedistributionusercounts.txt' } }, () => {
+      try {
+        assert.equal(requestStub.lastCall.args[0].url, "https://graph.microsoft.com/v1.0/reports/MockEndPoint(period='D7')");
+        assert.equal(requestStub.lastCall.args[0].headers["accept"], 'application/json;odata.metadata=none');
+        assert.equal(requestStub.lastCall.args[0].json, true);
+        assert.equal(fileStub.called, true);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('fails validation if the date option is not a valid date string', () => {
+    const actual = (mockCommand.validate() as CommandValidate)({
+      options:
+      {
+        date: '2018-X-09'
+      }
+    });
+    assert.notEqual(actual, true);
+  });
+
+  it('gets details about Microsoft Teams user activity by user for the given date', (done) => {
+    const requestStub: sinon.SinonStub = sinon.stub(request, 'get').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/reports/MockEndPoint(date=2019-07-13)`) {
+        return Promise.resolve(`
+        Report Refresh Date,User Principal Name,Last Activity Date,Is Deleted,Deleted Date,Assigned Products,Team Chat Message Count,Private Chat Message Count,Call Count,Meeting Count,Has Other Action,Report Period
+        2019-08-14,abisha@contoso.onmicrosoft.com,,False,,,0,0,0,0,No,7
+        2019-08-14,same@contoso.onmicrosoft.com,2019-05-22,False,,OFFICE 365 E3 DEVELOPER+MICROSOFT FLOW FREE,0,0,0,0,No,7
+        `);
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    cmdInstance.action({ options: { debug: false, date: '2019-07-13' } }, () => {
+      try {
+        assert.equal(requestStub.lastCall.args[0].url, "https://graph.microsoft.com/v1.0/reports/MockEndPoint(date=2019-07-13)");
+        assert.equal(requestStub.lastCall.args[0].headers["accept"], 'application/json;odata.metadata=none');
+        assert.equal(requestStub.lastCall.args[0].json, true);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('produce export using period format and Teams unique device type output in json', (done) => {
+    const requestStub: sinon.SinonStub = sinon.stub(request, 'get').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/reports/MockEndPoint(period='D7')`) {
+        return Promise.resolve(`Report Refresh Date,Web,Windows Phone,Android Phone,iOS,Mac,Windows,Report Period
+        2019-08-28,0,0,0,0,0,0,7
+        `);
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    const fileStub: sinon.SinonStub = sinon.stub(fs, 'writeFileSync').callsFake(writeFileSyncFake);
+
+    cmdInstance.action({ options: { debug: false, period: 'D7', output: 'json' } }, () => {
+      try {
+        assert.equal(requestStub.lastCall.args[0].url, "https://graph.microsoft.com/v1.0/reports/MockEndPoint(period='D7')");
+        assert.equal(requestStub.lastCall.args[0].headers["accept"], 'application/json;odata.metadata=none');
+        assert.equal(requestStub.lastCall.args[0].json, true);
+        assert.equal(fileStub.notCalled, true);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('produce export using period format and Teams unique users output in txt', (done) => {
+    const requestStub: sinon.SinonStub = sinon.stub(request, 'get').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/reports/MockEndPoint(period='D7')`) {
+        return Promise.resolve(`
+        Report Refresh Date,Web,Windows Phone,Android Phone,iOS,Mac,Windows,Report Period
+        2019-08-28,0,0,0,0,0,0,7
+        `);
+      }
+
+      return Promise.reject('Invalid request');
+    });
+    const fileStub: sinon.SinonStub = sinon.stub(fs, 'writeFileSync').callsFake(writeFileSyncFake);
+
+    cmdInstance.action({ options: { debug: false, period: 'D7', outputFile: '/Users/josephvelliah/Desktop/deviceusagedistributionusercounts.txt', output: 'text' } }, () => {
+      try {
+        assert.equal(requestStub.lastCall.args[0].url, "https://graph.microsoft.com/v1.0/reports/MockEndPoint(period='D7')");
+        assert.equal(requestStub.lastCall.args[0].headers["accept"], 'application/json;odata.metadata=none');
+        assert.equal(requestStub.lastCall.args[0].json, true);
+        assert.equal(fileStub.called, true);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('produce export using period format and Teams unique users output in json', (done) => {
+    const requestStub: sinon.SinonStub = sinon.stub(request, 'get').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/reports/MockEndPoint(period='D7')`) {
+        return Promise.resolve(`
+        Report Refresh Date,Web,Windows Phone,Android Phone,iOS,Mac,Windows,Report Period
+        2019-08-28,0,0,0,0,0,0,7
+        `);
+      }
+
+      return Promise.reject('Invalid request');
+    });
+    const fileStub: sinon.SinonStub = sinon.stub(fs, 'writeFileSync').callsFake(writeFileSyncFake);
+
+    cmdInstance.action({ options: { debug: false, period: 'D7', outputFile: '/Users/josephvelliah/Desktop/deviceusagedistributionusercounts.json' } }, () => {
+      try {
+        assert.equal(requestStub.lastCall.args[0].url, "https://graph.microsoft.com/v1.0/reports/MockEndPoint(period='D7')");
+        assert.equal(requestStub.lastCall.args[0].headers["accept"], 'application/json;odata.metadata=none');
+        assert.equal(requestStub.lastCall.args[0].json, true);
+        assert.equal(fileStub.called, true);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('produce export using period format and Teams output in json', (done) => {
+    const requestStub: sinon.SinonStub = sinon.stub(request, 'get').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/reports/MockEndPoint(period='D7')`) {
+        return Promise.resolve(`Report Refresh Date,Web,Windows Phone,Android Phone,iOS,Mac,Windows,Report Period\n2019-08-28,0,0,0,0,0,0,7`);
+      }
+
+      return Promise.reject('Invalid request');
+    });
+    const fileStub: sinon.SinonStub = sinon.stub(fs, 'writeFileSync').callsFake(writeFileSyncFake);
+
+    cmdInstance.action({ options: { debug: true, period: 'D7', outputFile: '/Users/josephvelliah/Desktop/deviceusagedistributionusercounts.json', output: 'json' } }, () => {
+      try {
+        assert.equal(requestStub.lastCall.args[0].url, "https://graph.microsoft.com/v1.0/reports/MockEndPoint(period='D7')");
+        assert.equal(requestStub.lastCall.args[0].headers["accept"], 'application/json;odata.metadata=none');
+        assert.equal(requestStub.lastCall.args[0].json, true);
+        assert.equal(fileStub.called, true);
+        assert(cmdInstanceLogSpy.calledWith(`File saved to path '/Users/josephvelliah/Desktop/deviceusagedistributionusercounts.json'`));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('correctly handles random API error', (done) => {
+    sinon.stub(request, 'get').callsFake((opts) => Promise.reject('An error has occurred'));
+
+    cmdInstance.action({ options: { debug: false, period: 'D7' } }, (err?: any) => {
+      try {
+        assert.equal(JSON.stringify(err), JSON.stringify(new CommandError('An error has occurred')));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('supports specifying outputFile', () => {
+    const options = mockCommand.options();
+    let containsOption = false;
+    options.forEach((o: any) => {
+      if (o.option.indexOf('--outputFile') > -1) {
+        containsOption = true;
+      }
+    });
+    assert(containsOption);
+  });
+
+  it('supports debug mode', () => {
+    const options = mockCommand.options();
+    let containsOption = false;
+    options.forEach((o: any) => {
+      if (o.option === '--debug') {
+        containsOption = true;
+      }
+    });
+    assert(containsOption);
+  });
+});

--- a/src/o365/base/DateAndPeriodBasedReport.spec.ts
+++ b/src/o365/base/DateAndPeriodBasedReport.spec.ts
@@ -89,6 +89,11 @@ describe('PeriodBasedReport', () => {
     assert.notEqual(actual, true);
   });
 
+  it('fails validation on invalid date', () => {
+    const actual = (mockCommand.validate() as CommandValidate)({ options: { date: '10.10.2019' } });
+    assert.notEqual(actual, true);
+  });
+
   it('passes validation on valid \'D7\' period', () => {
     const actual = (mockCommand.validate() as CommandValidate)({
       options: {

--- a/src/o365/base/DateAndPeriodBasedReport.ts
+++ b/src/o365/base/DateAndPeriodBasedReport.ts
@@ -2,6 +2,8 @@ import {
   CommandOption, CommandValidate
 } from '../../Command';
 import PeriodBasedReport, { OutputFileOptions } from './PeriodBasedReport';
+import * as path from 'path';
+import * as fs from 'fs';
 
 interface CommandArgs {
   options: DateAndPeriodBasedOptions;
@@ -43,6 +45,14 @@ export default abstract class DateAndPeriodBasedReport extends PeriodBasedReport
     return (args: CommandArgs): boolean | string => {
       if (!args.options.period && !args.options.date) {
         return 'Specify period or date, one is required.';
+      }
+
+      if (args.options.period && ['D7', 'D30', 'D90', 'D180'].indexOf(args.options.period) < 0) {
+        return `${args.options.period} is not a valid period type. The supported values are D7|D30|D90|D180`;
+      }
+      
+      if (args.options.outputFile && !fs.existsSync(path.dirname(args.options.outputFile))) {
+        return `The specified path ${path.dirname(args.options.outputFile)} doesn't exist`;
       }
 
       if (args.options.period && args.options.date) {

--- a/src/o365/base/DateAndPeriodBasedReport.ts
+++ b/src/o365/base/DateAndPeriodBasedReport.ts
@@ -1,0 +1,60 @@
+import {
+  CommandOption, CommandValidate
+} from '../../Command';
+import * as path from 'path';
+import * as fs from 'fs';
+import PeriodBasedReport, { UsagePeriodOptions } from './PeriodBasedReport';
+
+interface CommandArgs {
+  options: Options;
+}
+
+interface Options extends UsagePeriodOptions {
+  date?: string;
+}
+
+export default abstract class DateAndPeriodBasedReport extends PeriodBasedReport {
+  public commandAction(cmd: CommandInstance, args: CommandArgs, cb: () => void): void {
+    const periodParameter: string = args.options.period ? `${this.usageEndPoint}(period='${encodeURIComponent(args.options.period)}')` : '';
+    const dateParameter: string = args.options.date ? `${this.usageEndPoint}(date=${encodeURIComponent(args.options.date)})` : '';
+    const endPoint: string = `${this.resource}/v1.0/reports/${(args.options.period ? periodParameter : dateParameter)}`;
+    this.executeReport(endPoint, cmd, args, cb);
+  }
+
+  public options(): CommandOption[] {
+    const options: CommandOption[] = [
+      {
+        option: '-d, --date [date]',
+        description: 'The date for which you would like to view the users who performed any activity. Supported date format is YYYY-MM-DD. Specify the date or period, but not both.'
+      }
+    ];
+
+    const parentOptions: CommandOption[] = super.options();
+    return options.concat(parentOptions);
+  }
+
+  public validate(): CommandValidate {
+    return (args: CommandArgs): boolean | string => {
+      if (!args.options.period && !args.options.date) {
+        return 'Specify period or date, one is required.';
+      }
+      if (args.options.period && args.options.date) {
+        return 'Specify period or date but not both.';
+      }
+
+      if (args.options.date && !((args.options.date as string).match(/^\d{4}-\d{2}-\d{2}$/))) {
+        return `${args.options.date} is not a valid date. The supported date format is YYYY-MM-DD`;
+      }
+
+      if (args.options.outputFile && !fs.existsSync(path.dirname(args.options.outputFile))) {
+        return `The specified path ${path.dirname(args.options.outputFile)} doesn't exist`;
+      }
+
+      if (args.options.period && ['D7', 'D30', 'D90', 'D180'].indexOf(args.options.period) < 0) {
+        return `${args.options.period} is not a valid period type. The supported values are D7|D30|D90|D180`;
+      }
+
+      return true;
+    };
+  }
+}

--- a/src/o365/base/PeriodBasedReport.ts
+++ b/src/o365/base/PeriodBasedReport.ts
@@ -8,10 +8,10 @@ import * as path from 'path';
 import * as fs from 'fs';
 
 interface CommandArgs {
-  options: Options;
+  options: UsagePeriodOptions;
 }
 
-interface Options extends GlobalOptions {
+export interface UsagePeriodOptions extends GlobalOptions {
   period: string;
   outputFile?: string;
 }
@@ -21,16 +21,18 @@ export default abstract class PeriodBasedReport extends GraphCommand {
 
   public getTelemetryProperties(args: CommandArgs): any {
     const telemetryProps: any = super.getTelemetryProperties(args);
-    telemetryProps.period = args.options.period;
     telemetryProps.outputFile = typeof args.options.outputFile !== 'undefined';
     return telemetryProps;
   }
 
   public commandAction(cmd: CommandInstance, args: CommandArgs, cb: () => void): void {
-    const endpoint: string = `${this.resource}/v1.0/reports/${this.usageEndPoint}(period='${encodeURIComponent(args.options.period)}')`;
+    const endPoint: string = `${this.resource}/v1.0/reports/${this.usageEndPoint}(period='${encodeURIComponent(args.options.period)}')`;
+    this.executeReport(endPoint, cmd, args, cb);
+  }
 
+  protected executeReport(endPoint: string, cmd: CommandInstance, args: CommandArgs, cb: () => void): void {
     const requestOptions: any = {
-      url: endpoint,
+      url: endPoint,
       headers: {
         accept: 'application/json;odata.metadata=none'
       },
@@ -114,7 +116,7 @@ export default abstract class PeriodBasedReport extends GraphCommand {
       if (['D7', 'D30', 'D90', 'D180'].indexOf(args.options.period) < 0) {
         return `${args.options.period} is not a valid period type. The supported values are D7|D30|D90|D180`;
       }
-
+      
       if (args.options.outputFile && !fs.existsSync(path.dirname(args.options.outputFile))) {
         return `The specified path ${path.dirname(args.options.outputFile)} doesn't exist`;
       }

--- a/src/o365/teams/commands/report/teams-report-useractivityuserdetail.spec.ts
+++ b/src/o365/teams/commands/report/teams-report-useractivityuserdetail.spec.ts
@@ -1,20 +1,17 @@
 import commands from '../../commands';
-import Command, { CommandOption, CommandError, CommandValidate } from '../../../../Command';
 import * as sinon from 'sinon';
 import appInsights from '../../../../appInsights';
 import auth from '../../../../Auth';
-const command: Command = require('./teams-report-useractivityuserdetail');
+const command: DateAndPeriodBasedReport = require('./teams-report-useractivityuserdetail');
 import * as assert from 'assert';
 import Utils from '../../../../Utils';
 import request from '../../../../request';
-import * as fs from 'fs';
+import DateAndPeriodBasedReport from '../../../base/DateAndPeriodBasedReport';
 
 describe(commands.TEAMS_REPORT_USERACTIVITYUSERDETAIL, () => {
   let vorpal: Vorpal;
   let log: string[];
   let cmdInstance: any;
-  let cmdInstanceLogSpy: sinon.SinonSpy;
-  let writeFileSyncFake = () => { };
 
   before(() => {
     sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
@@ -34,15 +31,13 @@ describe(commands.TEAMS_REPORT_USERACTIVITYUSERDETAIL, () => {
         log.push(msg);
       }
     };
-    cmdInstanceLogSpy = sinon.spy(cmdInstance, 'log');
     (command as any).items = [];
   });
 
   afterEach(() => {
     Utils.restore([
       vorpal.find,
-      request.get,
-      fs.writeFileSync
+      request.get
     ]);
   });
 
@@ -60,310 +55,6 @@ describe(commands.TEAMS_REPORT_USERACTIVITYUSERDETAIL, () => {
 
   it('has a description', () => {
     assert.notEqual(command.description, null);
-  });
-
-  it('fails validation if both period and date options are not passed', () => {
-    const actual = (command.validate() as CommandValidate)({ options: {} });
-    assert.notEqual(actual, true);
-  });
-
-  it('fails validation if both period and date options set', () => {
-    const actual = (command.validate() as CommandValidate)({ options: { period: 'D7', date: '2019-07-13' } });
-    assert.notEqual(actual, true);
-  });
-
-  it('fails validation on invalid period', () => {
-    const actual = (command.validate() as CommandValidate)({ options: { period: 'abc' } });
-    assert.notEqual(actual, true);
-  });
-
-  it('passes validation on valid \'D7\' period', () => {
-    const actual = (command.validate() as CommandValidate)({
-      options: {
-        period: 'D7'
-      }
-    });
-    assert.equal(actual, true);
-  });
-
-  it('passes validation on valid \'D30\' period', () => {
-    const actual = (command.validate() as CommandValidate)({
-      options: {
-        period: 'D30'
-      }
-    });
-    assert.equal(actual, true);
-  });
-
-  it('passes validation on valid \'D90\' period', () => {
-    const actual = (command.validate() as CommandValidate)({
-      options: {
-        period: 'D90'
-      }
-    });
-    assert.equal(actual, true);
-  });
-
-  it('passes validation on valid \'180\' period', () => {
-    const actual = (command.validate() as CommandValidate)({
-      options: {
-        period: 'D180'
-      }
-    });
-    assert.equal(actual, true);
-  });
-
-  it('fails validation if the date option is not a valid date string', () => {
-    const actual = (command.validate() as CommandValidate)({
-      options:
-      {
-        date: '2018-X-09'
-      }
-    });
-    assert.notEqual(actual, true);
-  });
-
-  it('passes validation if the date option is a valid date', () => {
-    const actual = (command.validate() as CommandValidate)({ options: { date: '2019-07-13' } });
-    assert(actual);
-  });
-
-  it('fails validation if specified outputFile directory path doesn\'t exist', () => {
-    sinon.stub(fs, 'existsSync').callsFake(() => false);
-    const actual = (command.validate() as CommandValidate)({
-      options: {
-        period: 'D7',
-        outputFile: '/path/not/found.zip'
-      }
-    });
-    Utils.restore(fs.existsSync);
-    assert.notEqual(actual, true);
-  });
-
-  it('gets details about Microsoft Teams user activity by user for the given period', (done) => {
-    const requestStub: sinon.SinonStub = sinon.stub(request, 'get').callsFake((opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/reports/getTeamsUserActivityUserDetail(period='D7')`) {
-        return Promise.resolve(`
-        Report Refresh Date,User Principal Name,Last Activity Date,Is Deleted,Deleted Date,Assigned Products,Team Chat Message Count,Private Chat Message Count,Call Count,Meeting Count,Has Other Action,Report Period
-        2019-08-14,abisha@contoso.onmicrosoft.com,,False,,,0,0,0,0,No,7
-        2019-08-14,same@contoso.onmicrosoft.com,2019-05-22,False,,OFFICE 365 E3 DEVELOPER+MICROSOFT FLOW FREE,0,0,0,0,No,7
-        `);
-      }
-
-      return Promise.reject('Invalid request');
-    });
-
-    cmdInstance.action({ options: { debug: false, period: 'D7' } }, () => {
-      try {
-        assert.equal(requestStub.lastCall.args[0].url, "https://graph.microsoft.com/v1.0/reports/getTeamsUserActivityUserDetail(period='D7')");
-        assert.equal(requestStub.lastCall.args[0].headers["accept"], 'application/json;odata.metadata=none');
-        assert.equal(requestStub.lastCall.args[0].json, true);
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
-  });
-
-  it('gets details about Microsoft Teams user activity by user for the given date', (done) => {
-    const requestStub: sinon.SinonStub = sinon.stub(request, 'get').callsFake((opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/reports/getTeamsUserActivityUserDetail(date=2019-07-13)`) {
-        return Promise.resolve(`
-        Report Refresh Date,User Principal Name,Last Activity Date,Is Deleted,Deleted Date,Assigned Products,Team Chat Message Count,Private Chat Message Count,Call Count,Meeting Count,Has Other Action,Report Period
-        2019-08-14,abisha@contoso.onmicrosoft.com,,False,,,0,0,0,0,No,7
-        2019-08-14,same@contoso.onmicrosoft.com,2019-05-22,False,,OFFICE 365 E3 DEVELOPER+MICROSOFT FLOW FREE,0,0,0,0,No,7
-        `);
-      }
-
-      return Promise.reject('Invalid request');
-    });
-
-    cmdInstance.action({ options: { debug: false, date: '2019-07-13' } }, () => {
-      try {
-        assert.equal(requestStub.lastCall.args[0].url, "https://graph.microsoft.com/v1.0/reports/getTeamsUserActivityUserDetail(date=2019-07-13)");
-        assert.equal(requestStub.lastCall.args[0].headers["accept"], 'application/json;odata.metadata=none');
-        assert.equal(requestStub.lastCall.args[0].json, true);
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
-  });
-
-  it('gets details about Microsoft Teams user activity by user for the given period and export report data in txt format', (done) => {
-    const requestStub: sinon.SinonStub = sinon.stub(request, 'get').callsFake((opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/reports/getTeamsUserActivityUserDetail(period='D7')`) {
-        return Promise.resolve(`
-        Report Refresh Date,User Principal Name,Last Activity Date,Is Deleted,Deleted Date,Assigned Products,Team Chat Message Count,Private Chat Message Count,Call Count,Meeting Count,Has Other Action,Report Period
-        2019-08-14,abisha@contoso.onmicrosoft.com,,False,,,0,0,0,0,No,7
-        2019-08-14,same@contoso.onmicrosoft.com,2019-05-22,False,,OFFICE 365 E3 DEVELOPER+MICROSOFT FLOW FREE,0,0,0,0,No,7
-        `);
-      }
-
-      return Promise.reject('Invalid request');
-    });
-
-    const fileStub: sinon.SinonStub = sinon.stub(fs, 'writeFileSync').callsFake(writeFileSyncFake);
-
-    cmdInstance.action({ options: { debug: false, period: 'D7', outputFile: '/Users/josephvelliah/Desktop/teams-report-useractivityuserdetail.txt' } }, () => {
-      try {
-        assert.equal(requestStub.lastCall.args[0].url, "https://graph.microsoft.com/v1.0/reports/getTeamsUserActivityUserDetail(period='D7')");
-        assert.equal(requestStub.lastCall.args[0].headers["accept"], 'application/json;odata.metadata=none');
-        assert.equal(requestStub.lastCall.args[0].json, true);
-        assert.equal(fileStub.called, true);
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
-  });
-
-  it('gets details about Microsoft Teams user activity by user when output is json', (done) => {
-    const requestStub: sinon.SinonStub = sinon.stub(request, 'get').callsFake((opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/reports/getTeamsUserActivityUserDetail(period='D7')`) {
-        return Promise.resolve(`Report Refresh Date,User Principal Name,Last Activity Date,Is Deleted,Deleted Date,Assigned Products,Team Chat Message Count,Private Chat Message Count,Call Count,Meeting Count,Has Other Action,Report Period
-        2019-08-14,abisha@contoso.onmicrosoft.com,,False,,,0,0,0,0,No,7
-        2019-08-14,same@contoso.onmicrosoft.com,2019-05-22,False,,OFFICE 365 E3 DEVELOPER+MICROSOFT FLOW FREE,0,0,0,0,No,7
-        `);
-      }
-
-      return Promise.reject('Invalid request');
-    });
-
-    const fileStub: sinon.SinonStub = sinon.stub(fs, 'writeFileSync').callsFake(writeFileSyncFake);
-
-    cmdInstance.action({ options: { debug: false, period: 'D7', output: 'json' } }, () => {
-      try {
-        assert.equal(requestStub.lastCall.args[0].url, "https://graph.microsoft.com/v1.0/reports/getTeamsUserActivityUserDetail(period='D7')");
-        assert.equal(requestStub.lastCall.args[0].headers["accept"], 'application/json;odata.metadata=none');
-        assert.equal(requestStub.lastCall.args[0].json, true);
-        assert.equal(fileStub.notCalled, true);
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
-  });
-
-  it('gets details about Microsoft Teams user activity by user for the given period and export report data in txt format with output', (done) => {
-    const requestStub: sinon.SinonStub = sinon.stub(request, 'get').callsFake((opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/reports/getTeamsUserActivityUserDetail(period='D7')`) {
-        return Promise.resolve(`
-        Report Refresh Date,User Principal Name,Last Activity Date,Is Deleted,Deleted Date,Assigned Products,Team Chat Message Count,Private Chat Message Count,Call Count,Meeting Count,Has Other Action,Report Period
-        2019-08-14,abisha@contoso.onmicrosoft.com,,False,,,0,0,0,0,No,7
-        2019-08-14,same@contoso.onmicrosoft.com,2019-05-22,False,,OFFICE 365 E3 DEVELOPER+MICROSOFT FLOW FREE,0,0,0,0,No,7
-        `);
-      }
-
-      return Promise.reject('Invalid request');
-    });
-    const fileStub: sinon.SinonStub = sinon.stub(fs, 'writeFileSync').callsFake(writeFileSyncFake);
-
-    cmdInstance.action({ options: { debug: false, period: 'D7', outputFile: '/Users/josephvelliah/Desktop/teams-report-useractivityuserdetail.txt', output: 'text' } }, () => {
-      try {
-        assert.equal(requestStub.lastCall.args[0].url, "https://graph.microsoft.com/v1.0/reports/getTeamsUserActivityUserDetail(period='D7')");
-        assert.equal(requestStub.lastCall.args[0].headers["accept"], 'application/json;odata.metadata=none');
-        assert.equal(requestStub.lastCall.args[0].json, true);
-        assert.equal(fileStub.called, true);
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
-  });
-
-  it('gets details about Microsoft Teams user activity by user for the given period and export report data in json format', (done) => {
-    const requestStub: sinon.SinonStub = sinon.stub(request, 'get').callsFake((opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/reports/getTeamsUserActivityUserDetail(period='D7')`) {
-        return Promise.resolve(`
-        Report Refresh Date,User Principal Name,Last Activity Date,Is Deleted,Deleted Date,Assigned Products,Team Chat Message Count,Private Chat Message Count,Call Count,Meeting Count,Has Other Action,Report Period
-        2019-08-14,abisha@contoso.onmicrosoft.com,,False,,,0,0,0,0,No,7
-        2019-08-14,same@contoso.onmicrosoft.com,2019-05-22,False,,OFFICE 365 E3 DEVELOPER+MICROSOFT FLOW FREE,0,0,0,0,No,7
-        `);
-      }
-
-      return Promise.reject('Invalid request');
-    });
-    const fileStub: sinon.SinonStub = sinon.stub(fs, 'writeFileSync').callsFake(writeFileSyncFake);
-
-    cmdInstance.action({ options: { debug: false, period: 'D7', outputFile: '/Users/josephvelliah/Desktop/teams-report-useractivityuserdetail.json' } }, () => {
-      try {
-        assert.equal(requestStub.lastCall.args[0].url, "https://graph.microsoft.com/v1.0/reports/getTeamsUserActivityUserDetail(period='D7')");
-        assert.equal(requestStub.lastCall.args[0].headers["accept"], 'application/json;odata.metadata=none');
-        assert.equal(requestStub.lastCall.args[0].json, true);
-        assert.equal(fileStub.called, true);
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
-  });
-
-  it('gets details about Microsoft Teams user activity by user for the given period and export report data in json format with output', (done) => {
-    const requestStub: sinon.SinonStub = sinon.stub(request, 'get').callsFake((opts) => {
-      if (opts.url === `https://graph.microsoft.com/v1.0/reports/getTeamsUserActivityUserDetail(period='D7')`) {
-        return Promise.resolve('Report Refresh Date,User Principal Name,Last Activity Date,Is Deleted,Deleted Date,Assigned Products,Team Chat Message Count,Private Chat Message Count,Call Count,Meeting Count,Has Other Action,Report Period\n2019-08-14,abisha@contoso.onmicrosoft.com,,False,,,0,0,0,0,No,7');
-      }
-
-      return Promise.reject('Invalid request');
-    });
-    const fileStub: sinon.SinonStub = sinon.stub(fs, 'writeFileSync').callsFake(writeFileSyncFake);
-
-    cmdInstance.action({ options: { debug: true, period: 'D7', outputFile: '/Users/josephvelliah/Desktop/teams-report-useractivityuserdetail.json', output: 'json' } }, () => {
-      try {
-        assert.equal(requestStub.lastCall.args[0].url, "https://graph.microsoft.com/v1.0/reports/getTeamsUserActivityUserDetail(period='D7')");
-        assert.equal(requestStub.lastCall.args[0].headers["accept"], 'application/json;odata.metadata=none');
-        assert.equal(requestStub.lastCall.args[0].json, true);
-        assert.equal(fileStub.called, true);
-        assert(cmdInstanceLogSpy.calledWith(`File saved to path '/Users/josephvelliah/Desktop/teams-report-useractivityuserdetail.json'`));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
-  });
-
-  it('correctly handles random API error', (done) => {
-    sinon.stub(request, 'get').callsFake((opts) => Promise.reject('An error has occurred'));
-
-    cmdInstance.action({ options: { debug: false, date: '2019-07-13' } }, (err?: any) => {
-      try {
-        assert.equal(JSON.stringify(err), JSON.stringify(new CommandError('An error has occurred')));
-        done();
-      }
-      catch (e) {
-        done(e);
-      }
-    });
-  });
-
-  it('supports specifying outputFile', () => {
-    const options = (command.options() as CommandOption[]);
-    let containsOption = false;
-    options.forEach(o => {
-      if (o.option.indexOf('--outputFile') > -1) {
-        containsOption = true;
-      }
-    });
-    assert(containsOption);
-  });
-
-  it('supports debug mode', () => {
-    const options = (command.options() as CommandOption[]);
-    let containsOption = false;
-    options.forEach(o => {
-      if (o.option === '--debug') {
-        containsOption = true;
-      }
-    });
-    assert(containsOption);
   });
 
   it('has help referring to the right command', () => {
@@ -398,5 +89,31 @@ describe(commands.TEAMS_REPORT_USERACTIVITYUSERDETAIL, () => {
     });
     Utils.restore(vorpal.find);
     assert(containsExamples);
+  });
+
+  it('gets details about Microsoft Teams user activity by user for the given date', (done) => {
+    const requestStub: sinon.SinonStub = sinon.stub(request, 'get').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/reports/getTeamsUserActivityUserDetail(date=2019-07-13)`) {
+        return Promise.resolve(`
+        Report Refresh Date,User Principal Name,Last Activity Date,Is Deleted,Deleted Date,Assigned Products,Team Chat Message Count,Private Chat Message Count,Call Count,Meeting Count,Has Other Action,Report Period
+        2019-08-14,abisha@contoso.onmicrosoft.com,,False,,,0,0,0,0,No,7
+        2019-08-14,same@contoso.onmicrosoft.com,2019-05-22,False,,OFFICE 365 E3 DEVELOPER+MICROSOFT FLOW FREE,0,0,0,0,No,7
+        `);
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    cmdInstance.action({ options: { debug: false, date: '2019-07-13' } }, () => {
+      try {
+        assert.equal(requestStub.lastCall.args[0].url, "https://graph.microsoft.com/v1.0/reports/getTeamsUserActivityUserDetail(date=2019-07-13)");
+        assert.equal(requestStub.lastCall.args[0].headers["accept"], 'application/json;odata.metadata=none');
+        assert.equal(requestStub.lastCall.args[0].json, true);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
   });
 });

--- a/src/o365/teams/commands/report/teams-report-useractivityuserdetail.ts
+++ b/src/o365/teams/commands/report/teams-report-useractivityuserdetail.ts
@@ -1,153 +1,19 @@
 import commands from '../../commands';
-import GlobalOptions from '../../../../GlobalOptions';
-import {
-  CommandOption, CommandValidate
-} from '../../../../Command';
-import GraphCommand from "../../../base/GraphCommand";
-import request from '../../../../request';
-import * as path from 'path';
-import * as fs from 'fs';
+import DateAndPeriodBasedReport from '../../../base/DateAndPeriodBasedReport';
 
 const vorpal: Vorpal = require('../../../../vorpal-init');
 
-interface CommandArgs {
-  options: Options;
-}
-
-interface Options extends GlobalOptions {
-  period?: string;
-  date?: string;
-  outputFile?: string;
-}
-
-class TeamsReportUserActivityUserDetailCommand extends GraphCommand {
+class TeamsReportUserActivityUserDetailCommand extends DateAndPeriodBasedReport {
   public get name(): string {
     return `${commands.TEAMS_REPORT_USERACTIVITYUSERDETAIL}`;
   }
 
+  public get usageEndPoint(): string {
+    return 'getTeamsUserActivityUserDetail';
+  }
+
   public get description(): string {
     return 'Get details about Microsoft Teams user activity by user.';
-  }
-
-  public getTelemetryProperties(args: CommandArgs): any {
-    const telemetryProps: any = super.getTelemetryProperties(args);
-    telemetryProps.period = args.options.period;
-    telemetryProps.date = typeof args.options.date !== 'undefined';
-    telemetryProps.outputFile = typeof args.options.outputFile !== 'undefined';
-    return telemetryProps;
-  }
-
-  public commandAction(cmd: CommandInstance, args: CommandArgs, cb: () => void): void {
-    const periodParameter: string = args.options.period ? `getTeamsUserActivityUserDetail(period='${encodeURIComponent(args.options.period)}')` : '';
-    const dateParameter: string = args.options.date ? `getTeamsUserActivityUserDetail(date=${encodeURIComponent(args.options.date)})` : '';
-    const endpoint: string = `${this.resource}/v1.0/reports/${(args.options.period ? periodParameter : dateParameter)}`;
-
-    const requestOptions: any = {
-      url: endpoint,
-      headers: {
-        accept: 'application/json;odata.metadata=none'
-      },
-      json: true
-    };
-
-    request
-      .get(requestOptions)
-      .then((res: any): void => {
-        let content: string = '';
-        let cleanResponse = this.removeEmptyLines(res);
-
-        if (args.options.output && args.options.output.toLowerCase() === 'json') {
-          const reportdata: any = this.getReport(cleanResponse);
-          content = JSON.stringify(reportdata);
-        }
-        else {
-          content = cleanResponse;
-        }
-
-        if (!args.options.outputFile) {
-          cmd.log(content);
-        }
-        else {
-          fs.writeFileSync(args.options.outputFile, content, 'utf8');
-          if (this.verbose) {
-            cmd.log(`File saved to path '${args.options.outputFile}'`);
-          }
-        }
-
-        cb();
-      }, (err: any): void => this.handleRejectedODataJsonPromise(err, cmd, cb));
-  }
-
-  private removeEmptyLines(input: string): string {
-    const rows: string[] = input.split('\n');
-    const cleanRows = rows.filter(Boolean);
-    return cleanRows.join('\n');
-  }
-
-  private getReport(res: string): any {
-    const rows: string[] = res.split('\n');
-    const jsonObj: any = [];
-    const headers: string[] = rows[0].split(',');
-
-    for (let i = 1; i < rows.length; i++) {
-      const data: string[] = rows[i].split(',');
-      let obj: any = {};
-      for (let j = 0; j < data.length; j++) {
-        obj[headers[j].trim()] = data[j].trim();
-      }
-      jsonObj.push(obj);
-    }
-
-    return jsonObj;
-  }
-
-  public options(): CommandOption[] {
-    const options: CommandOption[] = [
-      {
-        option: '-p, --period [period]',
-        description: 'The length of time over which the report is aggregated. Supported values D7|D30|D90|D180. Specify the period or date, but not both.',
-        autocomplete: ['D7', 'D30', 'D90', 'D180']
-      },
-      {
-        option: '-d, --date [date]',
-        description: 'The date for which you would like to view the users who performed any activity. Supported date format is YYYY-MM-DD. Specify the date or period, but not both.'
-      },
-      {
-        option: '-f, --outputFile [outputFile]',
-        description: 'Path to the file where the Microsoft Teams user activity by user report should be stored in'
-      }
-    ];
-
-    const parentOptions: CommandOption[] = super.options();
-    return options.concat(parentOptions);
-  }
-
-  public validate(): CommandValidate {
-    return (args: CommandArgs): boolean | string => {
-      if (!args.options.period && !args.options.date) {
-        return 'Specify period or date, one is required.';
-      }
-
-      if (args.options.period && args.options.date) {
-        return 'Specify period or date but not both.';
-      }
-
-      if (args.options.period) {
-        if (['D7', 'D30', 'D90', 'D180'].indexOf(args.options.period) < 0) {
-          return `${args.options.period} is not a valid period type. The supported values are D7|D30|D90|D180`;
-        }
-      }
-
-      if (args.options.date && !((args.options.date as string).match(/^\d{4}-\d{2}-\d{2}$/))) {
-        return `${args.options.date} is not a valid date. The supported date format is YYYY-MM-DD`;
-      }
-
-      if (args.options.outputFile && !fs.existsSync(path.dirname(args.options.outputFile))) {
-        return `The specified path ${path.dirname(args.options.outputFile)} doesn't exist`;
-      }
-
-      return true;
-    };
   }
 
   public commandHelp(args: {}, log: (help: string) => void): void {


### PR DESCRIPTION
Implements #1175 

This report uses both options: the period and date.
Still not sure if the inheritance of the period base class is correct when looking at the options. In the base class we are required to provide a period while in this class you might have either the period or date.
In this pull I also implemented the class for teams-report-useractivityuserdetail. Once this pull is approved, we can proceed with the residual usage commands.
Just to be sure. Do you want to have an issue created for each individual command also in this scenario?