### PR TITLE
Extends 'spo site add' with support for LCID validation. Closes #1749

### DIFF
--- a/docs/manual/docs/cmd/spo/site/site-add.md
+++ b/docs/manual/docs/cmd/spo/site/site-add.md
@@ -19,7 +19,7 @@ Option|Description
 `-u, --url [url]`|Site URL  (applies to type CommunicationSite, ClassicSite)
 `-z, --timeZone [timeZone]`|Integer representing time zone to use for the site (applies to type ClassicSite)
 `-d, --description [description]`|Site description
-`-l, --lcid [lcid]`|Site language in the LCID format, eg. _1033_ for _en-US_
+`-l, --lcid [lcid]`|Site language in the LCID format, eg. _1033_ for _en-US_. See https://support.microsoft.com/en-us/office/languages-supported-by-sharepoint-dfbf3652-2902-4809-be21-9080b6512fff for the languages supported by SharePoint.
 `--owners [owners]`|Comma-separated list of users to set as site owners (applies to type TeamSite, ClassicSite)
 `--isPublic`|Determines if the associated group is public or not (applies to type TeamSite)
 `-c, --classification [classification]`|Site classification (applies to type TeamSite, CommunicationSite)

--- a/src/o365/spo/commands/site/site-add.spec.ts
+++ b/src/o365/spo/commands/site/site-add.spec.ts
@@ -1248,6 +1248,18 @@ describe(commands.SITE_ADD, () => {
     assert.notEqual(actual, true);
   });
 
+  it('fails validation when lcid is not valid', () => {
+    const actual = (command.validate() as CommandValidate)({
+      options: {
+        type: 'CommunicationSite',
+        title: 'Marketing',
+        url: 'https://contoso.sharepoint.com/sites/marketing',
+        lcid: 3081
+      }
+    });
+    assert.notEqual(actual, true);
+  });
+
   it('creates classic site with minimal options. doesn\'t wait for completion', (done) => {
     sinon.stub(request, 'post').callsFake((opts) => {
       if ((opts.url as string).indexOf(`/_vti_bin/client.svc/ProcessQuery`) > -1) {

--- a/src/o365/spo/commands/site/site-add.ts
+++ b/src/o365/spo/commands/site/site-add.ts
@@ -96,6 +96,13 @@ class SpoSiteAddCommand extends SpoCommand {
     return telemetryProps;
   }
 
+  public getAllLCIDOptions(): number[] {
+    // Languages supported by SharePoint
+    // https://support.microsoft.com/en-us/office/languages-supported-by-sharepoint-dfbf3652-2902-4809-be21-9080b6512fff
+    // https://github.com/pnp/PnP-PowerShell/wiki/Supported-LCIDs-by-SharePoint
+    return [1025, 1068, 1069, 5146, 1026, 1027, 2052, 1028, 1050, 1029, 1030, 1043, 1033, 1061, 1035, 1036, 1110, 1031, 1032, 1037, 1081, 1038, 1057, 2108, 1040, 1041, 1087, 1042, 1062, 1063, 1071, 1086, 1044, 1045, 1046, 2070, 1048, 1049, 10266, 2074, 1051, 1060, 3082, 1053, 1054, 1055, 1058, 1066, 1106];
+  }
+
   public commandAction(cmd: CommandInstance, args: CommandArgs, cb: (err?: any) => void): void {
     const isClassicSite: boolean = args.options.type === 'ClassicSite';
 
@@ -695,6 +702,10 @@ class SpoSiteAddCommand extends SpoCommand {
         if (args.options.lcid < 0) {
           return `LCID must be greater than 0 (${args.options.lcid})`;
         }
+
+        if (this.getAllLCIDOptions().indexOf(args.options.lcid) <= -1) {
+          return `LCID ${args.options.lcid} is not valid. See https://support.microsoft.com/en-us/office/languages-supported-by-sharepoint-dfbf3652-2902-4809-be21-9080b6512fff for the languages supported by SharePoint.`;
+        }   
       }
 
       return true;


### PR DESCRIPTION
> ### Extends 'spo site add' with support for LCID validation. Closes #1749

> ### Linked Issue
Closes #1749 