### PR TITLE
Removes deprecated exit code in 'spfx project upgrade'. Closes #1418

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnp/office365-cli",
-  "version": "2.12.0",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnp/office365-cli",
-  "version": "2.12.0",
+  "version": "3.0.0",
   "description": "Manage Microsoft Office 365 and SharePoint Framework projects on any platform",
   "license": "MIT",
   "main": "./dist/index.js",

--- a/src/o365/spfx/commands/project/project-upgrade.ts
+++ b/src/o365/spfx/commands/project/project-upgrade.ts
@@ -152,8 +152,6 @@ class SpfxProjectUpgradeCommand extends BaseProjectCommand {
   public static ERROR_NO_VERSION: number = 3;
   public static ERROR_UNSUPPORTED_FROM_VERSION: number = 4;
   public static ERROR_NO_DOWNGRADE: number = 5;
-  // no longer used. Left for backwards-compatibility
-  public static ERROR_PROJECT_UP_TO_DATE: number = 6;
 
   public get name(): string {
     return commands.PROJECT_UPGRADE;


### PR DESCRIPTION
Removes deprecated exit code in 'spfx project upgrade'. Closes #1418