### PR TITLE
Adding functionality for deleted sites in site-list solving #1335

### DIFF
--- a/docs/manual/docs/about/comparison-powershell.md
+++ b/docs/manual/docs/about/comparison-powershell.md
@@ -35,7 +35,7 @@ Get-SPOCrossGeoMovedUsers|Microsoft.Online.SharePoint.PowerShell|
 Get-SPOCrossGeoMoveReport|Microsoft.Online.SharePoint.PowerShell|
 Get-SPOCrossGeoUsers|Microsoft.Online.SharePoint.PowerShell|
 Get-SPODataEncryptionPolicy|Microsoft.Online.SharePoint.PowerShell|
-Get-SPODeletedSite|Microsoft.Online.SharePoint.PowerShell|
+Get-SPODeletedSite|Microsoft.Online.SharePoint.PowerShell|[spo site list --deleted](../cmd/spo/site/site-list.md)
 Get-SPOExternalUser|Microsoft.Online.SharePoint.PowerShell|[spo externaluser list](../cmd/spo/externaluser/externaluser-list.md)
 Get-SPOGeoAdministrator|Microsoft.Online.SharePoint.PowerShell|
 Get-SPOGeoMoveCrossCompatibilityStatus|Microsoft.Online.SharePoint.PowerShell|

--- a/docs/manual/docs/cmd/spo/site/site-list.md
+++ b/docs/manual/docs/cmd/spo/site/site-list.md
@@ -15,6 +15,7 @@ Option|Description
 `--help`|output usage information
 `--type [type]`|type of modern sites to list. Allowed values `TeamSite|CommunicationSite`, default `TeamSite`
 `-f, --filter [filter]`|filter to apply when retrieving sites
+`--deleted [deleted]`|use this switch to only return deleted sites
 `--query [query]`|JMESPath query string. See [http://jmespath.org/](http://jmespath.org/) for more information and examples
 `-o, --output [output]`|Output type. `json|text`. Default `text`
 `--verbose`|Runs command with verbose logging
@@ -53,4 +54,10 @@ List all modern team sites that contain _project_ in the URL
 
 ```sh
 spo site list --type TeamSite --filter "Url -like 'project'"
+```
+
+List all deleted sites in the tenant you're logged in to
+
+```sh
+spo site list --deleted
 ```

--- a/src/o365/spo/commands/site/site-list.spec.ts
+++ b/src/o365/spo/commands/site/site-list.spec.ts
@@ -252,6 +252,47 @@ describe(commands.SITE_LIST, () => {
       }
     });
   });
+    
+  it('retrieves a list of deleted sites', (done) => {
+    sinon.stub(request, 'post').callsFake((opts) => {
+      if (opts.url.indexOf(`/_vti_bin/client.svc/ProcessQuery`) > -1) {
+        if (opts.headers['X-RequestDigest'] &&
+          opts.headers['X-RequestDigest'] === 'abc' &&
+          opts.deleted &&
+          opts.body === `<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><ObjectPath Id="4" ObjectPathId="3" /><ObjectPath Id="6" ObjectPathId="5" /><Query Id="7" ObjectPathId="5"><Query SelectAllProperties="true"><Properties><Property Name="NextStartIndexFromSharePoint" ScalarProperty="true" /></Properties></Query><ChildItemQuery SelectAllProperties="true"><Properties /></ChildItemQuery></Query></Actions><ObjectPaths><Constructor Id="3" TypeId="{268004ae-ef6b-4e9b-8425-127220d84719}" /><Method Id="5" ParentId="3" Name="GetDeletedSitePropertiesFromSharePoint"><Parameters><Parameter Type="Null" /></Parameters></Method></ObjectPaths></Request>`) {
+          return Promise.resolve(JSON.stringify([
+            {
+            "SchemaVersion":"15.0.0.0","LibraryVersion":"16.0.19729.12021","ErrorInfo":null,"TraceCorrelationId":"782a00fd-e6ac-4129-8db1-0b84402490cf"
+            },12,{
+            "IsNull":false
+            },14,{
+            "IsNull":false
+            },15,{
+            "_ObjectType_":"Microsoft.Online.SharePoint.TenantAdministration.SPODeletedSitePropertiesEnumerable","NextStartIndex":-1,"NextStartIndexFromSharePoint":null,"_Child_Items_":[
+            {
+            "_ObjectType_":"Microsoft.Online.SharePoint.TenantAdministration.DeletedSiteProperties","_ObjectIdentity_":"782a00fd-e6ac-4129-8db1-0b84402490cf|908bed80-a04a-4433-b4a0-883d9847d110:6cd70031-6912-499f-877c-1df89d46200f\nDeletedSiteProperties\nhttps%3a%2f%2fm365x324230.sharepoint.com%2fsites%2fmtest_201","DaysRemaining":86,"DeletionTime":"\/Date(2020,1,7,13,8,26,907)\/","SiteId":"\/Guid(7bdf0575-0de3-4d41-9608-e57d27100001)\/","Status":"Recycled","StorageMaximumLevel":26214400,"Url":"https:\u002f\u002fm365x324230.sharepoint.com\u002fsites\u002fmtest_201","UserCodeMaximumLevel":300
+            },{
+            "_ObjectType_":"Microsoft.Online.SharePoint.TenantAdministration.DeletedSiteProperties","_ObjectIdentity_":"782a00fd-e6ac-4129-8db1-0b84402490cf|908bed80-a04a-4433-b4a0-883d9847d110:6cd70031-6912-499f-877c-1df89d46200f\nDeletedSiteProperties\nhttps%3a%2f%2fm365x324230.sharepoint.com%2fsites%2fmtest_202","DaysRemaining":86,"DeletionTime":"\/Date(2020,1,7,12,35,9,617)\/","SiteId":"\/Guid(87d49910-398c-48d1-80ca-b0d415293fa7)\/","Status":"Recycled","StorageMaximumLevel":26214400,"Url":"https:\u002f\u002fm365x324230.sharepoint.com\u002fsites\u002fmtest_202","UserCodeMaximumLevel":300
+            }
+            ]
+            }
+            ]));
+        }
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    cmdInstance.action({ options: { deleted: true } }, () => {
+      try {
+        assert(cmdInstanceLogSpy.notCalled);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
 
   it('retrieves list of modern teams sites when no type and filter specified', (done) => {
     sinon.stub(request, 'post').callsFake((opts) => {

--- a/src/o365/spo/commands/site/site-list.ts
+++ b/src/o365/spo/commands/site/site-list.ts
@@ -17,6 +17,7 @@ interface CommandArgs {
 interface Options extends GlobalOptions {
   type?: string;
   filter?: string;
+  deleted?: boolean;
 }
 
 class SpoSiteListCommand extends SpoCommand {
@@ -32,6 +33,7 @@ class SpoSiteListCommand extends SpoCommand {
     const telemetryProps: any = super.getTelemetryProperties(args);
     telemetryProps.siteType = args.options.type || 'TeamSite';
     telemetryProps.filter = (!(!args.options.filter)).toString();
+    telemetryProps.deleted = args.options.deleted
     return telemetryProps;
   }
 
@@ -39,7 +41,7 @@ class SpoSiteListCommand extends SpoCommand {
     const siteType: string = args.options.type || 'TeamSite';
     const webTemplate: string = siteType === 'TeamSite' ? 'GROUP#0' : 'SITEPAGEPUBLISHING#0';
     let startIndex: string = '0';
-    let spoAdminUrl: string 
+    let spoAdminUrl: string
 
     this
       .getSpoAdminUrl(cmd, this.debug)
@@ -53,12 +55,17 @@ class SpoSiteListCommand extends SpoCommand {
           cmd.log(`Retrieving list of site collections...`);
         }
 
+        let requestBody: string = `<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><ObjectPath Id="2" ObjectPathId="1" /><ObjectPath Id="4" ObjectPathId="3" /><Query Id="5" ObjectPathId="3"><Query SelectAllProperties="true"><Properties /></Query><ChildItemQuery SelectAllProperties="true"><Properties /></ChildItemQuery></Query></Actions><ObjectPaths><Constructor Id="1" TypeId="{268004ae-ef6b-4e9b-8425-127220d84719}" /><Method Id="3" ParentId="1" Name="GetSitePropertiesFromSharePointByFilters"><Parameters><Parameter TypeId="{b92aeee2-c92c-4b67-abcc-024e471bc140}"><Property Name="Filter" Type="String">${Utils.escapeXml(args.options.filter || '')}</Property><Property Name="IncludeDetail" Type="Boolean">false</Property><Property Name="IncludePersonalSite" Type="Enum">0</Property><Property Name="StartIndex" Type="String">${startIndex}</Property><Property Name="Template" Type="String">${webTemplate}</Property></Parameter></Parameters></Method></ObjectPaths></Request>`;
+        if (args.options.deleted) {
+          requestBody = `<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><ObjectPath Id="4" ObjectPathId="3" /><ObjectPath Id="6" ObjectPathId="5" /><Query Id="7" ObjectPathId="5"><Query SelectAllProperties="true"><Properties><Property Name="NextStartIndexFromSharePoint" ScalarProperty="true" /></Properties></Query><ChildItemQuery SelectAllProperties="true"><Properties /></ChildItemQuery></Query></Actions><ObjectPaths><Constructor Id="3" TypeId="{268004ae-ef6b-4e9b-8425-127220d84719}" /><Method Id="5" ParentId="3" Name="GetDeletedSitePropertiesFromSharePoint"><Parameters><Parameter Type="Null" /></Parameters></Method></ObjectPaths></Request>`;
+        }
+
         const requestOptions: any = {
           url: `${spoAdminUrl}/_vti_bin/client.svc/ProcessQuery`,
           headers: {
             'X-RequestDigest': res.FormDigestValue
           },
-          body: `<Request AddExpandoFieldTypeSuffix="true" SchemaVersion="15.0.0.0" LibraryVersion="16.0.0.0" ApplicationName="${config.applicationName}" xmlns="http://schemas.microsoft.com/sharepoint/clientquery/2009"><Actions><ObjectPath Id="2" ObjectPathId="1" /><ObjectPath Id="4" ObjectPathId="3" /><Query Id="5" ObjectPathId="3"><Query SelectAllProperties="true"><Properties /></Query><ChildItemQuery SelectAllProperties="true"><Properties /></ChildItemQuery></Query></Actions><ObjectPaths><Constructor Id="1" TypeId="{268004ae-ef6b-4e9b-8425-127220d84719}" /><Method Id="3" ParentId="1" Name="GetSitePropertiesFromSharePointByFilters"><Parameters><Parameter TypeId="{b92aeee2-c92c-4b67-abcc-024e471bc140}"><Property Name="Filter" Type="String">${Utils.escapeXml(args.options.filter || '')}</Property><Property Name="IncludeDetail" Type="Boolean">false</Property><Property Name="IncludePersonalSite" Type="Enum">0</Property><Property Name="StartIndex" Type="String">${startIndex}</Property><Property Name="Template" Type="String">${webTemplate}</Property></Parameter></Parameters></Method></ObjectPaths></Request>`
+          body: requestBody
         };
 
         return request.post(requestOptions);
@@ -109,6 +116,10 @@ class SpoSiteListCommand extends SpoCommand {
       {
         option: '-f, --filter [filter]',
         description: 'filter to apply when retrieving sites'
+      },
+      {
+        option: '--deleted [deleted]',
+        description: 'use this switch to only return deleted sites'
       }
     ];
 
@@ -159,6 +170,9 @@ class SpoSiteListCommand extends SpoCommand {
 
     List all modern team sites that contain 'project' in the URL
       ${commands.SITE_LIST} --type TeamSite --filter "Url -like 'project'"
+
+    List all deleted sites in the tenant you're logged in to
+      ${commands.SITE_LIST} --deleted
 `);
   }
 }


### PR DESCRIPTION
Solves #1335. Included in PR:

- Changed implementation to be able to use `--deleted`
- Updated test case to cover new branch in implementation
- Updated documentation with examples on how to get deleted sites
- Updated PowerShell comparsion for `Get-SPODeletedSite`