### PR TITLE
Fixes #1401

### DIFF
--- a/src/Utils.spec.ts
+++ b/src/Utils.spec.ts
@@ -106,6 +106,11 @@ describe('Utils', () => {
     assert.strictEqual(result, true);
   });
 
+  it('isValidTeamsChannelId returns true if valid channelId with new tacv2 format', () => {
+    const result = Utils.isValidTeamsChannelId('19:ABZTZ000000000000000000000rstfv@thread.tacv2');
+    assert.strictEqual(result, true);
+  });
+
   it('isValidTeamsChannelId returns false if invalid channelId (missing colon)', () => {
     const result = Utils.isValidTeamsChannelId('190000000000000000000000000000000@thread.skype');
     assert.strictEqual(result, false);

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -56,7 +56,7 @@ export default class Utils {
   }
 
   public static isValidTeamsChannelId(guid: string): boolean {
-    const guidRegEx: RegExp = new RegExp(/^19:[0-9a-zA-Z]+@thread\.skype$/i);
+    const guidRegEx: RegExp = new RegExp(/^19:[0-9a-zA-Z]+@thread\.(skype|tacv2)$/i);
 
     return guidRegEx.test(guid);
   }


### PR DESCRIPTION
Fixes #1401 
isValidTeamsChannelId - Fixing regex to allow 'tacv2' channel id format.