### PR TITLE
New sample: Scan Office 365 Groups created with User's First or Last Name

### DIFF
--- a/docs/manual/docs/examples/aad/flag-groups-with-user-names.md
+++ b/docs/manual/docs/examples/aad/flag-groups-with-user-names.md
@@ -1,10 +1,10 @@
-# Flag Microsoft Teams
+# Scan Office 365 Groups created with User's Givenname or Surname
 
 Author: [Joseph Velliah](https://sprider.blog/2020/02/03/governance-scan-office-365-groups-created-with-user-first-or-last-name-using-office-365-cli-commands/)
 
-We can use the group naming policy to enforce a consistent naming strategy for groups created by users in our organization. A naming policy can help us and our users identify the function of the group. We can use the policy to block specific words from being used in group names and aliases. But what if we need to find out the list of Office 365 groups created with user’s givenName or displayName as their mail?
+We can use the group naming policy to enforce a consistent naming strategy for groups created by users in our organization. A naming policy can help us and our users identify the function of the group. We can use the policy to block specific words from being used in group names and aliases. But what if we need to find out the list of Office 365 groups created with user’s givenName or surname as their mail?
 
-This sample script scans the Office 365 groups that may contain user’s givenName or displayName as the group mail.
+This sample script scans the Office 365 groups that may contain user’s givenName or surname as the group mail.
 
 Note: The filter condition can be changed as per your requirement.
 

--- a/docs/manual/docs/examples/aad/flag-groups-with-user-names.md
+++ b/docs/manual/docs/examples/aad/flag-groups-with-user-names.md
@@ -23,7 +23,6 @@ foreach ($user in $users) {
     foreach ($group in $groupsMatch) {
         $groupObject = New-Object -TypeName PSObject
         $groupObject | Add-Member -MemberType NoteProperty -Name "groupId" -Value $group.id
-        $groupObject | Add-Member -MemberType NoteProperty -Name "groupDisplayName" -Value $group.displayName
         $groupObject | Add-Member -MemberType NoteProperty -Name "groupMail" -Value $group.mail
         $groupObject | Add-Member -MemberType NoteProperty -Name "userGivenName" -Value $userGivenName
         $groupObject | Add-Member -MemberType NoteProperty -Name "userSurname" -Value $userSurname
@@ -56,11 +55,11 @@ for user in `echo $users | jq -c '.[]'`; do
         groupId=`echo $group | jq  -r '.id'`
         groupMail=`echo $group | jq  -r '.mail'`
         groupObject=$(jq -n -c \
-                --arg id "$groupId" \
-                --arg gm "${groupMail}" \
-                --arg gn "${userGivenName}" \
-                --arg sn "${userSurname}" \
-                '{groupId: $id, groupMail: $gm, userGivenName: $gn, userSurname: $sn}')
+                --arg GroupId "$groupId" \
+                --arg GroupMail "$groupMail" \
+                --arg UserGivenName "$userGivenName" \
+                --arg UserSurname "$userSurname" \
+                '{groupId: $GroupId, groupMail: $GroupMail, userGivenName: $UserGivenName, userSurname: $UserSurname}')
 
         groupsToFlag+=($groupObject)
     done

--- a/docs/manual/mkdocs.yml
+++ b/docs/manual/mkdocs.yml
@@ -428,6 +428,8 @@ nav:
     - 'GitHub Actions': 'concepts/github-actions.md'
   - Examples:
     - 'Introduction': 'examples/index.md'
+    - Azure Active Directory:
+      - 'Scan Office 365 Groups created with Users Givenname or Surname' : 'examples/aad/flag-groups-with-user-names.md'
     - Microsoft Graph:
       - 'Authenticate with and call the Microsoft Graph' : 'examples/graph/call-graph.md'
     - SharePoint Online:


### PR DESCRIPTION
Closes #1342

Docs |  
-- | --
Author | Joseph Velliah
Original Post | https://sprider.blog/2020/02/03/governance-scan-office-365-groups-created-with-user-first-or-last-name-using-office-365-cli-commands/
Description | We can use the group naming policy to enforce a consistent naming strategy for groups created by users in our organization. A naming policy can help us and our users identify the function of the group. We can use the policy to block specific words from being used in group names and aliases. But what if we need to find out the list of Office 365 groups created with user’s first or last name as their mail? The answer is very simple. We can use few lines of Office 365 CLI commands for this usecase. This sample script scans the Office 365 groups that may contain user’s first or last name as the group mail. Note - Filter conditions can be changed as per your requirement.
Keywords | Office 365 Groups

