### PR TITLE
Fix a command to get a token

### DIFF
--- a/docs/manual/docs/examples/graph/call-graph.md
+++ b/docs/manual/docs/examples/graph/call-graph.md
@@ -5,7 +5,7 @@ Author: [Garry Trinder](https://github.com/garrytrinder)
 Obtain a new access token for the Microsoft Graph and use it an HTTP request.
 
 ```powershell tab="PowerShell Core"
-$token = o365 accesstoken get --resource https://graph.microsoft.com --new
+$token = o365 util accesstoken get --resource https://graph.microsoft.com --new
 $me = Invoke-RestMethod -Uri https://graph.microsoft.com/v1.0/me -Headers @{"Authorization"="Bearer $token"}
 $me
 ```
@@ -15,7 +15,7 @@ $me
 
 # requires jq: https://stedolan.github.io/jq/
 
-token=`o365 accesstoken get --resource https://graph.microsoft.com --new`
+token=`o365 util accesstoken get --resource https://graph.microsoft.com --new`
 me=`curl https://graph.microsoft.com/v1.0/me -H "Authorization: Bearer $token"`
 echo $me | jq
 ```


### PR DESCRIPTION
A message `"Command 'accesstoken get' is deprecated. Please use 'util accesstoken get' instead"` gets output into the standard output and messes up the token string.

`util accesstoken get` command is used instead.