### PR TITLE
New command: Install Microsoft Teams app for user

### DIFF
--- a/docs/manual/docs/cmd/teams/user/user-app-add.md
+++ b/docs/manual/docs/cmd/teams/user/user-app-add.md
@@ -1,0 +1,37 @@
+# teams user app add
+
+Install an app in the personal scope of the specified user
+
+## Usage
+
+```sh
+teams user app add [options]
+```
+
+## Options
+
+Option|Description
+------|-----------
+`--help`|output usage information
+`--appId <appId>`|The ID of the app to install
+`--userId <userId>`|The ID of the user to install the app for
+`--query [query]`|JMESPath query string. See [http://jmespath.org/](http://jmespath.org/) for more information and examples
+`-o, --output [output]`|Output type. `json,text`. Default `text`
+`--pretty`|Prettifies `json` output
+`--verbose`|Runs command with verbose logging
+`--debug`|Runs command with debug logging
+
+## Remarks
+
+!!! attention
+    This command is based on an API that is currently in preview and is subject to change once the API reached general availability.
+
+The `appId` has to be the ID of the app from the Microsoft Teams App Catalog. Do not use the ID from the manifest of the zip app package. Use the [teams app list](./app-list.md) command to get this ID.
+
+## Examples
+
+Install an app from the catalog for the specified user
+
+```sh
+teams user app add --appId 4440558e-8c73-4597-abc7-3644a64c4bce --userId 2609af39-7775-4f94-a3dc-0dd67657e900
+```

--- a/docs/manual/mkdocs.yml
+++ b/docs/manual/mkdocs.yml
@@ -430,6 +430,7 @@ nav:
         - user list: 'cmd/aad/o365group/o365group-user-list.md'
         - user remove: 'cmd/aad/o365group/o365group-user-remove.md'
         - user set: 'cmd/aad/o365group/o365group-user-set.md'
+        - user app add: 'cmd/teams/user/user-app-add.md'
     - Office 365 (tenant):
       - id:
         - id get: 'cmd/tenant/id/id-get.md'

--- a/src/o365/teams/commands.ts
+++ b/src/o365/teams/commands.ts
@@ -42,5 +42,6 @@ export default {
   TEAMS_USER_ADD: `${prefix} user add`,
   TEAMS_USER_LIST: `${prefix} user list`,
   TEAMS_USER_REMOVE: `${prefix} user remove`,
-  TEAMS_USER_SET: `${prefix} user set`
+  TEAMS_USER_SET: `${prefix} user set`,
+  TEAMS_USER_APP_ADD: `${prefix} user app add`
 };

--- a/src/o365/teams/commands/user/user-app-add.spec.ts
+++ b/src/o365/teams/commands/user/user-app-add.spec.ts
@@ -1,0 +1,231 @@
+import commands from '../../commands';
+import Command, { CommandOption, CommandError, CommandValidate } from '../../../../Command';
+import * as sinon from 'sinon';
+import appInsights from '../../../../appInsights';
+import auth from '../../../../Auth';
+const command: Command = require('./user-app-add');
+import * as assert from 'assert';
+import request from '../../../../request';
+import Utils from '../../../../Utils';
+
+describe(commands.TEAMS_USER_APP_ADD, () => {
+  let vorpal: Vorpal;
+  let log: string[];
+  let cmdInstance: any;
+  let cmdInstanceLogSpy: sinon.SinonSpy;
+
+  before(() => {
+    sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
+    sinon.stub(appInsights, 'trackEvent').callsFake(() => {});
+    auth.service.connected = true;
+  });
+
+  beforeEach(() => {
+    vorpal = require('../../../../vorpal-init');
+    log = [];
+    cmdInstance = {
+      commandWrapper: {
+        command: command.name
+      },
+      action: command.action(),
+      log: (msg: string) => {
+        log.push(msg);
+      }
+    };
+    cmdInstanceLogSpy = sinon.spy(cmdInstance, 'log');
+    (command as any).items = [];
+  });
+
+  afterEach(() => {
+    Utils.restore([
+      vorpal.find,
+      request.post
+    ]);
+  });
+
+  after(() => {
+    Utils.restore([
+      auth.restoreAuth,
+      appInsights.trackEvent
+    ]);
+    auth.service.connected = false;
+  });
+
+  it('has correct name', () => {
+    assert.equal(command.name.startsWith(commands.TEAMS_USER_APP_ADD), true);
+  });
+
+  it('has a description', () => {
+    assert.notEqual(command.description, null);
+  });
+
+  it('fails validation if the userId is not a valid guid.', () => {
+    const actual = (command.validate() as CommandValidate)({
+      options: {
+        userId: 'invalid',
+        appId: '15d7a78e-fd77-4599-97a5-dbb6372846c5'
+      }
+    });
+    assert.notEqual(actual, true);
+  });
+
+  it('fails validation if the userId is not provided.', () => {
+    const actual = (command.validate() as CommandValidate)({
+      options: {
+        appId: '61703ac8-c49b-4fd4-8223-28f0ac3a6402'
+      }
+    });
+    assert.notEqual(actual, true);
+  });
+
+  it('fails validation if the appId is not a valid guid.', () => {
+    const actual = (command.validate() as CommandValidate)({
+      options: {
+        appId: 'not-c49b-4fd4-8223-28f0ac3a6402',
+        userId: '15d7a78e-fd77-4599-97a5-dbb6372846c5'
+      }
+    });
+    assert.notEqual(actual, true);
+  });
+
+  it('fails validation if the appId is not provided.', () => {
+    const actual = (command.validate() as CommandValidate)({
+      options: {
+        userId: '61703ac8a-c49b-4fd4-8223-28f0ac3a6402'
+      }
+    });
+    assert.notEqual(actual, true);
+  });
+
+  it('passes validation when the input is correct', () => {
+    const actual = (command.validate() as CommandValidate)({
+      options: {
+        appId: '15d7a78e-fd77-4599-97a5-dbb6372846c6',
+        userId: '15d7a78e-fd77-4599-97a5-dbb6372846c5'
+      }
+    });
+    assert.equal(actual, true);
+  });
+
+  it('adds app from the catalog for the specified user', (done) => {
+    sinon.stub(request, 'post').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/beta/users/c527a470-a882-481c-981c-ee6efaba85c7/teamwork/installedApps` &&
+        JSON.stringify(opts.body) === `{"teamsApp@odata.bind":"https://graph.microsoft.com/beta/appCatalogs/teamsApps/4440558e-8c73-4597-abc7-3644a64c4bce"}`) {
+        return Promise.resolve();
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    cmdInstance.action = command.action();
+    cmdInstance.action({
+      options: {
+        userId: 'c527a470-a882-481c-981c-ee6efaba85c7',
+        appId: '4440558e-8c73-4597-abc7-3644a64c4bce'
+      }
+    }, () => {
+      try {
+        assert(cmdInstanceLogSpy.notCalled);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('adds app from the catalog for the specified user (debug)', (done) => {
+    sinon.stub(request, 'post').callsFake((opts) => {
+      if (opts.url === `https://graph.microsoft.com/beta/users/c527a470-a882-481c-981c-ee6efaba85c7/teamwork/installedApps` &&
+        JSON.stringify(opts.body) === `{"teamsApp@odata.bind":"https://graph.microsoft.com/beta/appCatalogs/teamsApps/4440558e-8c73-4597-abc7-3644a64c4bce"}`) {
+        return Promise.resolve();
+      }
+
+      return Promise.reject('Invalid request');
+    });
+
+    cmdInstance.action = command.action();
+    cmdInstance.action({
+      options: {
+        userId: 'c527a470-a882-481c-981c-ee6efaba85c7',
+        appId: '4440558e-8c73-4597-abc7-3644a64c4bce',
+        debug: true
+      }
+    }, () => {
+      try {
+        assert(cmdInstanceLogSpy.called);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('correctly handles error while installing teams app', (done) => {
+    sinon.stub(request, 'post').callsFake((opts) => {
+      return Promise.reject('An error has occurred');
+    });
+
+    cmdInstance.action = command.action();
+    cmdInstance.action({
+      options: {
+        userId: 'c527a470-a882-481c-981c-ee6efaba85c7',
+        appId: '4440558e-8c73-4597-abc7-3644a64c4bce'
+      }
+    }, (err?: any) => {
+      try {
+        assert.equal(JSON.stringify(err), JSON.stringify(new CommandError('An error has occurred')));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('supports debug mode', () => {
+    const options = (command.options() as CommandOption[]);
+    let containsOption = false;
+    options.forEach(o => {
+      if (o.option === '--debug') {
+        containsOption = true;
+      }
+    });
+    assert(containsOption);
+  });
+
+  it('has help referring to the right command', () => {
+    const cmd: any = {
+      log: (msg: string) => { },
+      prompt: () => { },
+      helpInformation: () => { }
+    };
+    const find = sinon.stub(vorpal, 'find').callsFake(() => cmd);
+    cmd.help = command.help();
+    cmd.help({}, () => { });
+    assert(find.calledWith(commands.TEAMS_USER_APP_ADD));
+  });
+
+  it('has help with examples', () => {
+    const _log: string[] = [];
+    const cmd: any = {
+      log: (msg: string) => {
+        _log.push(msg);
+      },
+      prompt: () => { },
+      helpInformation: () => { }
+    };
+    sinon.stub(vorpal, 'find').callsFake(() => cmd);
+    cmd.help = command.help();
+    cmd.help({}, () => { });
+    let containsExamples: boolean = false;
+    _log.forEach(l => {
+      if (l && l.indexOf('Examples:') > -1) {
+        containsExamples = true;
+      }
+    });
+    Utils.restore(vorpal.find);
+    assert(containsExamples);
+  });
+});

--- a/src/o365/teams/commands/user/user-app-add.ts
+++ b/src/o365/teams/commands/user/user-app-add.ts
@@ -1,0 +1,113 @@
+import request from '../../../../request';
+import Utils from '../../../../Utils';
+import commands from '../../commands';
+import GlobalOptions from '../../../../GlobalOptions';
+import { CommandOption, CommandValidate } from '../../../../Command';
+import GraphCommand from '../../../base/GraphCommand';
+
+const vorpal: Vorpal = require('../../../../vorpal-init');
+
+interface CommandArgs {
+  options: Options;
+}
+
+interface Options extends GlobalOptions {
+  appId: string;
+  userId: string;
+}
+
+class TeamsUserAppAddCommand extends GraphCommand {
+  public get name(): string {
+    return `${commands.TEAMS_USER_APP_ADD}`;
+  }
+
+  public get description(): string {
+    return 'Install an app in the personal scope of the specified user';
+  }
+
+  public commandAction(cmd: CommandInstance, args: CommandArgs, cb: () => void): void {
+    const endpoint: string = `${this.resource}/beta`
+
+    const requestOptions: any = {
+      url: `${endpoint}/users/${args.options.userId}/teamwork/installedApps`,
+      headers: {
+        'content-type': 'application/json;odata=nometadata',
+        'accept': 'application/json;odata.metadata=none'
+      },
+      json: true,
+      body: {
+        'teamsApp@odata.bind': `${endpoint}/appCatalogs/teamsApps/${args.options.appId}`
+      }
+    };
+
+    request
+      .post(requestOptions)
+      .then((): void => {
+        if (this.verbose) {
+          cmd.log(vorpal.chalk.green('DONE'));
+        }
+
+        cb();
+      }, (res: any): void => this.handleRejectedODataJsonPromise(res, cmd, cb));
+  }
+
+  public options(): CommandOption[] {
+    const options: CommandOption[] = [
+      {
+        option: '--appId <appId>',
+        description: 'The ID of the app to install'
+      },
+      {
+        option: '--userId <userId>',
+        description: 'The ID of the user to install the app for'
+      }
+    ];
+
+    const parentOptions: CommandOption[] = super.options();
+    return options.concat(parentOptions);
+  }
+
+  public validate(): CommandValidate {
+    return (args: CommandArgs): boolean | string => {
+      if (!args.options.appId) {
+        return 'Required parameter appId missing';
+      }
+
+      if (!Utils.isValidGuid(args.options.appId)) {
+        return `${args.options.appId} is not a valid GUID`;
+      }
+
+      if (!args.options.userId) {
+        return 'Required parameter userId missing';
+      }
+
+      if (!Utils.isValidGuid(args.options.userId)) {
+        return `${args.options.userId} is not a valid GUID`;
+      }
+
+      return true;
+    };
+  }
+
+  public commandHelp(args: {}, log: (help: string) => void): void {
+    const chalk = vorpal.chalk;
+    log(vorpal.find(this.name).helpInformation());
+    log(
+      `  Remarks:
+
+    ${chalk.yellow('Attention:')} This command is based on an API that is currently in preview
+    and is subject to change once the API reached general availability.
+
+    The ${chalk.grey(`appId`)} has to be the ID of the app from the Microsoft Teams App Catalog.
+    Do not use the ID from the manifest of the zip app package.
+    Use the ${chalk.blue(`teams app list`)} command to get this ID.
+
+  Examples:
+
+    Install an app from the catalog for the specified user
+      ${this.name} --appId 4440558e-8c73-4597-abc7-3644a64c4bce --userId 2609af39-7775-4f94-a3dc-0dd67657e900
+`);
+  }
+}
+
+module.exports = new TeamsUserAppAddCommand();


### PR DESCRIPTION
New command: `teams user app add` to install an app in the personal scope for the specified user. Implements #1450 