### PR TITLE
New Command: teams user app remove. Closes #1711

### DIFF
--- a/docs/manual/docs/cmd/teams/user/user-app-remove.md
+++ b/docs/manual/docs/cmd/teams/user/user-app-remove.md
@@ -1,0 +1,39 @@
+# teams user app remove
+
+Uninstall an app from the personal scope of the specified user
+
+## Usage
+
+```sh
+teams user app remove [options]
+```
+
+## Options
+
+Option|Description
+------|-----------
+`--help`|output usage information
+`--appId <appId>`|The unique id of the app instance installed for the user
+`--userId <userId>`|The ID of the user to uninstall the app for
+`--confirm`|Confirm removal of app for user
+`--query [query]`|JMESPath query string. See [http://jmespath.org/](http://jmespath.org/) for more information and examples
+`-o, --output [output]`|Output type. `json,text`. Default `text`
+`--pretty`|Prettifies `json` output
+`--verbose`|Runs command with verbose logging
+`--debug`|Runs command with debug logging
+
+## Remarks
+
+!!! attention
+    This command is based on an API that is currently in preview and is subject to change once the API reached general availability.
+
+The `appId` has to be the id of the app instance installed for the user.
+Do not use the ID from the manifest of the zip app package or the id from the Microsoft Teams App Catalog.
+
+## Examples
+
+Uninstall an app for the specified user
+
+```sh
+teams user app remove --appId YzUyN2E0NzAtYTg4Mi00ODFjLTk4MWMtZWU2ZWZhYmE4NWM3IyM0ZDFlYTA0Ny1mMTk2LTQ1MGQtYjJlOS0wZDI4NTViYTA1YTY= --userId 2609af39-7775-4f94-a3dc-0dd67657e900
+```

--- a/docs/manual/mkdocs.yml
+++ b/docs/manual/mkdocs.yml
@@ -443,6 +443,7 @@ nav:
         - user remove: 'cmd/aad/o365group/o365group-user-remove.md'
         - user set: 'cmd/aad/o365group/o365group-user-set.md'
         - user app add: 'cmd/teams/user/user-app-add.md'
+        - user app remove: 'cmd/teams/user/user-app-remove.md'
     - Office 365 (tenant):
       - id:
         - id get: 'cmd/tenant/id/id-get.md'

--- a/src/o365/teams/commands.ts
+++ b/src/o365/teams/commands.ts
@@ -43,5 +43,6 @@ export default {
   TEAMS_USER_LIST: `${prefix} user list`,
   TEAMS_USER_REMOVE: `${prefix} user remove`,
   TEAMS_USER_SET: `${prefix} user set`,
-  TEAMS_USER_APP_ADD: `${prefix} user app add`
+  TEAMS_USER_APP_ADD: `${prefix} user app add`,
+  TEAMS_USER_APP_REMOVE: `${prefix} user app remove`
 };

--- a/src/o365/teams/commands/user/user-app-remove.spec.ts
+++ b/src/o365/teams/commands/user/user-app-remove.spec.ts
@@ -1,0 +1,271 @@
+import commands from '../../commands';
+import Command, { CommandOption, CommandError, CommandValidate } from '../../../../Command';
+import * as sinon from 'sinon';
+import appInsights from '../../../../appInsights';
+import auth from '../../../../Auth';
+const command: Command = require('./user-app-remove');
+import * as assert from 'assert';
+import request from '../../../../request';
+import Utils from '../../../../Utils';
+
+describe(commands.TEAMS_USER_APP_REMOVE, () => {
+  let vorpal: Vorpal;
+  let log: string[];
+  let cmdInstance: any;
+  let cmdInstanceLogSpy: sinon.SinonSpy;
+  let promptOptions: any;
+
+
+  before(() => {
+    sinon.stub(auth, 'restoreAuth').callsFake(() => Promise.resolve());
+    sinon.stub(appInsights, 'trackEvent').callsFake(() => { });
+    auth.service.connected = true;
+  });
+
+  beforeEach(() => {
+    vorpal = require('../../../../vorpal-init');
+    log = [];
+    cmdInstance = {
+      commandWrapper: {
+        command: command.name
+      },
+      action: command.action(),
+      log: (msg: string) => {
+        log.push(msg);
+      },
+      prompt: (options: any, cb: (result: { continue: boolean }) => void) => {
+        promptOptions = options;
+        cb({ continue: false });
+      }
+    };
+    cmdInstanceLogSpy = sinon.spy(cmdInstance, 'log');
+    (command as any).items = [];
+  });
+
+  afterEach(() => {
+    Utils.restore([
+      vorpal.find,
+      request.delete
+    ]);
+  });
+
+  after(() => {
+    Utils.restore([
+      auth.restoreAuth,
+      appInsights.trackEvent
+    ]);
+    auth.service.connected = false;
+  });
+
+  it('has correct name', () => {
+    assert.equal(command.name.startsWith(commands.TEAMS_USER_APP_REMOVE), true);
+  });
+
+  it('has a description', () => {
+    assert.notEqual(command.description, null);
+  });
+
+  it('fails validation if the userId is not a valid guid.', () => {
+    const actual = (command.validate() as CommandValidate)({
+      options: {
+        userId: 'invalid',
+        appId: 'YzUyN2E0NzAtYTg4Mi00ODFjLTk4MWMtZWU2ZWZhYmE4NWM3IyM0ZDFlYTA0Ny1mMTk2LTQ1MGQtYjJlOS0wZDI4NTViYTA1YTY='
+      }
+    });
+    assert.notEqual(actual, true);
+  });
+
+  it('fails validation if the userId is not provided.', () => {
+    const actual = (command.validate() as CommandValidate)({
+      options: {
+        appId: 'YzUyN2E0NzAtYTg4Mi00ODFjLTk4MWMtZWU2ZWZhYmE4NWM3IyM0ZDFlYTA0Ny1mMTk2LTQ1MGQtYjJlOS0wZDI4NTViYTA1YTY='
+      }
+    });
+    assert.notEqual(actual, true);
+  });
+
+  it('fails validation if the appId is not provided.', () => {
+    const actual = (command.validate() as CommandValidate)({
+      options: {
+        userId: '61703ac8a-c49b-4fd4-8223-28f0ac3a6402'
+      }
+    });
+    assert.notEqual(actual, true);
+  });
+
+  it('passes validation when the input is correct', () => {
+    const actual = (command.validate() as CommandValidate)({
+      options: {
+        appId: 'YzUyN2E0NzAtYTg4Mi00ODFjLTk4MWMtZWU2ZWZhYmE4NWM3IyM0ZDFlYTA0Ny1mMTk2LTQ1MGQtYjJlOS0wZDI4NTViYTA1YTY=',
+        userId: '15d7a78e-fd77-4599-97a5-dbb6372846c5'
+      }
+    });
+    assert.equal(actual, true);
+  });
+
+  it('prompts before removing the app when confirmation argument is not passed', (done) => {
+    cmdInstance.action({
+      options: {
+        userId: 'c527a470-a882-481c-981c-ee6efaba85c7',
+        appId: 'YzUyN2E0NzAtYTg4Mi00ODFjLTk4MWMtZWU2ZWZhYmE4NWM3IyM0ZDFlYTA0Ny1mMTk2LTQ1MGQtYjJlOS0wZDI4NTViYTA1YTY='
+      }
+    }, () => {
+      let promptIssued = false;
+      if (promptOptions && promptOptions.type === 'confirm') {
+        promptIssued = true;
+      }
+
+      try {
+        assert(promptIssued);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('aborts removing the app when confirmation prompt is not continued', (done) => {
+    const requestDeleteSpy = sinon.stub(request, 'delete');
+
+    cmdInstance.action({
+      options: {
+        userId: 'c527a470-a882-481c-981c-ee6efaba85c7',
+        appId: 'YzUyN2E0NzAtYTg4Mi00ODFjLTk4MWMtZWU2ZWZhYmE4NWM3IyM0ZDFlYTA0Ny1mMTk2LTQ1MGQtYjJlOS0wZDI4NTViYTA1YTY='
+      }
+    }, () => {
+      try {
+        assert(requestDeleteSpy.notCalled);
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('removes the app for the specified user when confirmation is specified (debug)', (done) => {
+    sinon.stub(request, 'delete').callsFake((opts) => {
+      if (opts.url.toString().indexOf(`/users/c527a470-a882-481c-981c-ee6efaba85c7/teamwork/installedApps/YzUyN2E0NzAtYTg4Mi00ODFjLTk4MWMtZWU2ZWZhYmE4NWM3IyM0ZDFlYTA0Ny1mMTk2LTQ1MGQtYjJlOS0wZDI4NTViYTA1YTY=`) > -1) {
+        return Promise.resolve();
+      }
+      return Promise.reject('Invalid request');
+    });
+
+    cmdInstance.action({
+      options: {
+        userId: 'c527a470-a882-481c-981c-ee6efaba85c7',
+        appId: 'YzUyN2E0NzAtYTg4Mi00ODFjLTk4MWMtZWU2ZWZhYmE4NWM3IyM0ZDFlYTA0Ny1mMTk2LTQ1MGQtYjJlOS0wZDI4NTViYTA1YTY=',
+        debug: true,
+        confirm: true
+      }
+    }, () => {
+      try {
+        assert(cmdInstanceLogSpy.calledWith(vorpal.chalk.green('DONE')));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('removes the app for the specified user when prompt is confirmed (debug)', (done) => {
+    sinon.stub(request, 'delete').callsFake((opts) => {
+      if (opts.url.toString().indexOf(`/users/c527a470-a882-481c-981c-ee6efaba85c7/teamwork/installedApps/YzUyN2E0NzAtYTg4Mi00ODFjLTk4MWMtZWU2ZWZhYmE4NWM3IyM0ZDFlYTA0Ny1mMTk2LTQ1MGQtYjJlOS0wZDI4NTViYTA1YTY=`) > -1) {
+        return Promise.resolve();
+      }
+      return Promise.reject('Invalid request');
+    });
+
+    cmdInstance.prompt = (options: any, cb: (result: { continue: boolean }) => void) => {
+      cb({ continue: true });
+    };
+    cmdInstance.action({
+      options: {
+        userId: 'c527a470-a882-481c-981c-ee6efaba85c7',
+        appId: 'YzUyN2E0NzAtYTg4Mi00ODFjLTk4MWMtZWU2ZWZhYmE4NWM3IyM0ZDFlYTA0Ny1mMTk2LTQ1MGQtYjJlOS0wZDI4NTViYTA1YTY=',
+        debug: true
+      }
+    }, () => {
+      try {
+        assert(cmdInstanceLogSpy.calledWith(vorpal.chalk.green('DONE')));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('correctly handles error while removing teams app', (done) => {
+    const error = 'An error has occurred';
+    sinon.stub(request, 'delete').callsFake((opts) => {
+      if (opts.url.toString().indexOf(`/users/c527a470-a882-481c-981c-ee6efaba85c7/teamwork/installedApps/YzUyN2E0NzAtYTg4Mi00ODFjLTk4MWMtZWU2ZWZhYmE4NWM3IyM0ZDFlYTA0Ny1mMTk2LTQ1MGQtYjJlOS0wZDI4NTViYTA1YTY=`) > -1) {
+        return Promise.reject(error);
+      }
+      return Promise.reject('Invalid Request');
+    });
+
+    cmdInstance.action({
+      options: {
+        userId: 'c527a470-a882-481c-981c-ee6efaba85c7',
+        appId: 'YzUyN2E0NzAtYTg4Mi00ODFjLTk4MWMtZWU2ZWZhYmE4NWM3IyM0ZDFlYTA0Ny1mMTk2LTQ1MGQtYjJlOS0wZDI4NTViYTA1YTY=',
+        confirm: true
+      }
+    }, (err?: any) => {
+      try {
+        assert.equal(JSON.stringify(err), JSON.stringify(new CommandError(error)));
+        done();
+      }
+      catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it('supports debug mode', () => {
+    const options = (command.options() as CommandOption[]);
+    let containsOption = false;
+    options.forEach(o => {
+      if (o.option === '--debug') {
+        containsOption = true;
+      }
+    });
+    assert(containsOption);
+  });
+
+  it('has help referring to the right command', () => {
+    const cmd: any = {
+      log: (msg: string) => { },
+      prompt: () => { },
+      helpInformation: () => { }
+    };
+    const find = sinon.stub(vorpal, 'find').callsFake(() => cmd);
+    cmd.help = command.help();
+    cmd.help({}, () => { });
+    assert(find.calledWith(commands.TEAMS_USER_APP_REMOVE));
+  });
+
+  it('has help with examples', () => {
+    const _log: string[] = [];
+    const cmd: any = {
+      log: (msg: string) => {
+        _log.push(msg);
+      },
+      prompt: () => { },
+      helpInformation: () => { }
+    };
+    sinon.stub(vorpal, 'find').callsFake(() => cmd);
+    cmd.help = command.help();
+    cmd.help({}, () => { });
+    let containsExamples: boolean = false;
+    _log.forEach(l => {
+      if (l && l.indexOf('Examples:') > -1) {
+        containsExamples = true;
+      }
+    });
+    Utils.restore(vorpal.find);
+    assert(containsExamples);
+  });
+});

--- a/src/o365/teams/commands/user/user-app-remove.ts
+++ b/src/o365/teams/commands/user/user-app-remove.ts
@@ -1,0 +1,140 @@
+import request from '../../../../request';
+import Utils from '../../../../Utils';
+import commands from '../../commands';
+import GlobalOptions from '../../../../GlobalOptions';
+import { CommandOption, CommandValidate } from '../../../../Command';
+import GraphCommand from '../../../base/GraphCommand';
+
+const vorpal: Vorpal = require('../../../../vorpal-init');
+
+interface CommandArgs {
+  options: Options;
+}
+
+interface Options extends GlobalOptions {
+  appId: string;
+  userId: string;
+  confirm?: boolean;
+}
+
+class TeamsUserAppRemoveCommand extends GraphCommand {
+  public get name(): string {
+    return `${commands.TEAMS_USER_APP_REMOVE}`;
+  }
+
+  public get description(): string {
+    return 'Uninstall an app from the personal scope of the specified user.';
+  }
+
+  public getTelemetryProperties(args: CommandArgs): any {
+    const telemetryProps: any = super.getTelemetryProperties(args);
+    telemetryProps.confirm = (!!args.options.confirm).toString();
+    return telemetryProps;
+  }
+
+  public commandAction(cmd: CommandInstance, args: CommandArgs, cb: () => void): void {
+    const removeApp: () => void = (): void => {
+      const endpoint: string = `${this.resource}/beta`
+
+      const requestOptions: any = {
+        url: `${endpoint}/users/${args.options.userId}/teamwork/installedApps/${args.options.appId}`,
+        headers: {
+          'accept': 'application/json;odata.metadata=none'
+        },
+        json: true
+      };
+
+      request
+        .delete(requestOptions)
+        .then((): void => {
+          if (this.verbose) {
+            cmd.log(vorpal.chalk.green('DONE'));
+          }
+
+          cb();
+        }, (res: any): void => this.handleRejectedODataJsonPromise(res, cmd, cb));
+    }
+
+    if (args.options.confirm) {
+      removeApp();
+    }
+    else {
+      cmd.prompt(
+        {
+          type: 'confirm',
+          name: 'continue',
+          default: false,
+          message: `Are you sure you want to remove the app with id ${args.options.appId} for user ${args.options.userId}?`
+        },
+        (result: { continue: boolean }): void => {
+          if (!result.continue) {
+            cb();
+          }
+          else {
+            removeApp();
+          }
+        }
+      );
+    }
+  }
+
+  public options(): CommandOption[] {
+    const options: CommandOption[] = [
+      {
+        option: '--appId <appId>',
+        description: 'The unique id of the app instance installed for the user'
+      },
+      {
+        option: '--userId <userId>',
+        description: 'The ID of the user to uninstall the app for'
+      },
+      {
+        option: '--confirm',
+        description: 'Confirm removal of app for user'
+      }
+    ];
+
+    const parentOptions: CommandOption[] = super.options();
+    return options.concat(parentOptions);
+  }
+
+  public validate(): CommandValidate {
+    return (args: CommandArgs): boolean | string => {
+      if (!args.options.appId) {
+        return 'Required parameter appId missing';
+      }
+
+      if (!args.options.userId) {
+        return 'Required parameter userId missing';
+      }
+
+      if (!Utils.isValidGuid(args.options.userId)) {
+        return `${args.options.userId} is not a valid GUID`;
+      }
+
+      return true;
+    };
+  }
+
+  public commandHelp(args: {}, log: (help: string) => void): void {
+    const chalk = vorpal.chalk;
+    log(vorpal.find(this.name).helpInformation());
+    log(
+      `  Remarks:
+
+    ${chalk.yellow('Attention:')} This command is based on an API that is currently in preview
+    and is subject to change once the API reached general availability.
+
+    The ${chalk.grey(`appId`)} has to be the id of the app instance installed for the user.
+    Do not use the ID from the manifest of the zip app package or the id
+    from the Microsoft Teams App Catalog.
+
+  Examples:
+
+    Uninstall an app for the specified user
+      ${this.name} --appId YzUyN2E0NzAtYTg4Mi00ODFjLTk4MWMtZWU2ZWZhYmE4NWM3IyM0ZDFlYTA0Ny1mMTk2LTQ1MGQtYjJlOS0wZDI4NTViYTA1YTY= --userId 2609af39-7775-4f94-a3dc-0dd67657e900
+`);
+  }
+}
+
+module.exports = new TeamsUserAppRemoveCommand();


### PR DESCRIPTION
New Command: `teams user app remove` that uninstalls an app from the personal scope of the specified user. Closes #1711