### PR TITLE
Removes deprecated 'accesstoken get' alias. Closes #1368

### DIFF
--- a/docs/manual/docs/cmd/util/accesstoken/accesstoken-get.md
+++ b/docs/manual/docs/cmd/util/accesstoken/accesstoken-get.md
@@ -8,12 +8,6 @@ Gets access token for the specified resource
 util accesstoken get [options]
 ```
 
-## Alias
-
-```sh
-accesstoken get
-```
-
 ## Options
 
 Option|Description

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnp/office365-cli",
-  "version": "2.12.0",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnp/office365-cli",
-  "version": "2.12.0",
+  "version": "3.0.0",
   "description": "Manage Microsoft Office 365 and SharePoint Framework projects on any platform",
   "license": "MIT",
   "main": "./dist/index.js",

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -39,7 +39,6 @@ describe('Lazy loading commands', () => {
     ];
     const aliases: string[] = [
       'consent',
-      'accesstoken get',
       'flow connector export',
       'flow connector list',
       'outlook sendmail',

--- a/src/o365/commands/commands.ts
+++ b/src/o365/commands/commands.ts
@@ -2,6 +2,5 @@ export default {
   CONSENT: `consent`,
   LOGIN: `login`,
   LOGOUT: `logout`,
-  STATUS: `status`,
-  ACCESSTOKEN_GET: `accesstoken get`
+  STATUS: `status`
 };

--- a/src/o365/util/commands/accesstoken/accesstoken-get.spec.ts
+++ b/src/o365/util/commands/accesstoken/accesstoken-get.spec.ts
@@ -1,5 +1,4 @@
 import commands from '../../commands';
-import globalCommands from '../../../commands/commands';
 import Command, { CommandOption, CommandValidate, CommandError } from '../../../../Command';
 import * as sinon from 'sinon';
 const command: Command = require('./accesstoken-get');
@@ -56,16 +55,6 @@ describe(commands.UTIL_ACCESSTOKEN_GET, () => {
 
   it('has a description', () => {
     assert.notEqual(command.description, null);
-  });
-
-  it('defines alias', () => {
-    const alias = command.alias();
-    assert.notEqual(typeof alias, 'undefined');
-  });
-
-  it('defines correct alias', () => {
-    const alias = command.alias();
-    assert.equal((alias && alias.indexOf(globalCommands.ACCESSTOKEN_GET) > -1), true);
   });
 
   it('retrieves access token for the specified resource', (done) => {

--- a/src/o365/util/commands/accesstoken/accesstoken-get.ts
+++ b/src/o365/util/commands/accesstoken/accesstoken-get.ts
@@ -1,5 +1,4 @@
 import commands from '../../commands';
-import globalCommands from '../../../commands/commands';
 import GlobalOptions from '../../../../GlobalOptions';
 import Command, {
   CommandOption,
@@ -28,13 +27,7 @@ class AccessTokenGetCommand extends Command {
     return 'Gets access token for the specified resource';
   }
 
-  public alias(): string[] | undefined {
-    return [globalCommands.ACCESSTOKEN_GET];
-  }
-
   public commandAction(cmd: CommandInstance, args: CommandArgs, cb: (err?: any) => void): void {
-    this.showDeprecationWarning(cmd, globalCommands.ACCESSTOKEN_GET, commands.UTIL_ACCESSTOKEN_GET);
-
     auth
       .ensureAccessToken(args.options.resource, cmd, this.debug, args.options.new)
       .then((accessToken: string): void => {


### PR DESCRIPTION
Removes deprecated 'accesstoken get' alias. Closes #1368