### PR TITLE
[doc] updated docs to solve #1347

### DIFF
--- a/docs/manual/docs/cmd/aad/o365group/o365group-add.md
+++ b/docs/manual/docs/cmd/aad/o365group/o365group-add.md
@@ -47,13 +47,13 @@ aad o365group add --displayName Finance --description 'This is the Contoso Finan
 Create a public Office 365 Group and set specified users as its owners
 
 ```sh
-aad o365group add --displayName Finance --description 'This is the Contoso Finance Group. Please come here and check out the latest news, posts, files, and more.' --mailNickname finance --owners DebraB@contoso.onmicrosoft.com,DiegoS@contoso.onmicrosoft.com
+aad o365group add --displayName Finance --description 'This is the Contoso Finance Group. Please come here and check out the latest news, posts, files, and more.' --mailNickname finance --owners "DebraB@contoso.onmicrosoft.com,DiegoS@contoso.onmicrosoft.com"
 ```
 
 Create a public Office 365 Group and set specified users as its members
 
 ```sh
-aad o365group add --displayName Finance --description 'This is the Contoso Finance Group. Please come here and check out the latest news, posts, files, and more.' --mailNickname finance --members DebraB@contoso.onmicrosoft.com,DiegoS@contoso.onmicrosoft.com
+aad o365group add --displayName Finance --description 'This is the Contoso Finance Group. Please come here and check out the latest news, posts, files, and more.' --mailNickname finance --members "DebraB@contoso.onmicrosoft.com,DiegoS@contoso.onmicrosoft.com"
 ```
 
 Create a public Office 365 Group and set its logo

--- a/docs/manual/docs/cmd/aad/o365group/o365group-set.md
+++ b/docs/manual/docs/cmd/aad/o365group/o365group-set.md
@@ -49,13 +49,13 @@ aad o365group set --id 28beab62-7540-4db1-a23f-29a6018a3848 --isPrivate false
 Add new Office 365 Group owners
 
 ```sh
-aad o365group set --id 28beab62-7540-4db1-a23f-29a6018a3848 --owners DebraB@contoso.onmicrosoft.com,DiegoS@contoso.onmicrosoft.com
+aad o365group set --id 28beab62-7540-4db1-a23f-29a6018a3848 --owners "DebraB@contoso.onmicrosoft.com,DiegoS@contoso.onmicrosoft.com"
 ```
 
 Add new Office 365 Group members
 
 ```sh
-aad o365group set --id 28beab62-7540-4db1-a23f-29a6018a3848 --members DebraB@contoso.onmicrosoft.com,DiegoS@contoso.onmicrosoft.com
+aad o365group set --id 28beab62-7540-4db1-a23f-29a6018a3848 --members "DebraB@contoso.onmicrosoft.com,DiegoS@contoso.onmicrosoft.com"
 ```
 
 Update Office 365 Group logo

--- a/docs/manual/docs/cmd/aad/user/user-get.md
+++ b/docs/manual/docs/cmd/aad/user/user-get.md
@@ -45,7 +45,7 @@ aad user get --userName AarifS@contoso.onmicrosoft.com
 For the user with id _1caf7dcd-7e83-4c3a-94f7-932a1299c844_ retrieve the user name, e-mail address and full name
 
 ```sh
-aad user get --id 1caf7dcd-7e83-4c3a-94f7-932a1299c844 --properties userPrincipalName,mail,displayName
+aad user get --id 1caf7dcd-7e83-4c3a-94f7-932a1299c844 --properties "userPrincipalName,mail,displayName"
 ```
 
 ## More information

--- a/docs/manual/docs/cmd/aad/user/user-list.md
+++ b/docs/manual/docs/cmd/aad/user/user-list.md
@@ -37,7 +37,7 @@ aad user list
 List all users in the tenant. For each one return the display name and e-mail address
 
 ```sh
-aad user list --properties displayName,mail
+aad user list --properties "displayName,mail"
 ```
 
 Show users whose display name starts with _Patt_

--- a/docs/manual/docs/cmd/outlook/mail/mail-send.md
+++ b/docs/manual/docs/cmd/outlook/mail/mail-send.md
@@ -36,23 +36,23 @@ Option|Description
 Send a text e-mail to the specified e-mail address
 
 ```sh
-outlook mail send --to chris@contoso.com --subject 'DG2000 Data Sheets' --bodyContents 'The latest data sheets are in the team site'
+outlook mail send --to chris@contoso.com --subject "DG2000 Data Sheets" --bodyContents "The latest data sheets are in the team site"
 ```
 
 Send an HTML e-mail to the specified e-mail addresses
 
 ```sh
-outlook mail send --to chris@contoso.com,brian@contoso.com --subject 'DG2000 Data Sheets' --bodyContents 'The latest data sheets are in the <a href="https://contoso.sharepoint.com/sites/marketing">team site</a>' --bodyContentType HTML
+outlook mail send --to "chris@contoso.com,brian@contoso.com" --subject "DG2000 Data Sheets" --bodyContents "The latest data sheets are in the <a href="https://contoso.sharepoint.com/sites/marketing">team site</a>" --bodyContentType HTML
 ```
 
 Send an HTML e-mail to the specified e-mail address loading e-mail contents from a file on disk
 
 ```sh
-outlook mail send --to chris@contoso.com --subject 'DG2000 Data Sheets' --bodyContentsFilePath email.html --bodyContentType HTML
+outlook mail send --to chris@contoso.com --subject "DG2000 Data Sheets" --bodyContentsFilePath email.html --bodyContentType HTML
 ```
 
 Send a text e-mail to the specified e-mail address. Don't store the e-mail in sent items
 
 ```sh
-outlook mail send --to chris@contoso.com --subject 'DG2000 Data Sheets' --bodyContents 'The latest data sheets are in the team site' --saveToSentItems false
+outlook mail send --to chris@contoso.com --subject "DG2000 Data Sheets" --bodyContents "The latest data sheets are in the team site" --saveToSentItems false
 ```

--- a/docs/manual/docs/cmd/spo/hubsite/hubsite-rights-grant.md
+++ b/docs/manual/docs/cmd/spo/hubsite/hubsite-rights-grant.md
@@ -41,7 +41,7 @@ spo hubsite rights grant --url https://contoso.sharepoint.com/sites/sales --prin
 Grant users with aliases _PattiF_ and _AdeleV_ permission to join sites to the hub site with URL _https://contoso.sharepoint.com/sites/sales_
 
 ```sh
-spo hubsite rights grant --url https://contoso.sharepoint.com/sites/sales --principals PattiF,AdeleV --rights Join
+spo hubsite rights grant --url https://contoso.sharepoint.com/sites/sales --principals "PattiF,AdeleV" --rights Join
 ```
 
 Grant user with email _PattiF@contoso.com_ permission to join sites to the hub site with URL _https://contoso.sharepoint.com/sites/sales_

--- a/docs/manual/docs/cmd/spo/hubsite/hubsite-rights-revoke.md
+++ b/docs/manual/docs/cmd/spo/hubsite/hubsite-rights-revoke.md
@@ -41,7 +41,7 @@ spo hubsite rights revoke --url https://contoso.sharepoint.com/sites/sales --pri
 Revoke rights to join sites to the hub site with URL _https://contoso.sharepoint.com/sites/sales_ from user with aliases _PattiF_ and _AdeleV_ without prompting for confirmation
 
 ```sh
-spo hubsite rights revoke --url https://contoso.sharepoint.com/sites/sales --principals PattiF,AdeleV --confirm
+spo hubsite rights revoke --url https://contoso.sharepoint.com/sites/sales --principals "PattiF,AdeleV" --confirm
 ```
 
 ## More information

--- a/docs/manual/docs/cmd/spo/listitem/listitem-get.md
+++ b/docs/manual/docs/cmd/spo/listitem/listitem-get.md
@@ -31,3 +31,10 @@ Get an item with ID _147_ from list with title _Demo List_ in site _https://cont
 ```sh
 spo listitem get --listTitle "Demo List" --id 147 --webUrl https://contoso.sharepoint.com/sites/project-x
 ```
+
+
+Get an items Title and Created column and with ID _147_ from list with title _Demo List_ in site _https://contoso.sharepoint.com/sites/project-x_
+
+```sh
+spo listitem get --listTitle "Demo List" --id 147 --webUrl https://contoso.sharepoint.com/sites/project-x --fields "Title,Created"
+```

--- a/docs/manual/docs/cmd/spo/mail/mail-send.md
+++ b/docs/manual/docs/cmd/spo/mail/mail-send.md
@@ -36,17 +36,17 @@ All recipients (internal and external) have to have access to the target SharePo
 Send an e-mail to _user@contoso.com_
 
 ```sh
-spo mail send --webUrl https://contoso.sharepoint.com/sites/project-x --to 'user@contoso.com' --subject 'Email sent via Office 365 CLI' --body '<h1>Office 365 CLI</h1>Email sent via <b>command</b>.'
+spo mail send --webUrl https://contoso.sharepoint.com/sites/project-x --to "user@contoso.com" --subject "Email sent via Office 365 CLI" --body "<h1>Office 365 CLI</h1>Email sent via <b>command</b>."
 ```
 
 Send an e-mail to multiples addresses
 
 ```sh
-spo mail send --webUrl https://contoso.sharepoint.com/sites/project-x --to 'user1@contoso.com,user2@contoso.com' --subject 'Email sent via Office 365 CLI' --body '<h1>Office 365 CLI</h1>Email sent via <b>command</b>.' --cc 'user3@contoso.com' --bcc 'user4@contoso.com'
+spo mail send --webUrl https://contoso.sharepoint.com/sites/project-x --to "user1@contoso.com,user2@contoso.com" --subject "Email sent via Office 365 CLI" --body "<h1>Office 365 CLI</h1>Email sent via <b>command</b>." --cc "user3@contoso.com" --bcc "user4@contoso.com"
 ```
 
 Send an e-mail to _user@contoso.com_ with additional headers
 
 ```sh
-spo mail send --webUrl https://contoso.sharepoint.com/sites/project-x --to 'user@contoso.com' --subject 'Email sent via Office 365 CLI' --body '<h1>Office 365 CLI</h1>Email sent via <b>command</b>.' --additionalHeaders "'{\"X-MC-Tags\":\"Office 365 CLI\"}'"
+spo mail send --webUrl https://contoso.sharepoint.com/sites/project-x --to "user@contoso.com" --subject "Email sent via Office 365 CLI" --body "<h1>Office 365 CLI</h1>Email sent via <b>command</b>." --additionalHeaders "'{\"X-MC-Tags\":\"Office 365 CLI\"}'"
 ```

--- a/docs/manual/docs/cmd/spo/page/page-header-set.md
+++ b/docs/manual/docs/cmd/spo/page/page-header-set.md
@@ -46,6 +46,12 @@ Reset the page header to default
 spo page header set --webUrl https://contoso.sharepoint.com/sites/team-a --pageName home.aspx
 ```
 
+Reset the page header to default and set authors
+
+```sh
+spo page header set --webUrl https://contoso.sharepoint.com/sites/team-a --pageName home.aspx --authors "steve@contoso.com, bob@contoso.com"
+```
+
 Use the specified image focused on the given coordinates in the page header
 
 ```sh

--- a/docs/manual/docs/cmd/spo/site/site-add.md
+++ b/docs/manual/docs/cmd/spo/site/site-add.md
@@ -61,7 +61,7 @@ spo site add --alias team1 --title Team 1 --lcid 1043
 Create modern team site with the specified users as owners
 
 ```sh
-spo site add --alias team1 --title Team 1 --owners 'steve@contoso.com, bob@contoso.com'
+spo site add --alias team1 --title Team 1 --owners "steve@contoso.com, bob@contoso.com"
 ```
 
 Create communication site using the Topic design

--- a/docs/manual/docs/cmd/spo/site/site-classic-set.md
+++ b/docs/manual/docs/cmd/spo/site/site-classic-set.md
@@ -63,7 +63,7 @@ spo site classic set --url https://contoso.sharepoint.com/sites/team --title Tea
 Add the specified user accounts as site collection administrators
 
 ```sh
-spo site classic set --url https://contoso.sharepoint.com/sites/team --owners joe@contoso.com,steve@contoso.com
+spo site classic set --url https://contoso.sharepoint.com/sites/team --owners "joe@contoso.com,steve@contoso.com"
 ```
 
 Lock the site preventing users from accessing it. Wait for the configuration to complete

--- a/docs/manual/docs/cmd/spo/sitedesign/sitedesign-add.md
+++ b/docs/manual/docs/cmd/spo/sitedesign/sitedesign-add.md
@@ -43,7 +43,7 @@ spo sitedesign add --title "Contoso team site" --webTemplate TeamSite --siteScri
 Create new default site design for provisioning modern communication sites
 
 ```sh
-spo sitedesign add --title "Contoso communication site" --webTemplate CommunicationSite --siteScripts 19b0e1b2-e3d1-473f-9394-f08c198ef43e --isDefault
+spo sitedesign add --title "Contoso communication site" --webTemplate CommunicationSite --siteScripts "19b0e1b2-e3d1-473f-9394-f08c198ef43e" --isDefault
 ```
 
 ## More information

--- a/docs/manual/docs/cmd/spo/sitedesign/sitedesign-rights-grant.md
+++ b/docs/manual/docs/cmd/spo/sitedesign/sitedesign-rights-grant.md
@@ -33,7 +33,7 @@ spo sitedesign rights grant --id 9b142c22-037f-4a7f-9017-e9d8c0e34b98 --principa
 Grant users with aliases _PattiF_ and _AdeleV_ view permission to the specified site design
 
 ```sh
-spo sitedesign rights grant --id 9b142c22-037f-4a7f-9017-e9d8c0e34b98 --principals PattiF,AdeleV --rights View
+spo sitedesign rights grant --id 9b142c22-037f-4a7f-9017-e9d8c0e34b98 --principals "PattiF,AdeleV" --rights View
 ```
 
 Grant user with email _PattiF@contoso.com_ view permission to the specified site design

--- a/docs/manual/docs/cmd/spo/sitedesign/sitedesign-rights-revoke.md
+++ b/docs/manual/docs/cmd/spo/sitedesign/sitedesign-rights-revoke.md
@@ -41,7 +41,7 @@ spo sitedesign rights revoke --id 2c1ba4c4-cd9b-4417-832f-92a34bc34b2a --princip
 Revoke access to the site design with ID _2c1ba4c4-cd9b-4417-832f-92a34bc34b2a_ from users with aliases _PattiF_ and _AdeleV_ without prompting for confirmation
 
 ```sh
-spo sitedesign rights revoke --id 2c1ba4c4-cd9b-4417-832f-92a34bc34b2a --principals PattiF,AdeleV --confirm
+spo sitedesign rights revoke --id 2c1ba4c4-cd9b-4417-832f-92a34bc34b2a --principals "PattiF,AdeleV" --confirm
 ```
 
 ## More information

--- a/docs/manual/docs/cmd/spo/sitedesign/sitedesign-set.md
+++ b/docs/manual/docs/cmd/spo/sitedesign/sitedesign-set.md
@@ -48,6 +48,13 @@ Update the site design to be the default design for provisioning modern communic
 spo sitedesign set --id 9b142c22-037f-4a7f-9017-e9d8c0e34b98 --webTemplate CommunicationSite  --isDefault true
 ```
 
+
+Update the site design to be the default design for provisioning modern communication sites, with specific scripts
+
+```sh
+spo sitedesign set --id 9b142c22-037f-4a7f-9017-e9d8c0e34b98 --webTemplate CommunicationSite  --isDefault true --siteScripts "19b0e1b2-e3d1-473f-9394-f08c198ef43e,b2307a39-e878-458b-bc90-03bc578531d6"
+```
+
 ## More information
 
 - SharePoint site design and site script overview: [https://docs.microsoft.com/en-us/sharepoint/dev/declarative-customization/site-design-overview](https://docs.microsoft.com/en-us/sharepoint/dev/declarative-customization/site-design-overview)

--- a/docs/manual/docs/cmd/spo/spo-search.md
+++ b/docs/manual/docs/cmd/spo/spo-search.md
@@ -48,23 +48,23 @@ Option|Description
 Execute search query to retrieve all Document Sets (ContentTypeId = _0x0120D520_) for the English locale
 
 ```sh
-spo search --query 'ContentTypeId:0x0120D520' --culture 1033
+spo search --query "ContentTypeId:0x0120D520" --culture 1033
 ```
 
 Retrieve all documents. For each document, retrieve the _Path_, _Author_ and _FileType_.
 
 ```sh
-spo search --query 'IsDocument:1' --selectProperties 'Path,Author,FileType' --allResults
+spo search --query "IsDocument:1" --selectProperties "Path,Author,FileType" --allResults
 ```
 
 Return the top 50 items of which the title starts with _Marketing_ while trimming duplicates.
 
 ```sh
-spo search --query 'Title:Marketing*' --rowLimit=50 --trimDuplicates
+spo search --query "Title:Marketing*" --rowLimit=50 --trimDuplicates
 ```
 
 Return only items from a specific result source (using the source id).
 
 ```sh
-spo search --query '*' --sourceId '6e71030e-5e16-4406-9bff-9c1829843083'
+spo search --query "*" --sourceId "6e71030e-5e16-4406-9bff-9c1829843083"
 ```

--- a/src/o365/aad/commands/o365group/o365group-add.ts
+++ b/src/o365/aad/commands/o365group/o365group-add.ts
@@ -310,11 +310,11 @@ class AadO365GroupAddCommand extends GraphCommand {
     log(vorpal.find(this.name).helpInformation());
     log(
       `  Remarks:
-  
+
     When specifying the path to the logo image you can use both relative and
     absolute paths. Note, that ~ in the path, will not be resolved and will most
     likely result in an error.
-   
+
   Examples:
 
     Create a public Office 365 Group
@@ -324,10 +324,10 @@ class AadO365GroupAddCommand extends GraphCommand {
       ${this.name} --displayName Finance --description 'This is the Contoso Finance Group. Please come here and check out the latest news, posts, files, and more.' --mailNickname finance --isPrivate true
 
     Create a public Office 365 Group and set specified users as its owners
-      ${this.name} --displayName Finance --description 'This is the Contoso Finance Group. Please come here and check out the latest news, posts, files, and more.' --mailNickname finance --owners DebraB@contoso.onmicrosoft.com,DiegoS@contoso.onmicrosoft.com
+      ${this.name} --displayName Finance --description 'This is the Contoso Finance Group. Please come here and check out the latest news, posts, files, and more.' --mailNickname finance --owners "DebraB@contoso.onmicrosoft.com,DiegoS@contoso.onmicrosoft.com"
 
     Create a public Office 365 Group and set specified users as its members
-      ${this.name} --displayName Finance --description 'This is the Contoso Finance Group. Please come here and check out the latest news, posts, files, and more.' --mailNickname finance --members DebraB@contoso.onmicrosoft.com,DiegoS@contoso.onmicrosoft.com
+      ${this.name} --displayName Finance --description 'This is the Contoso Finance Group. Please come here and check out the latest news, posts, files, and more.' --mailNickname finance --members "DebraB@contoso.onmicrosoft.com,DiegoS@contoso.onmicrosoft.com"
 
     Create a public Office 365 Group and set its logo
       ${this.name} --displayName Finance --description 'This is the Contoso Finance Group. Please come here and check out the latest news, posts, files, and more.' --mailNickname finance --logoPath images/logo.png

--- a/src/o365/aad/commands/o365group/o365group-set.ts
+++ b/src/o365/aad/commands/o365group/o365group-set.ts
@@ -323,7 +323,7 @@ class AadO365GroupSetCommand extends GraphCommand {
     log(vorpal.find(this.name).helpInformation());
     log(
       `  Remarks:
-  
+
     When updating group's owners and members, the command will add newly
     specified users to the previously set owners and members. The previously
     set users will not be replaced.
@@ -331,7 +331,7 @@ class AadO365GroupSetCommand extends GraphCommand {
     When specifying the path to the logo image you can use both relative and
     absolute paths. Note, that ~ in the path, will not be resolved and will most
     likely result in an error.
-   
+
   Examples:
 
     Update Office 365 Group display name
@@ -341,10 +341,10 @@ class AadO365GroupSetCommand extends GraphCommand {
       ${this.name} --id 28beab62-7540-4db1-a23f-29a6018a3848 --isPrivate false
 
     Add new Office 365 Group owners
-      ${this.name} --id 28beab62-7540-4db1-a23f-29a6018a3848 --owners DebraB@contoso.onmicrosoft.com,DiegoS@contoso.onmicrosoft.com
+      ${this.name} --id 28beab62-7540-4db1-a23f-29a6018a3848 --owners "DebraB@contoso.onmicrosoft.com,DiegoS@contoso.onmicrosoft.com"
 
     Add new Office 365 Group members
-      ${this.name} --id 28beab62-7540-4db1-a23f-29a6018a3848 --members DebraB@contoso.onmicrosoft.com,DiegoS@contoso.onmicrosoft.com
+      ${this.name} --id 28beab62-7540-4db1-a23f-29a6018a3848 --members "DebraB@contoso.onmicrosoft.com,DiegoS@contoso.onmicrosoft.com"
 
     Update Office 365 Group logo
       ${this.name} --id 28beab62-7540-4db1-a23f-29a6018a3848 --logoPath images/logo.png

--- a/src/o365/aad/commands/user/user-get.ts
+++ b/src/o365/aad/commands/user/user-get.ts
@@ -115,7 +115,7 @@ class AadUserGetCommand extends GraphCommand {
     ${chalk.grey(`objects are not present.`)} error.
 
   Examples:
-  
+
     Get information about the user with id ${chalk.grey(`1caf7dcd-7e83-4c3a-94f7-932a1299c844`)}
       ${this.name} --id 1caf7dcd-7e83-4c3a-94f7-932a1299c844
 
@@ -124,10 +124,10 @@ class AadUserGetCommand extends GraphCommand {
 
     For the user with id ${chalk.grey(`1caf7dcd-7e83-4c3a-94f7-932a1299c844`)}
     retrieve the user name, e-mail address and full name
-      ${this.name} --id 1caf7dcd-7e83-4c3a-94f7-932a1299c844 --properties userPrincipalName,mail,displayName
-  
+      ${this.name} --id 1caf7dcd-7e83-4c3a-94f7-932a1299c844 --properties "userPrincipalName,mail,displayName"
+
   More information:
-    
+
     Microsoft Graph User properties
       https://developer.microsoft.com/en-us/graph/docs/api-reference/v1.0/resources/user#properties
 `);

--- a/src/o365/aad/commands/user/user-list.ts
+++ b/src/o365/aad/commands/user/user-list.ts
@@ -98,7 +98,7 @@ class AadUserListCommand extends GraphItemsListCommand<any> {
     a comma-separated list of user properties to retrieve from the Microsoft
     Graph. If you don't specify any properties, the command will retrieve
     user's display name and account name.
-    
+
     To filter the list of users, include additional options that match the user
     property that you want to filter with. For example
     ${chalk.blue('--displayName Patt')} will return all users whose displayName
@@ -106,13 +106,13 @@ class AadUserListCommand extends GraphItemsListCommand<any> {
     the ${chalk.blue('and')} operator.
 
   Examples:
-  
+
     List all users in the tenant
       ${this.name}
 
     List all users in the tenant. For each one return the display name and
     e-mail address
-      ${this.name} --properties displayName,mail
+      ${this.name} --properties "displayName,mail"
 
     Show users whose display name starts with ${chalk.grey('Patt')}
       ${this.name} --displayName Patt
@@ -121,7 +121,7 @@ class AadUserListCommand extends GraphItemsListCommand<any> {
       ${this.name} --displayName Patt --jobTitle 'Account manager'
 
   More information:
-    
+
     Microsoft Graph User properties
       https://developer.microsoft.com/en-us/graph/docs/api-reference/v1.0/resources/user#properties
 `);

--- a/src/o365/outlook/commands/mail/mail-send.ts
+++ b/src/o365/outlook/commands/mail/mail-send.ts
@@ -173,18 +173,18 @@ class OutlookSendmailCommand extends GraphCommand {
       `  Examples:
 
     Send a text e-mail to the specified e-mail address
-      ${this.name} --to chris@contoso.com --subject 'DG2000 Data Sheets' --bodyContents 'The latest data sheets are in the team site'
+      ${this.name} --to chris@contoso.com --subject "DG2000 Data Sheets" --bodyContents "The latest data sheets are in the team site"
 
     Send an HTML e-mail to the specified e-mail addresses
-      ${this.name} --to chris@contoso.com,brian@contoso.com --subject 'DG2000 Data Sheets' --bodyContents 'The latest data sheets are in the <a href="https://contoso.sharepoint.com/sites/marketing">team site</a>' --bodyContentType HTML
+      ${this.name} --to "chris@contoso.com,brian@contoso.com" --subject "DG2000 Data Sheets" --bodyContents "The latest data sheets are in the <a href="https://contoso.sharepoint.com/sites/marketing">team site</a>" --bodyContentType HTML
 
     Send an HTML e-mail to the specified e-mail address loading e-mail contents
     from a file on disk
-      ${this.name} --to chris@contoso.com --subject 'DG2000 Data Sheets' --bodyContentsFilePath email.html --bodyContentType HTML
-  
+      ${this.name} --to chris@contoso.com --subject "DG2000 Data Sheets" --bodyContentsFilePath email.html --bodyContentType HTML
+
     Send a text e-mail to the specified e-mail address. Don't store the e-mail
     in sent items
-      ${this.name} --to chris@contoso.com --subject 'DG2000 Data Sheets' --bodyContents 'The latest data sheets are in the team site' --saveToSentItems false
+      ${this.name} --to chris@contoso.com --subject "DG2000 Data Sheets" --bodyContents "The latest data sheets are in the team site" --saveToSentItems false
 `);
   }
 }

--- a/src/o365/spo/commands/hubsite/hubsite-rights-grant.ts
+++ b/src/o365/spo/commands/hubsite/hubsite-rights-grant.ts
@@ -130,7 +130,7 @@ class SpoHubSiteRightsGrantCommand extends SpoCommand {
     log(
       `  ${chalk.yellow('Important:')} to use this command you have to have permissions to access
     the tenant admin site.
-        
+
   Remarks:
 
     ${chalk.yellow('Attention:')} This command is based on a SharePoint API that is currently
@@ -138,14 +138,14 @@ class SpoHubSiteRightsGrantCommand extends SpoCommand {
     availability.
 
   Examples:
-  
+
     Grant user with alias ${chalk.grey('PattiF')} permission to join sites to the hub site with
     URL ${chalk.grey('https://contoso.sharepoint.com/sites/sales')}
       ${this.name} --url https://contoso.sharepoint.com/sites/sales --principals PattiF --rights Join
 
     Grant users with aliases ${chalk.grey('PattiF')} and ${chalk.grey('AdeleV')} permission to join sites
     to the hub site with URL ${chalk.grey('https://contoso.sharepoint.com/sites/sales')}
-      ${this.name} --url https://contoso.sharepoint.com/sites/sales --principals PattiF,AdeleV --rights Join
+      ${this.name} --url https://contoso.sharepoint.com/sites/sales --principals "PattiF,AdeleV" --rights Join
 
     Grant user with email ${chalk.grey('PattiF@contoso.com')} permission to join sites
     to the hub site with URL ${chalk.grey('https://contoso.sharepoint.com/sites/sales')}

--- a/src/o365/spo/commands/hubsite/hubsite-rights-revoke.ts
+++ b/src/o365/spo/commands/hubsite/hubsite-rights-revoke.ts
@@ -150,7 +150,7 @@ class SpoHubSiteRightsRevokeCommand extends SpoCommand {
     log(
       `  ${chalk.yellow('Important:')} to use this command you have to have permissions to access
     the tenant admin site.
-                
+
   Remarks:
 
     ${chalk.yellow('Attention:')} This command is based on a SharePoint API that is currently
@@ -158,7 +158,7 @@ class SpoHubSiteRightsRevokeCommand extends SpoCommand {
     availability.
 
   Examples:
-  
+
     Revoke rights to join sites to the hub site with URL
     ${chalk.grey('https://contoso.sharepoint.com/sites/sales')} from user with alias ${chalk.grey('PattiF')}.
     Will prompt for confirmation before revoking the rights
@@ -167,7 +167,7 @@ class SpoHubSiteRightsRevokeCommand extends SpoCommand {
     Revoke rights to join sites to the hub site with URL
     ${chalk.grey('https://contoso.sharepoint.com/sites/sales')} from user with aliases ${chalk.grey('PattiF')}
     and ${chalk.grey('AdeleV')} without prompting for confirmation
-      ${this.name} --url https://contoso.sharepoint.com/sites/sales --principals PattiF,AdeleV --confirm
+      ${this.name} --url https://contoso.sharepoint.com/sites/sales --principals "PattiF,AdeleV" --confirm
 
   More information:
 

--- a/src/o365/spo/commands/listitem/listitem-get.ts
+++ b/src/o365/spo/commands/listitem/listitem-get.ts
@@ -158,9 +158,12 @@ class SpoListItemGetCommand extends SpoCommand {
     log(vorpal.find(this.name).helpInformation());
     log(
       `  Examples:
-  
+
     Get the item with ID of ${chalk.grey('147')} in list with title ${chalk.grey('Demo List')} in site ${chalk.grey('https://contoso.sharepoint.com/sites/project-x')}
       ${commands.LISTITEM_GET} --listTitle "Demo List" --id 147 --webUrl https://contoso.sharepoint.com/sites/project-x
+
+    Get the items Title and Created column and with ID of ${chalk.grey('147')} in list with title ${chalk.grey('Demo List')} in site ${chalk.grey('https://contoso.sharepoint.com/sites/project-x')}
+      ${commands.LISTITEM_GET} --listTitle "Demo List" --id 147 --webUrl https://contoso.sharepoint.com/sites/project-x --fields "Title,Created"
 
    `);
   }

--- a/src/o365/spo/commands/mail/mail-send.ts
+++ b/src/o365/spo/commands/mail/mail-send.ts
@@ -173,20 +173,20 @@ class SpoMailSendCommand extends SpoCommand {
     log(vorpal.find(this.name).helpInformation());
     log(
       `  Remarks:
-  
+
     All recipients (internal and external) have to have access to the target
     SharePoint site.
-        
+
   Examples:
-  
-    Send an e-mail to ${chalk.grey('user@contoso.com')} 
-      ${commands.MAIL_SEND} --webUrl https://contoso.sharepoint.com/sites/project-x --to 'user@contoso.com' --subject 'Email sent via Office 365 CLI' --body '<h1>Office 365 CLI</h1>Email sent via <b>command</b>.'
-    
+
+    Send an e-mail to ${chalk.grey('user@contoso.com')}
+      ${commands.MAIL_SEND} --webUrl https://contoso.sharepoint.com/sites/project-x --to "user@contoso.com" --subject "Email sent via Office 365 CLI" --body "<h1>Office 365 CLI</h1>Email sent via <b>command</b>."
+
     Send an e-mail to multiples addresses
-      ${commands.MAIL_SEND} --webUrl https://contoso.sharepoint.com/sites/project-x --to 'user1@contoso.com,user2@contoso.com' --subject 'Email sent via Office 365 CLI' --body '<h1>Office 365 CLI</h1>Email sent via <b>command</b>.' --cc 'user3@contoso.com' --bcc 'user4@contoso.com'
-    
+      ${commands.MAIL_SEND} --webUrl https://contoso.sharepoint.com/sites/project-x --to "user1@contoso.com,user2@contoso.com" --subject "Email sent via Office 365 CLI" --body "<h1>Office 365 CLI</h1>Email sent via <b>command</b>." --cc "user3@contoso.com" --bcc "user4@contoso.com"
+
     Send an e-mail to ${chalk.grey('user@contoso.com')} with additional headers
-      ${commands.MAIL_SEND} --webUrl https://contoso.sharepoint.com/sites/project-x --to 'user@contoso.com' --subject 'Email sent via Office 365 CLI' --body '<h1>Office 365 CLI</h1>Email sent via <b>command</b>.' --additionalHeaders "'{\"X-MC-Tags\":\"Office 365 CLI\"}'"
+      ${commands.MAIL_SEND} --webUrl https://contoso.sharepoint.com/sites/project-x --to "user@contoso.com" --subject "Email sent via Office 365 CLI" --body "<h1>Office 365 CLI</h1>Email sent via <b>command</b>." --additionalHeaders "'{\"X-MC-Tags\":\"Office 365 CLI\"}'"
       `);
   }
 }

--- a/src/o365/spo/commands/page/page-header-set.ts
+++ b/src/o365/spo/commands/page/page-header-set.ts
@@ -447,9 +447,12 @@ class SpoPageHeaderSetCommand extends SpoCommand {
     functionality that isn't available on all tenants yet.
 
   Examples:
-  
+
     Reset the page header to default
       ${this.name} --webUrl https://contoso.sharepoint.com/sites/team-a --pageName home.aspx
+
+    Reset the page header to default and set authors
+      ${this.name} --webUrl https://contoso.sharepoint.com/sites/team-a --pageName home.aspx --authors "steve@contoso.com, bob@contoso.com"
 
     Use the specified image focused on the given coordinates in the page header
       ${this.name} --webUrl https://contoso.sharepoint.com/sites/team-a --pageName home.aspx --type Custom --imageUrl /sites/team-a/SiteAssets/hero.jpg --altText 'Sunset over the ocean' --translateX 42.3837520042758 --translateY 56.4285714285714

--- a/src/o365/spo/commands/site/site-add.ts
+++ b/src/o365/spo/commands/site/site-add.ts
@@ -328,7 +328,7 @@ class SpoSiteAddCommand extends SpoCommand {
     log(vorpal.find(this.name).helpInformation());
     log(
       `  Examples:
-  
+
     Create modern team site with private group
       ${commands.SITE_ADD} --alias team1 --title Team 1
 
@@ -342,7 +342,7 @@ class SpoSiteAddCommand extends SpoCommand {
       ${commands.SITE_ADD} --alias team1 --title Team 1 --lcid 1043
 
     Create modern team site with the specified users as owners
-      ${commands.SITE_ADD} --alias team1 --title Team 1 --owners 'steve@contoso.com, bob@contoso.com'
+      ${commands.SITE_ADD} --alias team1 --title Team 1 --owners "steve@contoso.com, bob@contoso.com"
 
     Create communication site using the Topic design
       ${commands.SITE_ADD} --type CommunicationSite --url https://contoso.sharepoint.com/sites/marketing --title Marketing
@@ -355,9 +355,9 @@ class SpoSiteAddCommand extends SpoCommand {
 
     Create communication site using the Blank design with description and classification
       ${commands.SITE_ADD} --type CommunicationSite --url https://contoso.sharepoint.com/sites/marketing --title Marketing --description Site of the marketing department --classification MBI --siteDesign Blank
-  
+
   More information
-    
+
     Creating SharePoint Communication Site using REST
       https://docs.microsoft.com/en-us/sharepoint/dev/apis/communication-site-creation-rest
 `);

--- a/src/o365/spo/commands/site/site-classic-set.ts
+++ b/src/o365/spo/commands/site/site-classic-set.ts
@@ -76,7 +76,7 @@ class SpoSiteClassicSetCommand extends SpoCommand {
         return this.ensureFormDigest(this.spoAdminUrl, cmd, this.context, this.debug);
       })
       .then((res: FormDigestInfo): Promise<string> => {
-        this.context = res; 
+        this.context = res;
         if (this.verbose) {
           cmd.log(`Setting basic properties ${args.options.url}...`);
         }
@@ -176,7 +176,7 @@ class SpoSiteClassicSetCommand extends SpoCommand {
         return this.ensureFormDigest(this.spoAdminUrl as string, cmd, this.context, this.debug);
       })
       .then((res: FormDigestInfo): Promise<void> => {
-        this.context = res; 
+        this.context = res;
         return new Promise<void>((resolve: () => void, reject: (error: any) => void): void => {
           if (!args.options.owners) {
             resolve();
@@ -256,7 +256,7 @@ class SpoSiteClassicSetCommand extends SpoCommand {
       this
         .ensureFormDigest(this.spoAdminUrl as string, cmd, this.context, this.debug)
         .then((res: FormDigestInfo): Promise<string> => {
-          this.context = res; 
+          this.context = res;
           const requestOptions: any = {
             url: `${this.spoAdminUrl}/_vti_bin/client.svc/ProcessQuery`,
             headers: {
@@ -415,7 +415,7 @@ class SpoSiteClassicSetCommand extends SpoCommand {
     log(
       `  ${chalk.yellow('Important:')} to use this command you have to have permissions to access
     the tenant admin site.
-   
+
   Remarks:
 
     The value of the ${chalk.blue('--resourceQuota')} option must not exceed
@@ -452,7 +452,7 @@ class SpoSiteClassicSetCommand extends SpoCommand {
     the ${chalk.blue(this.getCommandName())} command will keep running until
     it received confirmation from Office 365 that the site has been fully
     configured.
-  
+
   Examples:
 
     Change the title of the site collection. Don't wait for the configuration
@@ -460,7 +460,7 @@ class SpoSiteClassicSetCommand extends SpoCommand {
       ${this.getCommandName()} --url https://contoso.sharepoint.com/sites/team --title Team
 
     Add the specified user accounts as site collection administrators
-      ${this.getCommandName()} --url https://contoso.sharepoint.com/sites/team --owners joe@contoso.com,steve@contoso.com
+      ${this.getCommandName()} --url https://contoso.sharepoint.com/sites/team --owners "joe@contoso.com,steve@contoso.com"
 
     Lock the site preventing users from accessing it. Wait for the configuration
     to complete

--- a/src/o365/spo/commands/sitedesign/sitedesign-add.ts
+++ b/src/o365/spo/commands/sitedesign/sitedesign-add.ts
@@ -180,12 +180,12 @@ class SpoSiteDesignAddCommand extends SpoCommand {
     the design will lead to unexpected results.
 
   Examples:
-  
+
     Create new site design for provisioning modern team sites
       ${this.name} --title "Contoso team site" --webTemplate TeamSite --siteScripts "19b0e1b2-e3d1-473f-9394-f08c198ef43e,b2307a39-e878-458b-bc90-03bc578531d6"
 
     Create new default site design for provisioning modern communication sites
-      ${this.name} --title "Contoso communication site" --webTemplate CommunicationSite --siteScripts 19b0e1b2-e3d1-473f-9394-f08c198ef43e --isDefault
+      ${this.name} --title "Contoso communication site" --webTemplate CommunicationSite --siteScripts "19b0e1b2-e3d1-473f-9394-f08c198ef43e" --isDefault
 
   More information:
 

--- a/src/o365/spo/commands/sitedesign/sitedesign-rights-grant.ts
+++ b/src/o365/spo/commands/sitedesign/sitedesign-rights-grant.ts
@@ -118,12 +118,12 @@ class SpoSiteDesignRightsGrantCommand extends SpoCommand {
     log(vorpal.find(this.name).helpInformation());
     log(
       `  Examples:
-  
+
     Grant user with alias ${chalk.grey('PattiF')} view permission to the specified site design
       ${this.name} --id 9b142c22-037f-4a7f-9017-e9d8c0e34b98 --principals PattiF --rights View
 
     Grant users with aliases ${chalk.grey('PattiF')} and ${chalk.grey('AdeleV')} view permission to the specified site design
-      ${this.name} --id 9b142c22-037f-4a7f-9017-e9d8c0e34b98 --principals PattiF,AdeleV --rights View
+      ${this.name} --id 9b142c22-037f-4a7f-9017-e9d8c0e34b98 --principals "PattiF,AdeleV" --rights View
 
     Grant user with email ${chalk.grey('PattiF@contoso.com')} view permission to the specified site design
       ${this.name} --id 9b142c22-037f-4a7f-9017-e9d8c0e34b98 --principals PattiF@contoso.com --rights View

--- a/src/o365/spo/commands/sitedesign/sitedesign-rights-revoke.ts
+++ b/src/o365/spo/commands/sitedesign/sitedesign-rights-revoke.ts
@@ -146,7 +146,7 @@ class SpoSiteDesignRightsRevokeCommand extends SpoCommand {
     ${chalk.grey('The specified user or domain group was not found')} error.
 
   Examples:
-  
+
     Revoke access to the site design with ID
     ${chalk.grey('2c1ba4c4-cd9b-4417-832f-92a34bc34b2a')} from user with alias ${chalk.grey('PattiF')}.
     Will prompt for confirmation before revoking the access
@@ -155,7 +155,7 @@ class SpoSiteDesignRightsRevokeCommand extends SpoCommand {
     Revoke access to the site design with ID
     ${chalk.grey('2c1ba4c4-cd9b-4417-832f-92a34bc34b2a')} from users with aliases ${chalk.grey('PattiF')} and
     ${chalk.grey('AdeleV')} without prompting for confirmation
-      ${this.name} --id 2c1ba4c4-cd9b-4417-832f-92a34bc34b2a --principals PattiF,AdeleV --confirm
+      ${this.name} --id 2c1ba4c4-cd9b-4417-832f-92a34bc34b2a --principals "PattiF,AdeleV" --confirm
 
   More information:
 

--- a/src/o365/spo/commands/sitedesign/sitedesign-set.ts
+++ b/src/o365/spo/commands/sitedesign/sitedesign-set.ts
@@ -205,12 +205,15 @@ class SpoSiteDesignSetCommand extends SpoCommand {
     the design will lead to unexpected results.
 
   Examples:
-  
+
     Update the site design title and version
       ${this.name} --id 9b142c22-037f-4a7f-9017-e9d8c0e34b98 --title "Contoso site design" --version 2
 
     Update the site design to be the default design for provisioning modern communication sites
       ${this.name} --id 9b142c22-037f-4a7f-9017-e9d8c0e34b98 --webTemplate CommunicationSite  --isDefault true
+
+    Update the site design to be the default design for provisioning modern communication sites, with specific scripts
+      ${this.name} --id 9b142c22-037f-4a7f-9017-e9d8c0e34b98 --webTemplate CommunicationSite  --isDefault true --siteScripts "19b0e1b2-e3d1-473f-9394-f08c198ef43e,b2307a39-e878-458b-bc90-03bc578531d6"
 
   More information:
 

--- a/src/o365/spo/commands/spo-search.ts
+++ b/src/o365/spo/commands/spo-search.ts
@@ -409,21 +409,21 @@ class SpoSearchCommand extends SpoCommand {
     log(vorpal.find(this.name).helpInformation());
     log(
       `  Examples:
-  
+
     Execute search query to retrieve all Document Sets
     (ContentTypeId = '${chalk.grey('0x0120D520')}') for the English locale
-      ${commands.SEARCH} --query 'ContentTypeId:0x0120D520' --culture 1033
+      ${commands.SEARCH} --query "ContentTypeId:0x0120D520" --culture 1033
 
     Retrieve all documents. For each document, retrieve the Path, Author
     and FileType.
-      ${commands.SEARCH} --query 'IsDocument:1' --selectProperties 'Path,Author,FileType' --allResults
-    
+      ${commands.SEARCH} --query "IsDocument:1" --selectProperties "Path,Author,FileType" --allResults
+
     Return the top 50 items of which the title starts with 'Marketing' while
     trimming duplicates.
-      ${commands.SEARCH} --query 'Title:Marketing*' --rowLimit=50 --trimDuplicates
+      ${commands.SEARCH} --query "Title:Marketing*" --rowLimit=50 --trimDuplicates
 
     Return only items from a specific result source (using the source id).
-      ${commands.SEARCH} --query '*' --sourceId 6e71030e-5e16-4406-9bff-9c1829843083
+      ${commands.SEARCH} --query "*" --sourceId "6e71030e-5e16-4406-9bff-9c1829843083"
       `);
   }
 }


### PR DESCRIPTION
Updated docs with comma seperated values and double quotes, solving #1347 

Changed following files: 
- [x] aad/o365group/o365group-add
- [x] aad/o365group/o365group-set
- [ ] aad/siteclassification/siteclassification-enable: had already double quotes
- [ ] aad/siteclassification/siteclassification-set: had already double quotes
- [x] aad/user/user-get
- [x] aad/user/user-list
- [ ] graph/schemaextension/schemaextension-add: had already double quotes
- [x] outlook/mail/mail-send
- [x] spo/hubsite/hubsite-rights-grant
- [x] spo/hubsite/hubsite-rights-revoke
- [x] spo/listitem/listitem-get
- [ ] spo/listitem/listitem-list: had already double quotes
- [x] spo/mail/mail-send
- [x] spo/page/page-header-set
- [x] spo/search/search
- [x] spo/site/site-add
- [x] spo/site/site-classic-set
- [x] spo/sitedesign/sitedesign-add
- [ ] spo/sitedesign/sitedesign-rights-grant: had already double quotes
- [ ] spo/sitedesign/sitedesign-rights-revoke: had already double quotes
- [x] spo/sitedesign/sitedesign-set
- [ ] teams/team/team-clone: had already double quotes