### PR TITLE
Fixes 'spo app get' documentation bug. Closes #1630

### DIFF
--- a/docs/manual/docs/cmd/spo/app/app-get.md
+++ b/docs/manual/docs/cmd/spo/app/app-get.md
@@ -52,7 +52,7 @@ spo app get --name solution.sppkg --appCatalogUrl https://contoso.sharepoint.com
 Return details about the app with ID _b2307a39-e878-458b-bc90-03bc578531d6_ available in the site collection app catalog of site _https://contoso.sharepoint.com/sites/site1_.
 
 ```sh
-spo app get --id b2307a39-e878-458b-bc90-03bc578531d6 --scope sitecollection --siteUrl https://contoso.sharepoint.com/sites/site1
+spo app get --id b2307a39-e878-458b-bc90-03bc578531d6 --scope sitecollection --appCatalogUrl https://contoso.sharepoint.com/sites/site1
 ```
 
 ## More information


### PR DESCRIPTION
Fixes `spo app get` documentation example's bug replacing the incorrect `siteUrl` argument with `appCatalogUrl`. Closes #1630