### PR TITLE
new-command: yammer report groupsactivitygroupcounts

### DIFF
--- a/docs/manual/docs/cmd/yammer/report/report-groupsactivitygroupcounts.md
+++ b/docs/manual/docs/cmd/yammer/report/report-groupsactivitygroupcounts.md
@@ -1,0 +1,42 @@
+# yammer report groupsactivitygroupcounts
+
+Gets the total number of groups that existed and how many included group conversation activity
+
+## Usage
+
+```sh
+yammer report groupsactivitygroupcounts [options]
+```
+
+## Options
+
+Option|Description
+------|-----------
+`--help`|output usage information
+`-p, --period <period>`|The length of time over which the report is aggregated. Supported values `D7,D30,D90,D180`
+`-f, --outputFile [outputFile]`|Path to the file where the report should be stored in
+`--query [query]`|JMESPath query string. See [http://jmespath.org/](http://jmespath.org/) for more information and examples
+`-o, --output [output]`|Output type. `text,json`. Default `text`
+`--pretty`|Prettifies `json` output
+`--verbose`|Runs command with verbose logging
+`--debug`|Runs command with debug logging
+
+## Examples
+
+Gets the total number of groups that existed and how many included group conversation activity for the last week
+
+```sh
+yammer report groupsactivitygroupcounts --period D7
+```
+
+Gets the total number of groups that existed and how many included group conversation activity for the last week and exports the report data in the specified path in text format
+
+```sh
+yammer report groupsactivitygroupcounts --period D7 --output text --outputFile "groupsactivitygroupcounts.txt"
+```
+
+Gets the total number of groups that existed and how many included group conversation activity for the last week and exports the report data in the specified path in json format
+
+```sh
+yammer report groupsactivitygroupcounts --period D7 --output json --outputFile "groupsactivitygroupcounts.json"
+```

--- a/docs/manual/mkdocs.yml
+++ b/docs/manual/mkdocs.yml
@@ -445,6 +445,7 @@ nav:
         - network list: 'cmd/yammer/network/network-list.md'
       - report:
         - report groupsactivitycounts: 'cmd/yammer/report/report-groupsactivitycounts.md'
+        - report groupsactivitygroupcounts: 'cmd/yammer/report/report-groupsactivitygroupcounts.md'
       - user:
         - user get: 'cmd/yammer/user/user-get.md'
         - user list: 'cmd/yammer/user/user-list.md'

--- a/src/o365/yammer/commands.ts
+++ b/src/o365/yammer/commands.ts
@@ -8,6 +8,7 @@ export default {
   YAMMER_MESSAGE_REMOVE: `${prefix} message remove`,
   YAMMER_NETWORK_LIST: `${prefix} network list`,
   YAMMER_REPORT_GROUPSACTIVITYCOUNTS: `${prefix} report groupsactivitycounts`,
+  YAMMER_REPORT_GROUPSACTIVITYGROUPCOUNTS: `${prefix} report groupsactivitygroupcounts`,
   YAMMER_USER_GET: `${prefix} user get`,
   YAMMER_USER_LIST: `${prefix} user list`
 };

--- a/src/o365/yammer/commands/report/report-groupsactivitygroupcounts.spec.ts
+++ b/src/o365/yammer/commands/report/report-groupsactivitygroupcounts.spec.ts
@@ -1,0 +1,95 @@
+import commands from '../../commands';
+import Command from '../../../../Command';
+import * as sinon from 'sinon';
+import appInsights from '../../../../appInsights';
+import auth from '../../../../Auth';
+const command: Command = require('./report-groupsactivitygroupcounts');
+import * as assert from 'assert';
+import Utils from '../../../../Utils';
+import request from '../../../../request';
+
+describe(commands.YAMMER_REPORT_GROUPSACTIVITYGROUPCOUNTS, () => {
+  let vorpal: Vorpal;
+  let log: string[];
+  let cmdInstance: any;
+
+  before(() => {
+    sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
+    sinon.stub(appInsights, 'trackEvent').callsFake(() => { });
+    auth.service.connected = true;
+  });
+
+  beforeEach(() => {
+    vorpal = require('../../../../vorpal-init');
+    log = [];
+    cmdInstance = {
+      commandWrapper: {
+        command: command.name
+      },
+      action: command.action(),
+      log: (msg: string) => {
+        log.push(msg);
+      }
+    };
+    (command as any).items = [];
+  });
+
+  afterEach(() => {
+    Utils.restore([
+      vorpal.find,
+      request.get
+    ]);
+  });
+
+  after(() => {
+    Utils.restore([
+      appInsights.trackEvent,
+      auth.restoreAuth
+    ]);
+    auth.service.connected = false;
+  });
+
+  it('has correct name', () => {
+    assert.equal(command.name.startsWith(commands.YAMMER_REPORT_GROUPSACTIVITYGROUPCOUNTS), true);
+  });
+
+  it('has a description', () => {
+    assert.notEqual(command.description, null);
+  });
+
+  it('gets the report for the last week', (done) => {
+    const requestStub: sinon.SinonStub = sinon.stub(request, 'get').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/v1.0/reports/getYammerGroupsActivityGroupCounts(period='D7')`) {
+        return Promise.resolve(`
+        Report Refresh Date,Total,Active,Report Date,Report Period`
+        );
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    cmdInstance.action({ options: { debug: false, period: 'D7' } }, () => {
+      try {
+        assert.equal(requestStub.lastCall.args[0].url, "https://graph.microsoft.com/v1.0/reports/getYammerGroupsActivityGroupCounts(period='D7')");
+        assert.equal(requestStub.lastCall.args[0].headers["accept"], 'application/json;odata.metadata=none');
+        assert.equal(requestStub.lastCall.args[0].json, true);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('has help referring to the right command', () => {
+    const cmd: any = {
+      log: (msg: string) => { },
+      prompt: () => { },
+      helpInformation: () => { }
+    };
+    const find = sinon.stub(vorpal, 'find').callsFake(() => cmd);
+    cmd.help = command.help();
+    cmd.help({}, () => { });
+    assert(find.calledWith(commands.YAMMER_REPORT_GROUPSACTIVITYGROUPCOUNTS));
+  });
+});

--- a/src/o365/yammer/commands/report/report-groupsactivitygroupcounts.ts
+++ b/src/o365/yammer/commands/report/report-groupsactivitygroupcounts.ts
@@ -1,0 +1,41 @@
+import commands from '../../commands';
+import PeriodBasedReport from '../../../base/PeriodBasedReport';
+
+const vorpal: Vorpal = require('../../../../vorpal-init');
+
+class YammerReportGroupsActivityGroupCountsCommand extends PeriodBasedReport {
+  public get name(): string {
+    return commands.YAMMER_REPORT_GROUPSACTIVITYGROUPCOUNTS;
+  }
+
+  public get usageEndpoint(): string {
+    return 'getYammerGroupsActivityGroupCounts';
+  }
+
+  public get description(): string {
+    return 'Gets the total number of groups that existed and how many included group conversation activity';
+  }
+
+  public commandHelp(args: {}, log: (help: string) => void): void {
+    log(vorpal.find(this.name).helpInformation());
+    log(
+      `  Examples:
+      
+    Gets the total number of groups that existed and how many included group conversation activity for
+    the last week
+      ${commands.YAMMER_REPORT_GROUPSACTIVITYGROUPCOUNTS} --period D7
+
+    Gets the total number of groups that existed and how many included group conversation activity for
+    the last week and exports the report data in the specified path in text
+    format
+      ${commands.YAMMER_REPORT_GROUPSACTIVITYGROUPCOUNTS} --period D7 --output text --outputFile "groupsactivitygroupcounts.txt"
+
+    Gets the total number of groups that existed and how many included group conversation activity for
+    the last week and exports the report data in the specified path in json
+    format
+      ${commands.YAMMER_REPORT_GROUPSACTIVITYGROUPCOUNTS} --period D7 --output json --outputFile "groupsactivitygroupcounts.json"
+`);
+  }
+}
+
+module.exports = new YammerReportGroupsActivityGroupCountsCommand();


### PR DESCRIPTION
implements #1389

Hi @waldekmastykarz , @VelinGeorgiev,
I finally made it. All reporting commands under https://docs.microsoft.com/en-us/graph/api/resources/report?view=graph-rest-1.0 are implemented.

This is the last one.

br,
Patrick