### PR TITLE
Removes deprecated 'id' option in 'spo site set'. Closes #1536

### DIFF
--- a/docs/manual/docs/cmd/spo/site/site-set.md
+++ b/docs/manual/docs/cmd/spo/site/site-set.md
@@ -14,7 +14,6 @@ Option|Description
 ------|-----------
 `--help`|output usage information
 `-u, --url <url>`|The URL of the site collection to update
-`-i, --id [id]`|The ID of the site collection to update (deprecated; id is automatically retrieved and does not need to be specified)
 `--classification [classification]`|The new classification for the site collection
 `--disableFlows [disableFlows]`|Set to `true` to disable using Microsoft Flow in this site collection
 `--isPublic [isPublic]`|Set to `true` to make the group linked to the site public or to `false` to make it private

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnp/office365-cli",
-  "version": "2.12.0",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnp/office365-cli",
-  "version": "2.12.0",
+  "version": "3.0.0",
   "description": "Manage Microsoft Office 365 and SharePoint Framework projects on any platform",
   "license": "MIT",
   "main": "./dist/index.js",

--- a/src/o365/spo/commands/site/site-set.spec.ts
+++ b/src/o365/spo/commands/site/site-set.spec.ts
@@ -1158,17 +1158,6 @@ describe(commands.SITE_SET, () => {
     assert(containsOption);
   });
 
-  it('supports specifying site ID', () => {
-    const options = (command.options() as CommandOption[]);
-    let containsOption = false;
-    options.forEach(o => {
-      if (o.option.indexOf('--id') > -1) {
-        containsOption = true;
-      }
-    });
-    assert(containsOption);
-  });
-
   it('supports specifying site url', () => {
     const options = (command.options() as CommandOption[]);
     let containsOption = false;

--- a/src/o365/spo/commands/site/site-set.ts
+++ b/src/o365/spo/commands/site/site-set.ts
@@ -27,7 +27,6 @@ interface CommandArgs {
 interface Options extends GlobalOptions {
   classification?: string;
   disableFlows?: string;
-  id?: string;
   isPublic?: string;
   owners?: string;
   shareByEmailEnabled?: string;
@@ -50,7 +49,6 @@ class SpoSiteSetCommand extends SpoCommand {
 
   public getTelemetryProperties(args: CommandArgs): any {
     const telemetryProps: any = super.getTelemetryProperties(args);
-    telemetryProps.id = typeof args.options.id === 'string';
     telemetryProps.classification = typeof args.options.classification === 'string';
     telemetryProps.disableFlows = args.options.disableFlows;
     telemetryProps.isPublic = args.options.isPublic;
@@ -62,10 +60,6 @@ class SpoSiteSetCommand extends SpoCommand {
   }
 
   public commandAction(cmd: CommandInstance, args: CommandArgs, cb: (err?: any) => void): void {
-    if (args.options.id && this.verbose) {
-      cmd.log(vorpal.chalk.yellow(`Option 'id' is deprecated and will be removed in the next major version. ID is being automatically retrieved and doesn't need to be specified.`));
-    }
-
     this
       .loadSiteIds(args.options.url, cmd)
       .then((): Promise<void> => {
@@ -381,11 +375,6 @@ class SpoSiteSetCommand extends SpoCommand {
       const isValidSharePointUrl: boolean | string = SpoCommand.isValidSharePointUrl(args.options.url);
       if (isValidSharePointUrl !== true) {
         return isValidSharePointUrl;
-      }
-
-      if (args.options.id &&
-        !Utils.isValidGuid(args.options.id)) {
-        return `${args.options.id} is not a valid GUID`;
       }
 
       if (typeof args.options.classification === 'undefined' &&


### PR DESCRIPTION
Removes deprecated 'id' option in 'spo site set'. Closes #1536