### PR TITLE
Extends the 'aad approleassignment list' with --objectId option. Closes #1579

### DIFF
--- a/docs/manual/docs/cmd/aad/approleassignment/approleassignment-list.md
+++ b/docs/manual/docs/cmd/aad/approleassignment/approleassignment-list.md
@@ -15,6 +15,7 @@ Option|Description
 `--help`|output usage information
 `-i, --appId [appId]`|Application (client) Id of the App Registration for which the configured app roles should be retrieved
 `-n, --displayName [displayName]`|Display name of the application for which the configured app roles should be retrieved
+`-o, --objectId [objectId]`|ObjectId of the application for which the configured app roles should be retrieved
 `--query [query]`|JMESPath query string. See [http://jmespath.org/](http://jmespath.org/) for more information and examples
 `-o, --output [output]`|Output type. `json,text`. Default `text`
 `--pretty`|Prettifies `json` output
@@ -23,7 +24,7 @@ Option|Description
 
 ## Remarks
 
-Specify either the `appId` or `displayName` but not both. If you specify both values, the command will fail with an error.
+Specify either the `appId`, `objectId` or `displayName`. If you specify more than one option value, the command will fail with an error.
 
 ## Examples
 
@@ -37,6 +38,12 @@ List app roles assigned to service principal with Application display name _MyAp
 
 ```sh
 aad approleassignment list --displayName 'MyAppName'
+```
+
+List app roles assigned to service principal with ObjectId _b2307a39-e878-458b-bc90-03bc578531dd_.
+
+```sh
+aad approleassignment list --objectId b2307a39-e878-458b-bc90-03bc578531dd
 ```
 
 ## More information

--- a/src/o365/aad/commands/approleassignment/approleassignment-list.spec.ts
+++ b/src/o365/aad/commands/approleassignment/approleassignment-list.spec.ts
@@ -353,6 +353,7 @@ class CommandActionParameters {
   static appIdWithRoleAssignments: string = "36e3a540-6f25-4483-9542-9f5fa00bb633";
   static appNameWithRoleAssignments: string = "Product Catalog daemon";
   static appIdWithNoRoleAssignments: string = "1c21749e-df7a-4fed-b3ab-921dce3bb124";
+  static objectIdWithRoleAssigments: string = "3aa76d8a-4145-40d1-89ca-b15bdb943bfd";
   static invalidAppId: string = "12345678-abcd-9876-fedc-0123456789ab";
 }
 
@@ -371,6 +372,10 @@ class RequestStub {
     if ((opts.url as string).indexOf(`/myorganization/servicePrincipals?api-version=1.6&$expand=appRoleAssignments&$filter=`) > -1) {
       // by app id
       if ((opts.url as string).indexOf(`appId eq '${CommandActionParameters.appIdWithRoleAssignments}'`) > -1) {
+        return Promise.resolve(ServicePrincipalCollections.ServicePrincipalByAppId);
+      }
+      // by object id
+      if ((opts.url as string).indexOf(`objectId eq '${CommandActionParameters.objectIdWithRoleAssigments}'`) > -1) {
         return Promise.resolve(ServicePrincipalCollections.ServicePrincipalByAppId);
       }
       // by display name
@@ -520,6 +525,20 @@ describe(commands.APPROLEASSIGNMENT_LIST, () => {
     });
   });
 
+  it('retrieves App Role assignments for the specified objectId and outputs text', (done) => {
+    sinon.stub(request, 'get').callsFake(RequestStub.retrieveAppRoles);
+
+    cmdInstance.action({ options: { output: 'text', objectId: CommandActionParameters.objectIdWithRoleAssigments } }, () => {
+      try {
+        assert(cmdInstanceLogSpy.calledWith(textOutput));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
   it('correctly handles an appId that does not exist', (done) => {
     sinon.stub(request, 'get').callsFake(RequestStub.retrieveAppRoles);
 
@@ -583,8 +602,18 @@ describe(commands.APPROLEASSIGNMENT_LIST, () => {
     assert.notEqual(actual, true);
   });
 
+  it('fails validation if the objectId is not a valid GUID', () => {
+    const actual = (command.validate() as CommandValidate)({ options: { objectId: '123' } });
+    assert.notEqual(actual, true);
+  });
+
   it('fails validation if both appId and displayName are specified', () => {
     const actual = (command.validate() as CommandValidate)({ options: { appId: CommandActionParameters.appIdWithNoRoleAssignments, displayName: CommandActionParameters.appNameWithRoleAssignments } });
+    assert.notEqual(actual, true);
+  })
+
+  it('fails validation if objectId and displayName are specified', () => {
+    const actual = (command.validate() as CommandValidate)({ options: { displayName: CommandActionParameters.appNameWithRoleAssignments, objectId: CommandActionParameters.objectIdWithRoleAssigments } });
     assert.notEqual(actual, true);
   })
 

--- a/src/o365/aad/commands/approleassignment/approleassignment-list.ts
+++ b/src/o365/aad/commands/approleassignment/approleassignment-list.ts
@@ -19,6 +19,7 @@ interface CommandArgs {
 interface Options extends GlobalOptions {
   appId?: string;
   displayName?: string;
+  objectId?: string;
 }
 
 class AadAppRoleAssignmentListCommand extends AadCommand {
@@ -34,6 +35,7 @@ class AadAppRoleAssignmentListCommand extends AadCommand {
     const telemetryProps: any = super.getTelemetryProperties(args);
     telemetryProps.appId = typeof args.options.appId !== 'undefined';
     telemetryProps.displayName = typeof args.options.displayName !== 'undefined';
+    telemetryProps.objectId = typeof args.options.objectId !== 'undefined';
     return telemetryProps;
   }
 
@@ -41,9 +43,14 @@ class AadAppRoleAssignmentListCommand extends AadCommand {
     let sp: ServicePrincipal;
 
     // get the service principal associated with the appId
-    const spMatchQuery: string = args.options.appId ?
-      `appId eq '${encodeURIComponent(args.options.appId)}'` :
-      `displayName eq '${encodeURIComponent(args.options.displayName as string)}'`;
+    let spMatchQuery: string = '';
+    if(args.options.appId) {
+      spMatchQuery = `appId eq '${encodeURIComponent(args.options.appId)}'`;
+    } else if(args.options.objectId) {
+      spMatchQuery = `objectId eq '${encodeURIComponent(args.options.objectId)}'`;
+    } else {
+      spMatchQuery = `displayName eq '${encodeURIComponent(args.options.displayName as string)}'`;
+    }
 
     this
       .getServicePrincipalForApp(spMatchQuery)
@@ -137,6 +144,10 @@ class AadAppRoleAssignmentListCommand extends AadCommand {
       {
         option: '-n, --displayName [displayName]',
         description: 'Display name of the application for which the configured app roles should be retrieved'
+      },
+      {
+        option: '-o, --objectId [objectId]',
+        description: 'ObjectId of the application for which the configured app roles should be retrieved'
       }
     ];
 
@@ -146,16 +157,24 @@ class AadAppRoleAssignmentListCommand extends AadCommand {
 
   public validate(): CommandValidate {
     return (args: CommandArgs): boolean | string => {
-      if (!args.options.appId && !args.options.displayName) {
-        return 'Specify either appId or displayName';
+      if (!args.options.appId && !args.options.displayName && !args.options.objectId) {
+        return 'Specify either appId, objectId or displayName';
       }
 
       if (args.options.appId && !Utils.isValidGuid(args.options.appId)) {
         return `${args.options.appId} is not a valid GUID`;
       }
 
-      if (args.options.appId && args.options.displayName) {
-        return 'Specify either appId or displayName but not both';
+      if (args.options.objectId && !Utils.isValidGuid(args.options.objectId)) {
+        return `${args.options.objectId} is not a valid GUID`;
+      }
+
+      let optionsSpecified: number = 0;
+      optionsSpecified += args.options.appId ? 1 : 0;
+      optionsSpecified += args.options.displayName ? 1 : 0;
+      optionsSpecified += args.options.objectId ? 1 : 0;
+      if (optionsSpecified > 1) {
+        return 'Specify either appId, objectId or displayName';
       }
 
       return true;
@@ -168,8 +187,8 @@ class AadAppRoleAssignmentListCommand extends AadCommand {
     log(
       `  Remarks:
   
-    Specify either the ${chalk.grey('appId')} or ${chalk.grey('displayName')} but not both. 
-    If you specify both values, the command will fail with an error.
+    Specify either the ${chalk.grey('appId')}, ${chalk.grey('objectId')} or ${chalk.grey('displayName')}. 
+    If you specify more than one option value, the command will fail with an error.
    
   Examples:
   
@@ -180,6 +199,10 @@ class AadAppRoleAssignmentListCommand extends AadCommand {
     List app roles assigned to service principal with Application display name
     ${chalk.grey('MyAppName')}.
       ${commands.APPROLEASSIGNMENT_LIST} --displayName 'MyAppName'
+
+    List app roles assigned to service principal with ObjectId
+    ${chalk.grey('b2307a39-e878-458b-bc90-03bc578531dd')}.
+      ${commands.APPROLEASSIGNMENT_LIST} --objectId b2307a39-e878-458b-bc90-03bc578531dd
 
   More information:
   


### PR DESCRIPTION
Extends the 'aad approleassignment list' with --objectId option. Closes #1579