### PR TITLE
New sample: Add remove bulk users to Microsoft Teams or Groups

### DIFF
--- a/docs/manual/docs/sample-scripts/aad/manage-group-users.md
+++ b/docs/manual/docs/sample-scripts/aad/manage-group-users.md
@@ -1,0 +1,58 @@
+# Add remove bulk users to Microsoft Teams or Groups
+
+Author: [Joseph Velliah](https://sprider.blog/add-remove-bulk-users-to-from-microsoft-teams-microsoft-365-group-office-365-cli-commands)
+
+Companies pursue to hasten profits growth or enter new marketplace through Mergers and Acquisitions(M&A). M&A typically fails during integration. This also applies to migrating users and data in Microsoft Teams and Groups. Partial acquisition can be pretty tricky. To help make the activity as charming as possible, I have created the following sample script to add/remove bulk users to/from Microsoft Teams team or Microsoft 365 group using Office 365 CLI commands.
+
+Note: Refactor the code as per your requirement.
+
+```csv tab="Input CSV File Format"
+groupMailNickname1, user1@domainname.com, owner, add
+groupMailNickname2, user2@domainname.com, member, add
+groupMailNickname3, user3@domainname.com, , remove
+```
+
+```powershell tab="PowerShell Core"
+$taskItems = import-csv "sample-input-file.csv" –header mailNickname, userEmail, role, action
+$groups = o365 aad o365group list -o json | ConvertFrom-Json
+
+ForEach ($taskItem in $taskItems) {
+
+    $mailNickname = $($taskItem.mailNickname)
+    $userEmail = $($taskItem.userEmail)
+    $role = $($taskItem.role)
+    $action = $($taskItem.action)
+
+    $group = $groups | Where-Object { $_.mailNickname -eq "$mailNickname" }
+    $user = o365 aad user get --userName $userEmail -o json | ConvertFrom-Json
+
+    Write-Host "Processing: User --> " $user.mail " Group --> " $group.mailNickname
+
+    If ($action -eq "add") {
+
+        If ($role -eq "owner") {
+            o365 aad o365group user add --groupId $group.id --userName $user.mail --role Owner; 
+            Write-Host $user.mail " added as owner in " $group.mailNickname
+        }
+        ElseIf ($role -eq "member") {
+            o365 aad o365group user add --groupId $group.id --userName $user.mail
+            Write-Host $user.mail " added as member in " $group.mailNickname
+        }
+        Else {
+            Write-Host "Invalid user role '" $role "'"
+        }
+    }
+    ElseIf ($action -eq "remove") {
+        o365 aad o365group user remove --groupId $group.id --userName $user.mail --confirm
+        Write-Host $user.mail " removed from " $group.mailNickname
+    }
+    Else {
+        Write-Host "Invalid task action '" $action "'"
+    }
+}
+```
+
+Keywords:
+
+- Office 365 Group
+- Governance

--- a/docs/manual/mkdocs.yml
+++ b/docs/manual/mkdocs.yml
@@ -477,6 +477,7 @@ nav:
     - 'Introduction': 'sample-scripts/index.md'
     - Azure Active Directory:
       - 'Delete all Office 365 groups' : 'sample-scripts/aad/delete-o365-groups.md'
+      - 'Add remove bulk users to Microsoft Teams or Groups' : 'sample-scripts/aad/manage-group-users.md'
       - 'Scan for Office 365 Groups created with user''s first or last name' : 'sample-scripts/aad/flag-groups-with-user-names.md'
     - Microsoft Graph:
       - 'Authenticate with and call the Microsoft Graph' : 'sample-scripts/graph/call-graph.md'


### PR DESCRIPTION
Closes #1540

Docs |  
-- | --
Author |Joseph Velliah
Original Post |https://sprider.blog/add-remove-bulk-users-to-from-microsoft-teams-microsoft-365-group-office-365-cli-commands
Description |Companies pursue to hasten profits growth or enter new marketplace through Mergers and Acquisitions(M&A). M&A typically fails during integration. This also applies to migrating users and data in Microsoft Teams and Groups. Partial acquisition can be pretty tricky. To help make the activity as charming as possible, I have created the following sample script to add/remove bulk users to/from Microsoft Teams team or Microsoft 365 group using Office 365 CLI commands.
Keywords |Microsoft 365 Groups

