### PR TITLE
New Sample: Ensure the Site Assets library is created

### DIFF
--- a/docs/manual/docs/examples/spo/ensure-siteassets-library.md
+++ b/docs/manual/docs/examples/spo/ensure-siteassets-library.md
@@ -1,0 +1,61 @@
+# Ensure the Site Assets Library is created
+
+Author: [Phillip Allan-Harding](https://github.com/phillipharding/)
+
+There are occasions when creating a new modern SharePoint site using the CLI/REST API that the Site Assets library isn't created, use this script to ensure that the Site Assets library is created.
+
+Reference: ['ensure' commands #1427](https://github.com/pnp/office365-cli/discussions/1427)
+
+- gets the collection of lists at the site url supplied
+- if a list with the title "Site Assets" isn't found
+  - gets an access token for the tenant's SharePoint resource
+  - calls the _api/web/Lists/EnsureSiteAssetsLibrary REST endpoint to create the Site Assets library
+- returns the existing or created SPList as a JSON object
+
+```powershell tab="PowerShell Core"
+function EnsureSiteAssetsLibrary {
+	param (
+		[Parameter(Mandatory)][string]$siteUrl
+	)
+
+	<#
+		send a HTTP POST request to:
+		https://<tenant>.sharepoint.com/sites/<sitename>/_api/web/Lists/EnsureSiteAssetsLibrary/
+		which returns an SPList
+	#>
+	$list = $null
+
+	Write-Host "-> Ensure Site Assets library: $siteUrl"
+	$lists = o365 spo list list --webUrl "$siteUrl" -o json | ConvertFrom-Json
+	if (($null -ne $lists) -and ($null -ne $lists.value)) {
+		$list = $lists.value | Where-Object { $_.Title -eq "Site Assets" }
+	}
+
+	if ($null -eq $list) {
+		Write-Host "...Creating Site Assets library"
+
+		try {
+			$resource = ($siteUrl -split "/")[2]
+			$accessToken = o365 util accesstoken get --new --resource "https://$resource/"
+		}
+		catch {
+			throw "!! Unable to get AccessToken for EnsureSiteAssetsLibrary at '$siteUrl'`nERROR: $_"
+		}
+		try {
+			$headers = @{ "Authorization" = "Bearer $accessToken"; "Accept" = "application/json;odata=nometadata" }
+			$endpoint = "$siteUrl/_api/web/Lists/EnsureSiteAssetsLibrary/"
+			$response = (Invoke-RestMethod -Uri $endpoint -Headers $headers -Method POST)
+			$list = $response
+
+			Write-Host "...Created: $($list.Id)"
+		}
+		catch {
+			throw "!! Unable to EnsureSiteAssetsLibrary at '$siteUrl'`nERROR: $_"
+		}
+	} else {
+		Write-Host "...Already exists: $($list.Id)"
+	}
+
+	$list
+}
+```

--- a/docs/manual/mkdocs.yml
+++ b/docs/manual/mkdocs.yml
@@ -471,6 +471,7 @@ nav:
       - 'Delete custom SharePoint site scripts': 'examples/spo/remove-site-scripts.md'
       - 'Hide SharePoint list from Site Contents': 'examples/spo/hide-list-from-site-contents.md'
       - 'Lists active SharePoint site collection application catalogs': 'examples/spo/list-site-app-catalogs.md'
+      - 'Ensure the Site Assets Library is created': 'examples/spo/ensure-siteassets-library.md'
     - Microsoft Teams:
       - 'Deploy Microsoft Teams app from Azure DevOps': 'examples/teams/deploy-teams-app.md'
       - 'Govern orphaned Microsoft Teams': 'examples/teams/govern-orphan-teams.md'


### PR DESCRIPTION
# Ensure the Site Assets library is created

There are occasions when creating a new modern SharePoint site using the CLI/REST API that the Site Assets library isn't created, use this script to ensure that the Site Assets library is created.

Reference: ['ensure' commands #1427](https://github.com/pnp/office365-cli/discussions/1427)
