### PR TITLE
SPFx project upgrade -output tour

### DIFF
--- a/docs/manual/docs/cmd/spfx/project/project-upgrade.md
+++ b/docs/manual/docs/cmd/spfx/project/project-upgrade.md
@@ -16,9 +16,9 @@ Option|Description
 `-v, --toVersion [toVersion]`|The version of SharePoint Framework to which upgrade the project
 `--packageManager [packageManager]`|The package manager you use. Supported managers `npm,pnpm,yarn`. Default `npm`
 `--shell [shell]`|The shell you use. Supported shells `bash,powershell,cmd`. Default `bash`
-`-f, --outputFile [outputFile]`|Path to the file where the upgrade report should be stored in
+`-f, --outputFile [outputFile]`|Path to the file where the upgrade report should be stored in. Ignored when `output` is `tour`
 `--query [query]`|JMESPath query string. See [http://jmespath.org/](http://jmespath.org/) for more information and examples
-`-o, --output [output]`|Output type. `json,text,md`. Default `text`
+`-o, --output [output]`|Output type. `json,text,md,tour`. Default `text`
 `--pretty`|Prettifies `json` output
 `--verbose`|Runs command with verbose logging
 `--debug`|Runs command with debug logging
@@ -64,4 +64,10 @@ Get instructions to upgrade the current SharePoint Framework project to the late
 
 ```sh
 spfx project upgrade --shell powershell
+```
+
+Get instructions to upgrade the current SharePoint Framework project to the latest version of SharePoint Framework and save the findings in a [CodeTour](https://aka.ms/codetour) file
+
+```sh
+spfx project upgrade  --output tour
 ```

--- a/src/o365/spfx/commands/project/project-upgrade.spec.ts
+++ b/src/o365/spfx/commands/project/project-upgrade.spec.ts
@@ -2389,6 +2389,20 @@ describe(commands.PROJECT_UPGRADE, () => {
     });
   });
 
+  it('writes CodeTour upgrade report to .tours folder when in tour output mode', () => {
+    sinon.stub(command as any, 'getProjectRoot').callsFake(_ => path.join(process.cwd(), 'src/o365/spfx/commands/project/test-projects/spfx-151-webpart-react-graph'));
+    let typeofReport: string = '';
+    sinon.stub(fs, 'writeFileSync').callsFake((path, contents: any) => {
+      typeofReport = typeof contents;
+    });
+
+    cmdInstance.action = command.action();
+    cmdInstance.action({ options: { output: 'tour', toVersion: '1.6.0' } }, (err?: any) => {
+      assert.equal(typeofReport, 'string');
+    });
+  });
+
+
   it('supports debug mode', () => {
     const options = (command.options() as CommandOption[]);
     let containsOption = false;

--- a/src/o365/spfx/commands/project/project-upgrade.ts
+++ b/src/o365/spfx/commands/project/project-upgrade.ts
@@ -509,7 +509,7 @@ ${f.resolution}
 
   private getTourReport(findings: FindingToReport[]): string {
     const tourFindings: FindingTour = {
-      title: "Upgrade Project to SPFx 1.10.0",
+      title: "Upgrade Project",
       steps: []
     };
 

--- a/src/o365/spfx/commands/project/project-upgrade.ts
+++ b/src/o365/spfx/commands/project/project-upgrade.ts
@@ -509,7 +509,7 @@ ${f.resolution}
 
   private getTourReport(findings: FindingToReport[], cmd: CommandInstance): string {
     const tourFindings: FindingTour = {
-      title: "Upgrade Project",
+      title: `Upgrade project ${path.posix.basename(this.projectRootPath as string)} to v${this.toVersion}`,
       steps: []
     };
 

--- a/src/o365/spfx/commands/project/project-upgrade.ts
+++ b/src/o365/spfx/commands/project/project-upgrade.ts
@@ -513,14 +513,6 @@ ${f.resolution}
       steps: []
     };
 
-    let addedBuildStep: boolean = false;
-    const buildStep: FindingTourStep = {
-      file: "./package.json",
-      title: "REQUIRED: Build project",
-      description: "### REQUIRED\r\n\r\nBuild the project\r\n>> gulp build",
-      line: 1
-    };
-
     findings.forEach(f => {
 
       const lineNumber: number = f.position && f.position.line ? f.position.line : this.getLineToModify(f);
@@ -538,14 +530,6 @@ ${f.resolution}
           break;
       }
 
-      // If there is an NPM dedupe rule, instruct user to build
-      if (f.id === 'FN017001') {
-        tourFindings.steps.push(
-          buildStep
-        );
-        addedBuildStep = true;
-      }
-
       // Make severity uppercase for the markdown
       const sev: string = f.severity.toUpperCase();
 
@@ -561,11 +545,6 @@ ${f.resolution}
         step
       );
     });
-
-    // If we didn't add a build step, add one now
-    if (!addedBuildStep) {
-      tourFindings.steps.push(buildStep);
-    }
 
     // Add the finale
     tourFindings.steps.push({
@@ -588,7 +567,7 @@ ${f.resolution}
     const fileContent: string = fs.readFileSync(finding.file, 'utf-8');
 
     // Try to find the line this relates to
-    const splits: any = fileContent.split('\n');
+    const splits: any = fileContent.split(os.EOL);
 
     // Look for a line with the content to change
     const packageIndex: number = splits.findIndex((line:string) => line.indexOf(finding.title) > -1);

--- a/src/o365/spfx/commands/project/project-upgrade.ts
+++ b/src/o365/spfx/commands/project/project-upgrade.ts
@@ -380,14 +380,14 @@ class SpfxProjectUpgradeCommand extends BaseProjectCommand {
   }
 
   private writeReportTourFolder(findingsToReport: any, cmd: CommandInstance, options: Options): void {
-    const toursFolder: string = path.resolve(`${this.projectRootPath}/.tours`);
+    const toursFolder: string = path.join(this.projectRootPath+'','.tours');
 
     if (!fs.existsSync(toursFolder)) {
       fs.mkdirSync(toursFolder, { recursive: false });
     }
 
     // Override reports folder
-    options.outputFile = `${this.projectRootPath}/.tours/upgrade.tour`;
+    options.outputFile = path.join(this.projectRootPath+'','.tours','upgrade.tour');
 
     // Write reports
     this.writeReport(findingsToReport, cmd, options);

--- a/src/o365/spfx/commands/project/project-upgrade.ts
+++ b/src/o365/spfx/commands/project/project-upgrade.ts
@@ -367,7 +367,7 @@ class SpfxProjectUpgradeCommand extends BaseProjectCommand {
         this.writeReport(findingsToReport, cmd, args.options);
         break;
       case 'tour':
-        this.writeReportTourFolder(this.getTourReport(findingsToReport, cmd), cmd, args.options);
+        this.writeReportTourFolder(this.getTourReport(findingsToReport, project), cmd, args.options);
         break;
       case 'md':
         this.writeReport(this.getMdReport(findingsToReport), cmd, args.options);
@@ -507,13 +507,12 @@ ${f.resolution}
     return s.join('').trim();
   }
 
-  private getTourReport(findings: FindingToReport[], cmd: CommandInstance): string {
+  private getTourReport(findings: FindingToReport[], project: Project): string {
     const tourFindings: FindingTour = {
       title: `Upgrade project ${path.posix.basename(this.projectRootPath as string)} to v${this.toVersion}`,
       steps: []
     };
 
-    const project: Project = this.getProject(this.projectRootPath + '');
     findings.forEach(f => {
       const lineNumber: number = f.position && f.position.line ? f.position.line : this.getLineToModify(f, project.path);
 
@@ -560,12 +559,12 @@ ${f.resolution}
 
     const filePath: string = path.resolve(path.join(rootPath, finding.file));
   
-    // // Don't cause an issue if the file isn't there
+    // Don't cause an issue if the file isn't there
     if (!fs.existsSync(filePath)) {
       return 1;
     }
 
-    // // Read the file content
+    // Read the file content
     const fileContent: string = fs.readFileSync(filePath, 'utf-8');
   
     // Try to find the line this relates to

--- a/src/o365/spfx/commands/project/project-upgrade.ts
+++ b/src/o365/spfx/commands/project/project-upgrade.ts
@@ -567,15 +567,15 @@ ${f.resolution}
     const fileContent: string = fs.readFileSync(finding.file, 'utf-8');
 
     // Try to find the line this relates to
-    const splits: any = fileContent.split(os.EOL);
+    const splits: string[] = fileContent.split(os.EOL);
 
     // Look for a line with the content to change
-    const packageIndex: number = splits.findIndex((line:string) => line.indexOf(finding.title) > -1);
-    if (packageIndex < 1) {
+    const lineIndex: number = splits.findIndex((line:string) => line.indexOf(finding.title) > -1);
+    if (lineIndex < 1) {
       return 1;
     } else {
       // Lines are 1-based in files
-      return packageIndex + 1;
+      return lineIndex + 1;
     }
   }
 

--- a/src/o365/spfx/commands/project/project-upgrade.ts
+++ b/src/o365/spfx/commands/project/project-upgrade.ts
@@ -526,7 +526,7 @@ ${f.resolution}
         case 'js':
         case 'ts':
         case 'scss':
-          resolution = `Update the code as follows:\r\n\`\`\`${f.resolutionType}\r\n${f.resolution}\r\n\`\`\``;
+          resolution = `\r\n\`\`\`${f.resolutionType}\r\n${f.resolution}\r\n\`\`\``;
           break;
       }
 

--- a/src/o365/spfx/commands/project/project-upgrade.ts
+++ b/src/o365/spfx/commands/project/project-upgrade.ts
@@ -13,6 +13,8 @@ import { FindingToReport } from './project-upgrade/FindingToReport';
 import { FN017001_MISC_npm_dedupe } from './project-upgrade/rules/FN017001_MISC_npm_dedupe';
 import { ReportData, ReportDataModification } from './ReportData';
 import { BaseProjectCommand } from './base-project-command';
+import { FindingTour } from './project-upgrade/FindingTour';
+import { FindingTourStep } from './project-upgrade/FindingTourStep';
 
 const vorpal: Vorpal = require('../../../../vorpal-init');
 
@@ -364,6 +366,9 @@ class SpfxProjectUpgradeCommand extends BaseProjectCommand {
       case 'json':
         this.writeReport(findingsToReport, cmd, args.options);
         break;
+      case 'tour':
+        this.writeReportTourFolder(this.getTourReport(findingsToReport), cmd, args.options);
+        break;
       case 'md':
         this.writeReport(this.getMdReport(findingsToReport), cmd, args.options);
         break;
@@ -372,6 +377,20 @@ class SpfxProjectUpgradeCommand extends BaseProjectCommand {
     }
 
     cb();
+  }
+
+  private writeReportTourFolder(findingsToReport: any, cmd: CommandInstance, options: Options): void {
+    const toursFolder: string = path.resolve(`${this.projectRootPath}/.tours`);
+    
+    if (!fs.existsSync(toursFolder)) {
+      fs.mkdirSync(toursFolder, { recursive: false });
+    }
+
+    // Override reports folder
+    options.outputFile = `${this.projectRootPath}/.tours/upgrade.tour`;
+    
+    // Write reports
+    this.writeReport(findingsToReport, cmd, options);
   }
 
   private writeReport(findingsToReport: any, cmd: CommandInstance, options: Options): void {
@@ -486,6 +505,99 @@ ${f.resolution}
     ];
 
     return s.join('').trim();
+  }
+
+  private getTourReport(findings: FindingToReport[]): string {
+    const tourFindings: FindingTour = {
+      title: "Upgrade Project to SPFx 1.10.0",
+      steps: []
+    };
+
+    let addedBuildStep: boolean = false;
+    const buildStep: FindingTourStep = {
+      file: "./package.json",
+      title: "REQUIRED: Build project",
+      description: "### REQUIRED\r\n\r\nBuild the project\r\n>> gulp build",
+      line: 1
+    };
+
+    findings.forEach(f => {
+
+      const lineNumber: number = f.position && f.position.line ? f.position.line : this.getLineToModify(f);
+      
+      let resolution: string = '';
+      switch (f.resolutionType) {
+        case 'cmd':
+          resolution = `Execute the following command:\r\n>> ${f.resolution}`;
+          break;
+        case 'json':
+        case 'js':
+        case 'ts':
+        case 'scss':
+          resolution = `Update the code as follows:\r\n\`\`\`${f.resolutionType}\r\n${f.resolution}\r\n\`\`\``;
+          break;
+      }
+
+      // If there is an NPM dedupe rule, instruct user to build
+      if (f.id === 'FN017001') {
+        tourFindings.steps.push(
+          buildStep
+        );
+        addedBuildStep = true;
+      }
+
+      // Make severity uppercase for the markdown
+      const sev: string = f.severity.toUpperCase();
+
+      // Create a tour step entry
+      const step: FindingTourStep = {
+        file: f.file,
+        title: `${sev}: ${f.title}`,
+        description: `### ${sev}\r\n\r\n${f.description}\r\n\r\n${resolution}`,
+        line: lineNumber
+      };
+
+      tourFindings.steps.push(
+        step
+      );
+    });
+
+    // If we didn't add a build step, add one now
+    if (!addedBuildStep) {
+      tourFindings.steps.push(buildStep);
+    }
+
+    // Add the finale
+    tourFindings.steps.push({
+      file: "./.tours/upgrade.tour",
+      title: "RECOMMENDED: Delete tour",
+      description: "### THAT'S IT!!!\r\nOnce you have tested that your upgrade is successful, you can delete the `.tour` folder and its content. Otherwise, you'll be prompted to launch this CodeTour every time you open this project."
+    });
+
+    return JSON.stringify(tourFindings, null, 2);
+  }
+
+  private getLineToModify(finding: FindingToReport): number {
+
+    // Don't cause an issue if the file isn't there
+    if (!fs.existsSync(finding.file)) {
+      return 1;
+    }
+
+    // Read the file content
+    const fileContent: string = fs.readFileSync(finding.file, 'utf-8');
+
+    // Try to find the line this relates to
+    const splits: any = fileContent.split('\n');
+
+    // Look for a line with the content to change
+    const packageIndex: number = splits.findIndex((line:string) => line.indexOf(finding.title) > -1);
+    if (packageIndex < 1) {
+      return 1;
+    } else {
+      // Lines are 1-based in files
+      return packageIndex + 1;
+    }
   }
 
   private getReportData(findings: FindingToReport[]): ReportData {
@@ -623,15 +735,15 @@ ${f.resolution}
       },
       {
         option: '-f, --outputFile [outputFile]',
-        description: 'Path to the file where the upgrade report should be stored in'
+        description: 'Path to the file where the upgrade report should be stored in. This option is ignored if output type is "tour"'
       }
     ];
 
     const parentOptions: CommandOption[] = super.options();
     parentOptions.forEach(o => {
       if (o.option.indexOf('--output') > -1) {
-        o.description = 'Output type. json|text|md. Default text';
-        o.autocomplete = ['json', 'text', 'md'];
+        o.description = 'Output type. json|text|md|tour. Default text';
+        o.autocomplete = ['json', 'text', 'md', 'tour'];
       }
     })
     return options.concat(parentOptions);
@@ -651,7 +763,7 @@ ${f.resolution}
         }
       }
 
-      if (args.options.outputFile) {
+      if (args.options.outputFile && args.options.output !== 'tour') {
         const dirPath: string = path.dirname(path.resolve(args.options.outputFile));
         if (!fs.existsSync(dirPath)) {
           return `Directory ${dirPath} doesn't exist. Please check the path and try again.`;
@@ -714,6 +826,11 @@ ${f.resolution}
     latest SharePoint Framework version supported by the Office 365 CLI using
     PowerShell
       ${this.name} --shell powershell
+
+    Get instructions to upgrade the current SharePoint Framework project to
+    the latest version of SharePoint Framework and save the findings in a 
+    CodeTour file
+        ${this.name} --output tour
 `);
   }
 }

--- a/src/o365/spfx/commands/project/project-upgrade/FindingTour.ts
+++ b/src/o365/spfx/commands/project/project-upgrade/FindingTour.ts
@@ -1,0 +1,6 @@
+import { FindingTourStep } from "./FindingTourStep";
+
+export interface FindingTour {
+  title: string;
+  steps: FindingTourStep[];
+}

--- a/src/o365/spfx/commands/project/project-upgrade/FindingTourStep.ts
+++ b/src/o365/spfx/commands/project/project-upgrade/FindingTourStep.ts
@@ -1,0 +1,6 @@
+export interface FindingTourStep {
+  description: string;
+  file: string;
+  line?: number;
+  title: string;
+}


### PR DESCRIPTION
Closes #1592, partially solves #1523 

Adds the ability to export SPFx project upgrades to CodeTour.