### PR TITLE
Adds 'spo site add' owners option for CommunicationSite creation. Partically solves #1734

### DIFF
--- a/docs/manual/docs/cmd/spo/site/site-add.md
+++ b/docs/manual/docs/cmd/spo/site/site-add.md
@@ -20,7 +20,7 @@ Option|Description
 `-z, --timeZone [timeZone]`|Integer representing time zone to use for the site (applies to type ClassicSite)
 `-d, --description [description]`|Site description
 `-l, --lcid [lcid]`|Site language in the LCID format, eg. _1033_ for _en-US_
-`--owners [owners]`|Comma-separated list of users to set as site owners (applies to type TeamSite, ClassicSite)
+`--owners [owners]`|Comma-separated list of users to set as site owners
 `--isPublic`|Determines if the associated group is public or not (applies to type TeamSite)
 `-c, --classification [classification]`|Site classification (applies to type TeamSite, CommunicationSite)
 `--siteDesign [siteDesign]`|Type of communication site to create. Allowed values `Topic,Showcase,Blank`, default `Topic`. When creating a communication site, specify either `siteDesign` or `siteDesignId` (applies to type CommunicationSite)
@@ -55,6 +55,13 @@ The value of the `--storageQuotaWarningLevel` option must not exceed the the val
 If you try to create a site with the same URL as a site that has been previously moved to the recycle bin, you will get an error. To avoid this error, you can use the `--removeDeletedSite` option. Prior to creating the site, the spo site classic add command will check if the site with the specified URL has been previously moved to the recycle bin and if so, will remove it. Because removing sites from the recycle bin might take a moment, it should be used in conjunction with the `--wait` option so that the new site is not created before the old site is fully removed.
 
 Deleting and creating classic site collections is by default asynchronous and depending on the current state of Office 365, might take up to few minutes. If you're building a script with steps that require the site to be fully provisioned, you should use the `--wait` flag. When using this flag, the spo site classic add command will keep running until it received confirmation from Office 365 that the site has been fully provisioned.
+
+## Remarks for modern sites:
+
+The `--owners` option is mandatory for site creation of type CommunicationSite 
+when using Azure AD application permissions.
+    
+The creation of the team site under Azure AD application permissions currently throws error 'Insufficient privileges to complete the operation.'. As a workaround, the `aad o365group add` command can be used instead, followed by `spo site set` to further set the properties on the Team site.
 
 ## Examples
 
@@ -92,6 +99,12 @@ Create communication site using the Topic design
 
 ```sh
 spo site add --type CommunicationSite --url https://contoso.sharepoint.com/sites/marketing --title Marketing
+```
+
+Create communication site when using Azure AD application permissions instead of delegated permissions
+
+```sh
+spo site add --type CommunicationSite --url https://contoso.sharepoint.com/sites/marketing --title Marketing --owners "john.smith@contoso.com"
 ```
 
 Create communication site using the Showcase design

--- a/src/o365/spo/commands/site/site-add.ts
+++ b/src/o365/spo/commands/site/site-add.ts
@@ -205,6 +205,10 @@ class SpoSiteAddCommand extends SpoCommand {
           if (args.options.lcid) {
             requestOptions.body.request.Lcid = args.options.lcid;
           }
+
+          if (args.options.owners) {
+            requestOptions.body.request.Owner = args.options.owners;
+          }
         }
 
         return request.post(requestOptions);
@@ -498,7 +502,7 @@ class SpoSiteAddCommand extends SpoCommand {
       },
       {
         option: '--owners [owners]',
-        description: 'Comma-separated list of users to set as site owners (applies to type TeamSite, ClassicSite)'
+        description: 'Comma-separated list of users to set as site owners'
       },
       {
         option: '--isPublic',
@@ -604,6 +608,10 @@ class SpoSiteAddCommand extends SpoCommand {
           }
         }
 
+        if (args.options.owners && args.options.owners.indexOf(",") > -1) {
+          return 'The CommunicationSite supports only one owner in the owners options';
+        }
+
         if (args.options.siteDesignId) {
           if (!Utils.isValidGuid(args.options.siteDesignId)) {
             return `${args.options.siteDesignId} is not a valid GUID`;
@@ -614,8 +622,8 @@ class SpoSiteAddCommand extends SpoCommand {
           return 'Specify siteDesign or siteDesignId but not both';
         }
 
-        if (args.options.timeZone || args.options.isPublic || args.options.removeDeletedSite || args.options.owners || args.options.wait || args.options.alias || args.options.resourceQuota || args.options.resourceQuotaWarningLevel || args.options.storageQuota || args.options.storageQuotaWarningLevel || args.options.webTemplate) {
-          return "Type CommunicationSite supports only the parameters url, title, lcid, classification, siteDesign, shareByEmailEnabled, allowFileSharingForGuestUsers, siteDesignId, and description";
+        if (args.options.timeZone || args.options.isPublic || args.options.removeDeletedSite || args.options.wait || args.options.alias || args.options.resourceQuota || args.options.resourceQuotaWarningLevel || args.options.storageQuota || args.options.storageQuotaWarningLevel || args.options.webTemplate) {
+          return "Type CommunicationSite supports only the parameters url, title, lcid, classification, siteDesign, shareByEmailEnabled, allowFileSharingForGuestUsers, siteDesignId, owners, and description";
         }
       }
       else {
@@ -707,41 +715,51 @@ class SpoSiteAddCommand extends SpoCommand {
     log(
       `  Remarks for classic sites:
 
-      Using the ${chalk.blue('-z, --timeZone')} option you have to specify the
-      time zone of the site. For more information about the valid values see
-      https://msdn.microsoft.com/library/microsoft.sharepoint.spregionalsettings.timezones.aspx.
-  
-      The value of the ${chalk.blue('--resourceQuota')} option must not exceed
-      the company's aggregate available Sandboxed Solutions quota.
-      For more information, see Resource Usage Limits on Sandboxed Solutions
-      in SharePoint 2010: http://msdn.microsoft.com/en-us/library/gg615462.aspx.
-  
-      The value of the ${chalk.blue('--resourceQuotaWarningLevel')} option
-      must not exceed the value of the ${chalk.blue('--resourceQuota')} option.
-  
-      The value of the ${chalk.blue('--storageQuota')} option must not exceed
-      the company's available quota.
-  
-      The value of the ${chalk.blue('--storageQuotaWarningLevel')} option must not
-      exceed the the value of the ${chalk.blue('--storageQuota')} option.
-  
-      If you try to create a site with the same URL as a site that has been
-      previously moved to the recycle bin, you will get an error. To avoid this
-      error, you can use the ${chalk.blue('--removeDeletedSite')} option. Prior
-      to creating the site, the ${chalk.blue(this.getCommandName())} command will
-      check if the site with the specified URL has been previously moved to the
-      recycle bin and if so, will remove it. Because removing sites from the
-      recycle bin might take a moment, it should be used in conjunction with the
-      ${chalk.blue('--wait')} option so that the new site is not created before
-      the old site is fully removed.
-  
-      Deleting and creating classic site collections is by default asynchronous
-      and depending on the current state of Office 365, might take up to few
-      minutes. If you're building a script with steps that require the site to be
-      fully provisioned, you should use the ${chalk.blue('--wait')} flag. When
-      using this flag, the ${chalk.blue(this.getCommandName())} command will keep
-      running until it received confirmation from Office 365 that the site
-      has been fully provisioned.
+    Using the ${chalk.blue('-z, --timeZone')} option you have to specify the
+    time zone of the site. For more information about the valid values see
+    https://msdn.microsoft.com/library/microsoft.sharepoint.spregionalsettings.timezones.aspx.
+
+    The value of the ${chalk.blue('--resourceQuota')} option must not exceed
+    the company's aggregate available Sandboxed Solutions quota.
+    For more information, see Resource Usage Limits on Sandboxed Solutions
+    in SharePoint 2010: http://msdn.microsoft.com/en-us/library/gg615462.aspx.
+
+    The value of the ${chalk.blue('--resourceQuotaWarningLevel')} option
+    must not exceed the value of the ${chalk.blue('--resourceQuota')} option.
+
+    The value of the ${chalk.blue('--storageQuota')} option must not exceed
+    the company's available quota.
+
+    The value of the ${chalk.blue('--storageQuotaWarningLevel')} option must not
+    exceed the the value of the ${chalk.blue('--storageQuota')} option.
+
+    If you try to create a site with the same URL as a site that has been
+    previously moved to the recycle bin, you will get an error. To avoid this
+    error, you can use the ${chalk.blue('--removeDeletedSite')} option. Prior
+    to creating the site, the ${chalk.blue(this.getCommandName())} command will
+    check if the site with the specified URL has been previously moved to the
+    recycle bin and if so, will remove it. Because removing sites from the
+    recycle bin might take a moment, it should be used in conjunction with the
+    ${chalk.blue('--wait')} option so that the new site is not created before
+    the old site is fully removed.
+
+    Deleting and creating classic site collections is by default asynchronous
+    and depending on the current state of Office 365, might take up to few
+    minutes. If you're building a script with steps that require the site to be
+    fully provisioned, you should use the ${chalk.blue('--wait')} flag. When
+    using this flag, the ${chalk.blue(this.getCommandName())} command will keep
+    running until it received confirmation from Office 365 that the site
+    has been fully provisioned.
+      
+  Remarks for modern sites:
+    
+    The ${chalk.blue('--owners')} option is mandatory for site creation of type CommunicationSite 
+    when using Azure AD application permissions.
+
+    The creation of the team site under Azure AD application permissions currently throws error
+    'Insufficient privileges to complete the operation.'. As a workaround, the 
+    ${chalk.yellow('aad o365group add')} command can be used instead, followed by 
+    ${chalk.yellow('spo site set')} to further set the properties on the Team site.
       
   Examples:
 
@@ -762,6 +780,9 @@ class SpoSiteAddCommand extends SpoCommand {
 
     Create communication site using the Topic design
       ${commands.SITE_ADD} --type CommunicationSite --url https://contoso.sharepoint.com/sites/marketing --title Marketing
+
+    Create communication site when using Azure AD application permissions instead of delegated permissions
+      ${commands.SITE_ADD} --type CommunicationSite --url https://contoso.sharepoint.com/sites/marketing --title Marketing --owners "john.smith@contoso.com"
 
     Create communication site using the Showcase design
       ${commands.SITE_ADD} --type CommunicationSite --url https://contoso.sharepoint.com/sites/marketing --title Marketing --siteDesign Showcase


### PR DESCRIPTION
The `--owners` option is mandatory for site creation of type CommunicationSite 
when using Azure AD application permissions and this PR enables that.

The creation of the team site under Azure AD application permissions currently throws error 'Insufficient privileges to complete the operation.'. As a workaround, the `aad o365group add` command can be used instead, followed by `spo site set` to further set the properties on the Team site. 

This PR adds `Remarks` to address the Teams site creation issue. I will later reply into #1734 with more details how the workaround can be applied.