### PR TITLE
Rush stack compiler made optional for 1.9.1 upgrade, fixes #1222

### DIFF
--- a/src/o365/spfx/commands/project/project-upgrade/rules/FN002011_DEVDEP_microsoft_rush_stack_compiler_2_9.spec.ts
+++ b/src/o365/spfx/commands/project/project-upgrade/rules/FN002011_DEVDEP_microsoft_rush_stack_compiler_2_9.spec.ts
@@ -1,0 +1,27 @@
+import * as assert from 'assert';
+import { Finding } from '../Finding';
+import { Project } from '../model';
+import { FN002011_DEVDEP_microsoft_rush_stack_compiler_2_9 } from './FN002011_DEVDEP_microsoft_rush_stack_compiler_2_9';
+
+describe('FN002011_DEVDEP_microsoft_rush_stack_compiler_2_9', () => {
+  let findings: Finding[];
+  let rule: FN002011_DEVDEP_microsoft_rush_stack_compiler_2_9;
+
+  beforeEach(() => {
+    findings = [];
+    rule = new FN002011_DEVDEP_microsoft_rush_stack_compiler_2_9('1.0.0', true);
+  })
+
+  it('should not show finding when package is not present', () => {
+    const project: Project = {
+      path: '/usr/tmp',
+      packageJson: {
+        dependencies: {
+          '@microsoft/rush-stack-compiler-3.3': '0.1.6'
+        }
+      }
+    };
+    rule.visit(project, findings);
+    assert.equal(findings.length, 0);
+  });
+});

--- a/src/o365/spfx/commands/project/project-upgrade/rules/FN002011_DEVDEP_microsoft_rush_stack_compiler_2_9.ts
+++ b/src/o365/spfx/commands/project/project-upgrade/rules/FN002011_DEVDEP_microsoft_rush_stack_compiler_2_9.ts
@@ -1,9 +1,9 @@
 import { DependencyRule } from "./DependencyRule";
 
 export class FN002011_DEVDEP_microsoft_rush_stack_compiler_2_9 extends DependencyRule {
-  constructor(packageVersion: string) {
+  constructor(packageVersion: string, isOptional: boolean = true) {
     /* istanbul ignore next */
-    super('@microsoft/rush-stack-compiler-2.9', packageVersion, true);
+    super('@microsoft/rush-stack-compiler-2.9', packageVersion, true, isOptional);
   }
 
   get id(): string {

--- a/src/o365/spfx/commands/project/project-upgrade/upgrade-1.8.2.ts
+++ b/src/o365/spfx/commands/project/project-upgrade/upgrade-1.8.2.ts
@@ -38,7 +38,7 @@ module.exports = [
   new FN002003_DEVDEP_microsoft_sp_webpart_workbench('1.8.2'),
   new FN002009_DEVDEP_microsoft_sp_tslint_rules('1.8.2'),
   new FN002010_DEVDEP_microsoft_rush_stack_compiler_2_7('', false),
-  new FN002011_DEVDEP_microsoft_rush_stack_compiler_2_9('0.7.7'),
+  new FN002011_DEVDEP_microsoft_rush_stack_compiler_2_9('0.7.7', false),
   new FN010001_YORC_version('1.8.2'),
   new FN012017_TSC_extends('./node_modules/@microsoft/rush-stack-compiler-2.9/includes/tsconfig-web.json'),
   new FN020001_RES_types_react('16.7.22')


### PR DESCRIPTION
Rush stack compiler made optional for 1.9.1 upgrade, fixes #1222