### PR TITLE
Moves the 'consent' command to the 'cli' namespace. Closes #1336

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -38,6 +38,7 @@ describe('Lazy loading commands', () => {
       yammerCommands.default
     ];
     const aliases: string[] = [
+      'consent',
       'accesstoken get',
       'flow connector export',
       'flow connector list',

--- a/src/o365/cli/commands.ts
+++ b/src/o365/cli/commands.ts
@@ -5,5 +5,6 @@ export default {
   COMPLETION_PWSH_SETUP: `${prefix} completion pwsh setup`,
   COMPLETION_PWSH_UPDATE: `${prefix} completion pwsh update`,
   COMPLETION_SH_SETUP: `${prefix} completion sh setup`,
-  COMPLETION_SH_UPDATE: `${prefix} completion sh update`
+  COMPLETION_SH_UPDATE: `${prefix} completion sh update`,
+  CONSENT: `${prefix} consent`
 };

--- a/src/o365/cli/commands/cli-consent.spec.ts
+++ b/src/o365/cli/commands/cli-consent.spec.ts
@@ -1,11 +1,12 @@
-import commands from './commands';
-import Command, { CommandOption, CommandValidate } from '../../Command';
+import commands from '../commands';
+import globalCommands from '../../commands/commands';
+import Command, { CommandOption, CommandValidate } from '../../../Command';
 import * as sinon from 'sinon';
-import appInsights from '../../appInsights';
-const command: Command = require('./consent');
+import appInsights from '../../../appInsights';
+const command: Command = require('./cli-consent');
 import * as assert from 'assert';
-import Utils from '../../Utils';
-import config from '../../config';
+import Utils from '../../../Utils';
+import config from '../../../config';
 
 describe(commands.CONSENT, () => {
   let vorpal: Vorpal;
@@ -22,7 +23,7 @@ describe(commands.CONSENT, () => {
   });
 
   beforeEach(() => {
-    vorpal = require('../../vorpal-init');
+    vorpal = require('../../../vorpal-init');
     log = [];
     cmdInstance = {
       commandWrapper: {
@@ -54,6 +55,16 @@ describe(commands.CONSENT, () => {
 
   it('has a description', () => {
     assert.notEqual(command.description, null);
+  });
+
+  it('defines alias', () => {
+    const alias = command.alias();
+    assert.notEqual(typeof alias, 'undefined');
+  });
+
+  it('defines correct alias', () => {
+    const alias = command.alias();
+    assert.equal((alias && alias.indexOf(globalCommands.CONSENT) > -1), true);
   });
 
   it('shows consent URL for yammer permissions for the default multi-tenant app', (done) => {

--- a/src/o365/cli/commands/cli-consent.ts
+++ b/src/o365/cli/commands/cli-consent.ts
@@ -1,13 +1,14 @@
-import commands from './commands';
-import GlobalOptions from '../../GlobalOptions';
+import commands from '../commands';
+import globalCommands from '../../commands/commands';
+import GlobalOptions from '../../../GlobalOptions';
 import Command, {
   CommandOption,
   CommandValidate,
   CommandAction
-} from '../../Command';
-import config from '../../config';
+} from '../../../Command';
+import config from '../../../config';
 
-const vorpal: Vorpal = require('../../vorpal-init');
+const vorpal: Vorpal = require('../../../vorpal-init');
 
 interface CommandArgs {
   options: Options;
@@ -17,13 +18,17 @@ interface Options extends GlobalOptions {
   service: string;
 }
 
-class ConsentCommand extends Command {
+class CliConsentCommand extends Command {
   public get name(): string {
     return `${commands.CONSENT}`;
   }
 
   public get description(): string {
     return 'Consent additional permissions for the Azure AD application used by the Office 365 CLI';
+  }
+
+  public alias(): string[] | undefined {
+    return [globalCommands.CONSENT];
   }
 
   public getTelemetryProperties(args: CommandArgs): any {
@@ -33,6 +38,8 @@ class ConsentCommand extends Command {
   }
 
   public commandAction(cmd: CommandInstance, args: CommandArgs, cb: (err?: any) => void): void {
+    this.showDeprecationWarning(cmd, globalCommands.CONSENT, commands.CONSENT);
+
     let scope = '';
     switch (args.options.service) {
       case 'yammer':
@@ -109,4 +116,4 @@ class ConsentCommand extends Command {
   }
 }
 
-module.exports = new ConsentCommand();
+module.exports = new CliConsentCommand();


### PR DESCRIPTION
Moves the 'consent' command to the 'cli' namespace. Closes #1336