### PR TITLE
Adds 'since' option to teams message list command

### DIFF
--- a/docs/manual/docs/cmd/teams/message/message-list.md
+++ b/docs/manual/docs/cmd/teams/message/message-list.md
@@ -15,7 +15,7 @@ Option|Description
 `--help`|output usage information
 `-i, --teamId <teamId>`|The ID of the team where the channel is located
 `-c, --channelId <channelId>`|The ID of the channel for which to list messages
-`-s, --since <since>`|Date (ISO standard, dash separator) to get delta of messages from (in last 8 months)
+`-s, --since [since]`|Date (ISO standard, dash separator) to get delta of messages from (in last 8 months)
 `--query [query]`|JMESPath query string. See [http://jmespath.org/](http://jmespath.org/) for more information and examples
 `-o, --output [output]`|Output type. `json|text`. Default `text`
 `--verbose`|Runs command with verbose logging

--- a/docs/manual/docs/cmd/teams/message/message-list.md
+++ b/docs/manual/docs/cmd/teams/message/message-list.md
@@ -15,6 +15,7 @@ Option|Description
 `--help`|output usage information
 `-i, --teamId <teamId>`|The ID of the team where the channel is located
 `-c, --channelId <channelId>`|The ID of the channel for which to list messages
+`-s, --since <since>`|Date (ISO standard, dash separator) to get delta of messages from (in last 8 months)
 `--query [query]`|JMESPath query string. See [http://jmespath.org/](http://jmespath.org/) for more information and examples
 `-o, --output [output]`|Output type. `json|text`. Default `text`
 `--verbose`|Runs command with verbose logging
@@ -29,8 +30,14 @@ You can only retrieve a message from a Microsoft Teams team if you are a member 
 
 ## Examples
 
-Retrieve the specified message from a channel of the Microsoft Teams team
+List the messages from a channel of the Microsoft Teams team
 
 ```sh
 teams message list --teamId fce9e580-8bba-4638-ab5c-ab40016651e3 --channelId 19:eb30973b42a847a2a1df92d91e37c76a@thread.skype
+```
+
+List the messages from a channel of the Microsoft Teams team that have been created or modified since the date specified by the --since parameter (WARNING: only captures the last 8 months of data) 
+
+```sh
+teams message list --teamId fce9e580-8bba-4638-ab5c-ab40016651e3 --channelId 19:eb30973b42a847a2a1df92d91e37c76a@thread.skype --since 2019-12-31T14:00:00Z
 ```

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -731,7 +731,7 @@
     },
     "chalk": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "requires": {
         "ansi-styles": "^2.2.1",
@@ -1651,7 +1651,7 @@
     },
     "inquirer": {
       "version": "0.11.4",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.11.4.tgz",
+      "resolved": "http://registry.npmjs.org/inquirer/-/inquirer-0.11.4.tgz",
       "integrity": "sha1-geM3ToNhvq/y2XAWIG01nQsy+k0=",
       "requires": {
         "ansi-escapes": "^1.1.0",
@@ -1671,7 +1671,7 @@
       "dependencies": {
         "lodash": {
           "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
         }
       }
@@ -2197,7 +2197,7 @@
     },
     "node-localstorage": {
       "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/node-localstorage/-/node-localstorage-0.6.0.tgz",
+      "resolved": "http://registry.npmjs.org/node-localstorage/-/node-localstorage-0.6.0.tgz",
       "integrity": "sha1-RaBgHGky395mRKIzYfG+Fzx1068="
     },
     "normalize-url": {
@@ -2277,7 +2277,7 @@
     },
     "onetime": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
       "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
     },
     "p-cancelable": {
@@ -2789,7 +2789,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "to-readable-stream": {
@@ -3031,7 +3031,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "requires": {
         "string-width": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   ],
   "contributors": [
     "Ågren, Simon <simon.agren@sogeti.com>",
-    "Albany, Bruce <you@example.com>",
+    "Albany, Bruce <bruce.albany@gmail.com>",
     "Balasubramaniam, Jayakumar <jayakumar@live.in>",
     "Bauer, Stefan <stefan.bauer@n8d.at>",
     "Bernier, Hugo <hugoabernier@live.ca>",

--- a/src/Utils.spec.ts
+++ b/src/Utils.spec.ts
@@ -37,6 +37,55 @@ describe('Utils', () => {
     assert.equal(result, false);
   });
 
+  it('isValidISODateDashOnly returns true if value is in ISO Date format with - separator', () => {
+    const result = Utils.isValidISODateDashOnly("2019-03-22");
+    assert.equal(result, true);
+  });
+
+  it('isValidISODateDashOnly returns false if value is in ISO Date format with . separator', () => {
+    const result = Utils.isValidISODateDashOnly("2019.03.22");
+    assert.equal(result, false);
+  });
+
+  it('isValidISODateDashOnly returns false if value is in ISO Date format with / separator', () => {
+    const result = Utils.isValidISODateDashOnly("2019/03/22");
+    assert.equal(result, false);
+  });
+
+  it('isValidISODateDashOnly returns false if value is blank', () => {
+    const result = Utils.isValidISODateDashOnly("");
+    assert.equal(result, false);
+  });
+
+  it('isValidISODate returns false if value is not in ISO Date format', () => {
+    const result = Utils.isValidISODate("22-03-2019");
+    assert.equal(result, false);
+  });
+
+  it('isValidISODateDashOnly returns false if alpha characters are passed', () => {
+    const result = Utils.isValidISODateDashOnly("sharing is caring");
+    assert.equal(result, false);
+  });
+
+  it('isDateInRange returns true if date within monthOffset is passed', () => {
+    let d: Date = new Date()
+    d.setMonth(d.getMonth() - 1);
+    const result = Utils.isDateInRange(d.toISOString(), 2);
+    assert.equal(result, true);
+  });
+
+  it('isDateInRange returns false if date prior to monthOffset is passed', () => {
+    let d: Date = new Date()
+    d.setMonth(d.getMonth() - 2);
+    const result = Utils.isDateInRange(d.toISOString(), 1);
+    assert.equal(result, false);
+  });
+
+  it('isDateInRange returns false if alpha characters are passed', () => {
+    const result = Utils.isDateInRange("sharing is caring", 1);
+    assert.equal(result, false);
+  });
+
   it('isValidGuid returns true if valid guid', () => {
     const result = Utils.isValidGuid('b2307a39-e878-458b-bc90-03bc578531d6');
     assert.equal(result, true);

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -61,11 +61,28 @@ export default class Utils {
     return guidRegEx.test(guid);
   }
 
+  public static isDateInRange(date: string, monthOffset: number): boolean {
+    const d: Date = new Date(date);
+    let cutoffDate: Date = new Date();
+    cutoffDate.setMonth(cutoffDate.getMonth() - monthOffset);
+    return d > cutoffDate;
+  }
+
   public static isValidISODate(date: string): boolean {
     const dateRegEx: RegExp = new RegExp(
       /^(19|20)\d\d[- /.](0[1-9]|1[012])[- /.](0[1-9]|[12][0-9]|3[01])$/i
     );
     return dateRegEx.test(date);
+  }
+
+  public static isValidISODateDashOnly(date: string): boolean {
+    const dateTimeRegEx: RegExp = new RegExp(
+      /^(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+([+-][0-2]\d:[0-5]\d|Z))|(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d([+-][0-2]\d:[0-5]\d|Z))|(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d([+-][0-2]\d:[0-5]\d|Z))$/i
+    );
+    const dateOnlyRegEx: RegExp = new RegExp(
+      /^(19|20)\d\d[-](0[1-9]|1[012])[-](0[1-9]|[12][0-9]|3[01])$/i
+    );
+    return dateTimeRegEx.test(date) ? true : dateOnlyRegEx.test(date);
   }
 
   public static isValidBoolean(value: string): boolean {

--- a/src/o365/teams/commands/message/teams-message-list.spec.ts
+++ b/src/o365/teams/commands/message/teams-message-list.spec.ts
@@ -449,6 +449,111 @@ describe(commands.TEAMS_MESSAGE_LIST, () => {
     });
   });
 
+  it('lists messages since date specified', (done) => {
+    const dt: string = new Date().toISOString()
+    sinon.stub(request, 'get').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/beta/teams/fce9e580-8bba-4638-ab5c-ab40016651e3/channels/19:eb30973b42a847a2a1df92d91e37c76a@thread.skype/messages/delta?$filter=lastModifiedDateTime gt ${dt}`) {
+        return Promise.resolve({
+          value: [
+            {
+              "attachments": [],
+              "body": {
+                "content": "<p>Welcome!</p>",
+                "contentType": "html"
+              },
+              "createdDateTime": "2018-11-15T13:56:40.091Z",
+              "deleted": false,
+              "etag": "1542290200091",
+              "from": {
+                "application": {
+                  "applicationIdentityType": "bot",
+                  "displayName": "POITBot",
+                  "id": "d22ece15-e04f-453a-adbd-d1514d2f1abe"
+                },
+                "conversation": null,
+                "device": null,
+                "user": null
+              },
+              "id": "1542290200091",
+              "importance": "normal",
+              "lastModifiedDateTime": null,
+              "locale": "en-us",
+              "mentions": [],
+              "messageType": "message",
+              "policyViolation": null,
+              "reactions": [],
+              "replyToId": null,
+              "subject": null,
+              "summary": null
+            },
+            {
+              "attachments": [],
+              "body": {
+                "content": "hello",
+                "contentType": "text"
+              },
+              "createdDateTime": "2018-11-15T13:20:43.581Z",
+              "deleted": false,
+              "etag": "1542288043581",
+              "from": {
+                "application": null,
+                "conversation": null,
+                "device": null,
+                "user": {
+                  "displayName": "Balamurugan Kailasam",
+                  "id": "065868eb-f08f-4a82-9786-690bc5c38fce",
+                  "userIdentityType": "aadUser"
+                }
+              },
+              "id": "1542288043581",
+              "importance": "normal",
+              "lastModifiedDateTime": null,
+              "locale": "en-us",
+              "mentions": [],
+              "messageType": "message",
+              "policyViolation": null,
+              "reactions": [],
+              "replyToId": null,
+              "subject": "",
+              "summary": null
+            }
+          ]
+        });
+      }
+
+      return Promise.reject('Invalid Request');
+    });
+
+    cmdInstance.action({
+      options: {
+        debug: false,
+        teamId: "fce9e580-8bba-4638-ab5c-ab40016651e3",
+        channelId: "19:eb30973b42a847a2a1df92d91e37c76a@thread.skype",
+        since: dt 
+      }
+    }, () => {
+      try {
+        assert(cmdInstanceLogSpy.calledWith([
+          {
+            "id": "1542290200091",
+            "summary": null,
+            "body": "<p>Welcome!</p>"
+          },
+          {
+            "id": "1542288043581",
+            "summary": null,
+            "body": "hello"
+          }
+        ]));
+
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
   it('outputs all data in json output mode', (done) => {
     sinon.stub(request, 'get').callsFake((opts) => {
       if (opts.url === `https://graph.microsoft.com/beta/teams/fce9e580-8bba-4638-ab5c-ab40016651e3/channels/19:eb30973b42a847a2a1df92d91e37c76a@thread.skype/messages`) {

--- a/src/o365/teams/commands/message/teams-message-list.spec.ts
+++ b/src/o365/teams/commands/message/teams-message-list.spec.ts
@@ -143,6 +143,17 @@ describe(commands.TEAMS_MESSAGE_LIST, () => {
     done();
   });
 
+  it('fails validation for since date wrong format', () => {
+    const actual = (command.validate() as CommandValidate)({
+      options: {
+        teamId: "fce9e580-8bba-4638-ab5c-ab40016651e3",
+        channelId: "19:eb30973b42a847a2a1df92d91e37c76a@thread.skype",
+        since: "2019.12.31"
+      }
+    });
+    assert.notEqual(actual, true);
+  });
+
   it('fails validation for since date too far in the past (> 8 months)', () => {
     let d: Date = new Date()
     d.setMonth(d.getMonth() - 9);

--- a/src/o365/teams/commands/message/teams-message-list.spec.ts
+++ b/src/o365/teams/commands/message/teams-message-list.spec.ts
@@ -121,7 +121,7 @@ describe(commands.TEAMS_MESSAGE_LIST, () => {
     assert.notEqual(actual, true);
   });
 
-  it('fails validates for a incorrect channelId missing leading 19:.', (done) => {
+  it('fails validatation for a incorrect channelId missing leading 19:.', (done) => {
     const actual = (command.validate() as CommandValidate)({
       options: {
         teamId: '00000000-0000-0000-0000-000000000000',
@@ -132,7 +132,7 @@ describe(commands.TEAMS_MESSAGE_LIST, () => {
     done();
   });
 
-  it('fails validates for a incorrect channelId missing trailing @thread.skpye.', (done) => {
+  it('fails validation for a incorrect channelId missing trailing @thread.skpye.', (done) => {
     const actual = (command.validate() as CommandValidate)({
       options: {
         teamId: '00000000-0000-0000-0000-000000000000',
@@ -141,6 +141,19 @@ describe(commands.TEAMS_MESSAGE_LIST, () => {
     });
     assert.notEqual(actual, true);
     done();
+  });
+
+  it('fails validation for since date too far in the past (> 8 months)', () => {
+    let d: Date = new Date()
+    d.setMonth(d.getMonth() - 9);
+    const actual = (command.validate() as CommandValidate)({
+      options: {
+        teamId: "fce9e580-8bba-4638-ab5c-ab40016651e3",
+        channelId: "19:eb30973b42a847a2a1df92d91e37c76a@thread.skype",
+        since: d.toISOString()
+      }
+    });
+    assert.notEqual(actual, true);
   });
 
   it('supports debug mode', () => {
@@ -159,6 +172,19 @@ describe(commands.TEAMS_MESSAGE_LIST, () => {
       options: {
         teamId: "fce9e580-8bba-4638-ab5c-ab40016651e3",
         channelId: "19:eb30973b42a847a2a1df92d91e37c76a@thread.skype"
+      }
+    });
+    assert.equal(actual, true);
+  });
+
+  it('validates for a correct input (with optional --since param)', () => {
+    let d: Date = new Date()
+    d.setMonth(d.getMonth() - 7);
+    const actual = (command.validate() as CommandValidate)({
+      options: {
+        teamId: "fce9e580-8bba-4638-ab5c-ab40016651e3",
+        channelId: "19:eb30973b42a847a2a1df92d91e37c76a@thread.skype",
+        since: d.toISOString()
       }
     });
     assert.equal(actual, true);

--- a/src/o365/teams/commands/message/teams-message-list.ts
+++ b/src/o365/teams/commands/message/teams-message-list.ts
@@ -29,7 +29,7 @@ class TeamsMessageListCommand extends GraphItemsListCommand<Message> {
   }
 
   public commandAction(cmd: CommandInstance, args: CommandArgs, cb: () => void): void {
-    const deltaExtension: string = !!args.options.since ? `/delta?$filter=lastModifiedDateTime gt ${args.options.since}` : '';
+    const deltaExtension: string = args.options.since !== undefined ? `/delta?$filter=lastModifiedDateTime gt ${args.options.since}` : '';
     const endpoint: string = `${this.resource}/beta/teams/${args.options.teamId}/channels/${args.options.channelId}/messages${deltaExtension}`;
 
     this
@@ -66,7 +66,7 @@ class TeamsMessageListCommand extends GraphItemsListCommand<Message> {
         description: 'The ID of the channel for which to list messages'
       },
       {
-        option: '-s, --since <since>',
+        option: '-s, --since [since]',
         description: 'Date (ISO standard, dash separator) to get delta of messages from (in last 8 months)'
       }
     ];
@@ -93,13 +93,12 @@ class TeamsMessageListCommand extends GraphItemsListCommand<Message> {
         return `${args.options.channelId} is not a valid Teams ChannelId`;
       }
 
-      if (!!args.options.since) {
-        if (!Utils.isValidISODateDashOnly(args.options.since as string)) {
-          return `${args.options.since} is not a valid ISO Date (with dash separator)`;
-        }
-        if (!Utils.isDateInRange(args.options.since as string, 8)) {
-          return `${args.options.since} is not in the last 8 months (for delta messages)`;
-        }
+      if (args.options.since && !Utils.isValidISODateDashOnly(args.options.since as string)) {
+        return `${args.options.since} is not a valid ISO Date (with dash separator)`;
+      }
+      
+      if (args.options.since && !Utils.isDateInRange(args.options.since as string, 8)) {
+        return `${args.options.since} is not in the last 8 months (for delta messages)`;
       }
 
       return true;

--- a/src/o365/teams/commands/message/teams-message-list.ts
+++ b/src/o365/teams/commands/message/teams-message-list.ts
@@ -16,6 +16,7 @@ interface CommandArgs {
 interface Options extends GlobalOptions {
   teamId: string;
   channelId: string;
+  since?: string;
 }
 
 class TeamsMessageListCommand extends GraphItemsListCommand<Message> {
@@ -28,7 +29,8 @@ class TeamsMessageListCommand extends GraphItemsListCommand<Message> {
   }
 
   public commandAction(cmd: CommandInstance, args: CommandArgs, cb: () => void): void {
-    const endpoint: string = `${this.resource}/beta/teams/${args.options.teamId}/channels/${args.options.channelId}/messages`;
+    const deltaExtension: string = !!args.options.since ? `/delta?$filter=lastModifiedDateTime gt ${args.options.since}` : '';
+    const endpoint: string = `${this.resource}/beta/teams/${args.options.teamId}/channels/${args.options.channelId}/messages${deltaExtension}`;
 
     this
     .getAllItems(endpoint, cmd, true)
@@ -62,6 +64,10 @@ class TeamsMessageListCommand extends GraphItemsListCommand<Message> {
       {
         option: '-c, --channelId <channelId>',
         description: 'The ID of the channel for which to list messages'
+      },
+      {
+        option: '-s, --since <since>',
+        description: 'Date (ISO standard, dash separator) to get delta of messages from (in last 8 months)'
       }
     ];
 
@@ -87,6 +93,15 @@ class TeamsMessageListCommand extends GraphItemsListCommand<Message> {
         return `${args.options.channelId} is not a valid Teams ChannelId`;
       }
 
+      if (!!args.options.since) {
+        if (!Utils.isValidISODateDashOnly(args.options.since as string)) {
+          return `${args.options.since} is not a valid ISO Date (with dash separator)`;
+        }
+        if (!Utils.isDateInRange(args.options.since as string, 8)) {
+          return `${args.options.since} is not in the last 8 months (for delta messages)`;
+        }
+      }
+
       return true;
     };
   }
@@ -108,6 +123,10 @@ class TeamsMessageListCommand extends GraphItemsListCommand<Message> {
   
     Lists all the messages from a channel of the Microsoft Teams team
       ${this.name} --teamId fce9e580-8bba-4638-ab5c-ab40016651e3 --channelId 19:eb30973b42a847a2a1df92d91e37c76a@thread.skype
+
+    List the messages from a channel of the Microsoft Teams team that have been created or modified since the date specified by the --since parameter (WARNING: only captures the last 8 months of data) 
+
+      teams message list --teamId fce9e580-8bba-4638-ab5c-ab40016651e3 --channelId 19:eb30973b42a847a2a1df92d91e37c76a@thread.skype --since 2019-12-31T14:00:00Z
 `   );
   }
 }


### PR DESCRIPTION
Implements #1125 

Needed to add some new utils functions as `isValidISODate` wasn't cutting it (was more permissive with format than the Teams messages endpoint and didn't allow for time, which the endpoint does) and needed a new one to capture whether the date passed in is in the last 8 months (which is a current limitation of the delta endpoint). 

We'd want to be quick to take that validation restriction away if the service restriction goes away on GA.

Fingers crossed that all the tests pass in CI, because I was getting a random failure (something unrelated - spfx project externalize, covers all text report branches) when I ran them locally on my Win10 machine.